### PR TITLE
Feat/change tone plus spellcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ endif
 ifneq ($(INCLUDE_FFMPEG),)
 	cp $(INCLUDE_FFMPEG) dist/$(PLUGIN_ID)/server/dist/
 endif
-	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+	cd dist && tar -cvzf $(BUNDLE_NAME) -C $(PLUGIN_ID) .
 
 	@echo plugin built at: dist/$(BUNDLE_NAME)
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ This plugin is currently experimental. More options and the ability to use local
 
 1. Clone and enter this repository:
   * `git clone https://github.com/mattermost/mattermost-plugin-ai && cd mattermost-plugin-ai`
-2. Start the services:
+2. Create a `.env.docker` file inside a `mattermost` folder.
+   - You can adjust this accordingly based on the environment variables you see in the [`docker-compose.yml`](./docker-compose.yml) file.
+3. Start the services:
   * `docker compose up -d`
-3. Configure the Mattermost server from the init script:
+4. Configure the Mattermost server from the init script:
   * `bash ./init.sh`
-4. Install `mattermost-plugin-ai` on Mattermost from the command line:
+5. Install `mattermost-plugin-ai` on Mattermost from the command line:
   * `MM_SERVICESETTINGS_SITEURL=http://localhost:8065 MM_ADMIN_USERNAME=root MM_ADMIN_PASSWORD=<YOUR_PASSWORD> make deploy`
-5. Access Mattermost and configure the plugin:
+6. Access Mattermost and configure the plugin:
   * Open Mattermost at `http://localhost:8065`
   * Select **View in Browser**
   * Log in with the generated `root` credentials

--- a/server/ai/prompts.go
+++ b/server/ai/prompts.go
@@ -24,6 +24,8 @@ const (
 	PromptMeetingSummary        = "meeting_summary"
 	PromptMeetingSummaryOnly    = "summary_only"
 	PromptMeetingKeyPoints      = "meeting_key_points"
+	PromptSpellcheck            = "spellcheck"
+	PromptChangeTone            = "change_tone"
 )
 
 func NewPrompts(input fs.FS) (*Prompts, error) {

--- a/server/ai/prompts/change_tone.tmpl
+++ b/server/ai/prompts/change_tone.tmpl
@@ -1,0 +1,10 @@
+{{define "change_tone.system"}}
+Change tone and voice to {{.Tone}}.
+{{if eq .Tone "professional"}}
+Use industry-specific language and terminology.
+Avoid complex words.
+{{end}}
+Provide only the resulting text as an answer.
+Avoid greetings and sign-offs.
+The original text: "{{.Message}}"
+{{end}}

--- a/server/ai/prompts/spellcheck.tmpl
+++ b/server/ai/prompts/spellcheck.tmpl
@@ -1,0 +1,3 @@
+{{define "spellcheck.system"}}
+Correct the spelling for the following: "{{.Message}}"
+{{end}}

--- a/server/service.go
+++ b/server/service.go
@@ -309,3 +309,38 @@ func (p *Plugin) handleCallRecordingPost(recordingPost *model.Post) (err error) 
 
 	return nil
 }
+
+func (p *Plugin) spellcheckMessage(message string) (*string, error) {
+	prompt, err := p.prompts.ChatCompletion(ai.PromptSpellcheck, map[string]string{"Message": message})
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := p.getLLM().ChatCompletionNoStream(prompt, ai.WithmaxTokens(128))
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (p *Plugin) changeTone(tone, message string) (*string, error) {
+	if tone != "professional" && tone != "casual" {
+		return nil, fmt.Errorf("unsupported tone: %s", tone)
+	}
+
+	prompt, err := p.prompts.ChatCompletion(ai.PromptChangeTone, map[string]string{
+		"Tone":    tone,
+		"Message": message,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := p.getLLM().ChatCompletionNoStream(prompt, ai.WithmaxTokens(128))
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}


### PR DESCRIPTION
#### Summary

This commit adds to commands: 
- `/spellcheck [message]`: Corrects the spell check for the message.
- `/change_tone [tone] [message]`: Changes the tone for the provided message (allowed: `casual` & `professional`).

My main idea was to add some buttons/menus on the post editor to toggle this directly from there and modify the user input directly, before sending the message, but since the Mattermost Plugin Framework doesn't allow customizing the post editor, there is that. (Maybe for another OSF?)