### PR TITLE
Fix the cursor position on markdown generation

### DIFF
--- a/webapp/src/components/post_text.tsx
+++ b/webapp/src/components/post_text.tsx
@@ -28,7 +28,20 @@ const blinkKeyframes = keyframes`
 
 const TextContainer = styled.div<{showCursor?: boolean}>`
 	${(props) => props.showCursor && css`
-		>p:last-of-type::after {
+		>ul:last-child>li:last-child>span:not(:has(li))::after,
+		>ol:last-child>li:last-child>span:not(:has(li))::after,
+		>ul:last-child>li:last-child>span>ul>li:last-child>span:not(:has(li))::after,
+		>ol:last-child>li:last-child>span>ul>li:last-child>span:not(:has(li))::after,
+		>ul:last-child>li:last-child>span>ol>li:last-child>span:not(:has(li))::after,
+		>ol:last-child>li:last-child>span>ol>li:last-child>span:not(:has(li))::after,
+		>h1:last-child::after,
+		>h2:last-child::after,
+		>h3:last-child::after,
+		>h4:last-child::after,
+		>h5:last-child::after,
+		>h6:last-child::after,
+		>blockquote:last-child>p::after,
+		>p:last-child::after {
 			content: '';
 			width: 7px;
 			height: 16px;


### PR DESCRIPTION
Closes #181

## Description

It provides a more detail selection of nodes that has a better behavior on
generation of markdown.

There are some exceptions like triple nested lists where it doesn't work as
expected, but I can add it, but then it would be a problem with 4 nested lists,
and so on. I think it's better to keep it simple. And 2 nested lists are the most
common case.