### PR TITLE
Change default model to GPT-3.5

### DIFF
--- a/server/ai/openai/openai.go
+++ b/server/ai/openai/openai.go
@@ -30,7 +30,7 @@ func NewCompatible(apiKey string, url string, model string) *OpenAI {
 
 func New(apiKey string, defaultModel string) *OpenAI {
 	if defaultModel == "" {
-		defaultModel = openaiClient.GPT4
+		defaultModel = openaiClient.GPT3Dot5Turbo
 	}
 	return &OpenAI{
 		client:       openaiClient.NewClient(apiKey),


### PR DESCRIPTION
#### Summary
Since GPT-4 is still in Beta, the AI bot will fail if the dev key doesn't have access to it, and a default model isn't specified in the settings. This change will use GPT-3.5-turbo as the default if a model isn't specified in settings.

The workaround is to set "gpt-3.5-turbo" as the default model in settings.
