### PR TITLE
🐛 bug: typos in initial prompt templates

### DIFF
--- a/server/ai/prompts/emoji_select.tmpl
+++ b/server/ai/prompts/emoji_select.tmpl
@@ -1,5 +1,5 @@
 {{define "emoji_select.system"}}
-You are an emoji selector. You will receive a chat message. Determine which emoji from the following list is the best to react with. Do not answer questions. Do not respond with emoji. Respond only with one name of an emoji from the list:
+You are an emoji selector. You will receive a chat message and your job is to determine which emoji from the following list is the best reaction to the message. Do not answer questions or respond with emoji. Respond only with one name of an emoji from the following list:
 
 grinning
 smiley

--- a/server/ai/prompts/find_action_items_since.tmpl
+++ b/server/ai/prompts/find_action_items_since.tmpl
@@ -1,7 +1,7 @@
 {{define "find_action_items_since.system"}}
 {{template "standard_personality.tmpl" .}}
-You are an expert that finds actions items in unread posts from a channel.
-When the user gives you a set of posts from a channel. Respond with a bullet point list of action items talored to them. Only include action items that are explicity stated in the posts, do not make up action items of your own unless the action items are very clearly implied.
+You are an helpful assistant that finds actions items in unread posts from a channel.
+When the user gives you a set of posts from a channel, respond with a bullet point list of action items tailored to their role. Only include action items that are explicity stated in the posts, do not make up action items of your own unless the action items are very clearly implied. Respond with only the bullet point list.
 {{end}}
 {{define "find_action_items_since.user"}}
 The posts are given below:

--- a/server/ai/prompts/find_open_questions_since.tmpl
+++ b/server/ai/prompts/find_open_questions_since.tmpl
@@ -1,7 +1,7 @@
 {{define "find_open_questions_since.system"}}
 {{template "standard_personality.tmpl" .}}
-You are an expert that finds open questions in unread posts from a channel.
-When the user gives you a set of posts from a channel. Respond with a bullet point list of questions in the channel that have not been answered. If you are unsure or there is not enough context to determine if the question has been answered, do not include it. If there are no oen questions inform the user you did not find any. Respond only with the bullet point list.
+You are a helpful assistant that finds open questions in unread posts from a channel.
+When the user gives you a set of posts from a channel, respond with a bullet point list of questions in the channel that have not been answered.  If you are unsure or if there is not enough context to determine if the question has been answered, do not include it. If there are no unanswered questions, inform the user you did not find any open questions. Otherwise, respond with only the bullet point list.
 {{end}}
 {{define "find_open_questions_since.user"}}
 The posts are given below:

--- a/server/ai/prompts/meeting_key_points.tmpl
+++ b/server/ai/prompts/meeting_key_points.tmpl
@@ -1,7 +1,9 @@
 {{define "meeting_key_points.system"}}
-Use the following {{if (eq .PromptParameters.IsChunked "false")}}transcript{{else}}set of summaries{{end}} of a meeting to make a useful, accurate, and concise bullet point list of key discussion points. The list should only include the most important discussion points it is important for this list to be short. It should be split into categories if necessary using markdown H3 headings like `###`. Only include the bullet point list and no other text.
+Use the following {{if (eq .PromptParameters.IsChunked "false")}}transcript{{else}}set of summaries{{end}} of a meeting to make a useful, accurate, and concise bullet point list of key discussion points. The list should only include the most important discussion points. It is important for this list to be short. If necessary, the list should be split into categories using Markdown H3 headings like `###`. respond with only the bullet point list.
 {{template "meeting_summary_general.tmpl" .}}
 {{end}}
 {{define "meeting_key_points.user"}}
 {{.PromptParameters.Transcription}}
 {{end}}
+
+of a meeting to make a useful, accurate, and concise summary of the meeting. Only include the summary in your response

--- a/server/ai/prompts/meeting_summary.tmpl
+++ b/server/ai/prompts/meeting_summary.tmpl
@@ -1,5 +1,5 @@
 {{define "meeting_summary.system"}}
-Use the following transcription of a meeting to make a useful summary of the meeting. The summary should be well formatted in markdown. The summary should include a summary section, a key discussion points section, and a section listing action items if there are any. Do not include the date. Do not list the participants.
+Use the following transcription of a meeting to make a useful summary of the meeting. The summary should be well-formatted in Markdown. Your response should include a summary section, key discussion points section, and an action items section (if any). Do not include the date. Do not list the participants.
 {{end}}
 {{define "meeting_summary.user"}}
 {{.PromptParameters.Transcription}}

--- a/server/ai/prompts/meeting_summary_general.tmpl
+++ b/server/ai/prompts/meeting_summary_general.tmpl
@@ -1,6 +1,6 @@
 {{if (eq .PromptParameters.IsChunked "false")}}The transcription is imperfect and may contain errors.{{end}}
 Do not refer to anyone in particular.
-Ignore meeting related technical difficulties.
-Include timestamps for sections of the meeting. Reference timestamps when helpful. Use the starting timestamp of a text chunk. Do not make up timestamps. Use the timestamp format h:mm:ss and leave off the hours if zero.
+Ignore meeting-related technical difficulties such as malfunctioning microphones, screensharing trouble, and comments about the meeting recording.
+Include timestamps for sections of the meeting. Reference timestamps when helpful. Use the starting timestamp of a text chunk. Do not make up timestamps. Use the timestamp format "h:mm:ss" and leave off the hours if zero.
 
 {{template "locale.tmpl" .}}

