### PR TITLE
Add post prop and render option for unsafe links

### DIFF
--- a/server/post_processing.go
+++ b/server/post_processing.go
@@ -93,11 +93,15 @@ func formatThread(data *ThreadData) string {
 }
 
 const LLMRequesterUserID = "llm_requester_user_id"
+const UnsafeLinksPostProp = "unsafe_links"
 
 func (p *Plugin) modifyPostForBot(requesterUserID string, post *model.Post) {
 	post.UserId = p.botid
 	post.Type = "custom_llmbot" // This must be the only place we add this type for security.
 	post.AddProp(LLMRequesterUserID, requesterUserID)
+	// This tags that the post has unsafe links since they could have been generted by a prompt injection.
+	// This will prevent the server from making OpenGraph requests and markdown images being rendered.
+	post.AddProp(UnsafeLinksPostProp, "true")
 }
 
 func (p *Plugin) botCreatePost(requesterUserID string, post *model.Post) error {

--- a/webapp/src/components/post_text.tsx
+++ b/webapp/src/components/post_text.tsx
@@ -55,6 +55,7 @@ const PostText = (props: Props) => {
         mentionHighlight: true,
         atMentions: true,
         team,
+        unsafeLinks: true,
 
         //channelNamesMap,
     };

--- a/webapp/src/components/post_text.tsx
+++ b/webapp/src/components/post_text.tsx
@@ -44,6 +44,7 @@ const TextContainer = styled.div<{showCursor?: boolean}>`
 const PostText = (props: Props) => {
     const channel = useSelector<GlobalState, Channel>((state) => state.entities.channels.channels[props.channelID]);
     const team = useSelector<GlobalState, Team>((state) => state.entities.teams.teams[channel?.team_id]);
+    const siteURL = useSelector<GlobalState, string | undefined>((state) => state.entities.general.config.SiteURL);
 
     //const channelNamesMap = useSelector<GlobalState, ChannelNamesMap>(getChannelsNameMapInCurrentTeam);
 
@@ -56,6 +57,7 @@ const PostText = (props: Props) => {
         atMentions: true,
         team,
         unsafeLinks: true,
+        siteURL,
 
         //channelNamesMap,
     };


### PR DESCRIPTION
## Summary
Unsafe links can potentially be generated by LLMs in the Mattermost AI plugin. For example a prompt injection could occour that tells the AI to create a malicious link that contains private data in the query paramenter: `http://badserver.com/all/my?private=data`

This PR adds a post prop and rendering options to mitigate the risk of links from prompt injections. 

## Related PRs

Server: https://github.com/mattermost/mattermost/pull/26098
Webapp: https://github.com/mattermost/mattermost/pull/26129
Mobile: https://github.com/mattermost/mattermost-mobile/pull/7815