### PR TITLE
Fixing open ai compatible type value in the admin console

### DIFF
--- a/webapp/src/components/config/service_form.tsx
+++ b/webapp/src/components/config/service_form.tsx
@@ -60,13 +60,13 @@ const ServiceForm = ({service, onChange, onDelete}: Props) => {
                         value={service.serviceName}
                     >
                         <option value='openai'>{'OpenAI'}</option>
-                        <option value='openai-compatible'>{'OpenAI Compatible'}</option>
+                        <option value='openaicompatible'>{'OpenAI Compatible'}</option>
                         <option value='anthropic'>{'Anthropic'}</option>
                         <option value='asksage'>{'Ask Sage'}</option>
                     </select>
                 </div>
             </div>
-            {service.serviceName === 'openai-compatible' && (
+            {service.serviceName === 'openaicompatible' && (
                 <div className='form-group'>
                     <label
                         className='control-label col-sm-4'


### PR DESCRIPTION
#### Summary
The OpenAI compatible "driver" was identified as `openai-compatible` in the frontend code, but as `openaicompatible` in the backend code, making it unusable.

#### Ticket Link
Fixes #79