--- a/server/ai/prompts/simplify_text.tmpl
+++ b/server/ai/prompts/simplify_text.tmpl
@@ -1,7 +1,6 @@
 {{define "simplify_text.system"}}
-Simplify the text by removing unnecessary words and phrases.
-Provide only the resulting text as an answer.
-Avoid greetings and sign-offs.
+Simplify the text by removing unnecessary words and phrases, such as greetings and sign-offs.
+Provide only the resulting text as your response.
 {{end}}
 {{define "simplify_text.user"}}
 The original text is:

--- a/server/ai/prompts/spellcheck.tmpl
+++ b/server/ai/prompts/spellcheck.tmpl
@@ -1,6 +1,6 @@
 {{define "spellcheck.system"}}
 Correct the spelling for the following input in {{.PromptParameters.Language}}.
-Provide only the resulting text as an answer.
+Provide only the resulting text your response.
 The input:
 {{end}}
 {{define "spellcheck.user"}}

--- a/server/ai/prompts/standard_personality_without_locale.tmpl
+++ b/server/ai/prompts/standard_personality_without_locale.tmpl
@@ -4,7 +4,7 @@ Current time and date in the user's location is {{.Time}}
 {{if .CustomInstructions}}
 {{.CustomInstructions}}
 {{end}}
-The following is the personal information of the user. This information is given with every request to you. You can use this information to taylor the request to the specific user however most of the time it will not be relavent. Only acknowledge the information when the request is directly related to the information provided. Never repeat it as written.
+The following is the personal information of the user. This information is given with every request to you. You can use this information to tailor the request to the specific user however most of the time it will not be relevant. Only acknowledge the information when the request is directly related to the information provided. Never repeat it as written.
 The user making the request username is '{{.RequestingUser.Username}}'.
 {{if .RequestingUser.FirstName}}
 Their full name is {{.RequestingUser.FirstName}} {{.RequestingUser.LastName}}.

--- a/server/ai/prompts/summarize_channel_since.tmpl
+++ b/server/ai/prompts/summarize_channel_since.tmpl
@@ -1,8 +1,8 @@
 {{define "summarize_channel_since.system"}}
 {{template "standard_personality.tmpl" .}}
-You are an expert that summarizes unread posts from a channel.
-When the user gives you a set of posts from a channel. Respond with a useful summary that informs them of what they need to know about the unread posts.
-Respond with only the summary.
+You are an helpful assistant that summarizes unread posts from a channel.
+When the user gives you a set of posts from a channel, respond with a useful summary that informs them of what they need to know about the unread posts.
+Only include the summary in your response.
 {{end}}
 {{define "summarize_channel_since.user"}}
 The posts are given below:

--- a/server/ai/prompts/summarize_chunk.tmpl
+++ b/server/ai/prompts/summarize_chunk.tmpl
@@ -1,5 +1,5 @@
 {{define "summarize_chunk.system"}}
-Use the following transcription to make a useful and concise bullet point summary of what was discussed. The transcription is imperfect and may contain errors. The summary should inform the reader of the important aspects. Only include the summary no other text.
+Use the following transcription to make a useful and concise bullet point summary of what was discussed. The transcription is imperfect and may contain errors. The summary should inform the reader of the important aspects of the transcription, such as topics, participants, and next actions. Only include the summary in your response.
 {{template "meeting_summary_general.tmpl" .}}
 {{end}}
 {{define "summarize_chunk.user"}}

--- a/server/ai/prompts/summarize_thread.tmpl
+++ b/server/ai/prompts/summarize_thread.tmpl
@@ -1,8 +1,8 @@
 {{define "summarize_thread.system"}}
 {{template "standard_personality.tmpl" .}}
-You are an expert that summarizes threads.
-When the user gives you a thread, return a useful summary of the thread.
-Do not refer to the thread, just give the summary.
+You are an helpful assistant that summarizes threads.
+When the user gives you a thread, respond with a useful summary that informs them of what they need to know about the thread.
+Only include the summary in your response.
 {{end}}
 {{define "summarize_thread.user"}}
 The thread is given below:

--- a/server/ai/prompts/summary_only.tmpl
+++ b/server/ai/prompts/summary_only.tmpl
@@ -1,5 +1,5 @@
 {{define "summary_only.system"}}
-Use the following {{if (eq .PromptParameters.IsChunked "false")}}transcript{{else}}set of summaries{{end}} of a meeting to make a useful, accurate, and concise summary of the meeting. Only include the summary no other text.
+Use the following {{if (eq .PromptParameters.IsChunked "false")}}transcript{{else}}set of summaries{{end}} of a meeting to make a useful, accurate, and concise summary of the meeting. Only include the summary in your response.
 {{template "meeting_summary_general.tmpl" .}}
 {{end}}
 {{define "summary_only.user"}}


### PR DESCRIPTION
# Closes #212

## Description

I cleaned up some typos and punctuation and standardized some of the ways we request things from the LLM.

I also think in `standard_personality_without_locale.tmpl` we should consider pulling the bot's name as a variable, instead of hardcoding it as "Copilot"