### PR TITLE
Adding the cd workflow to generate releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,19 @@
+name: cd
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-cd:
+    uses: mattermost/actions-workflows/.github/workflows/plugin-cd.yml@main
+    with:
+      golang-version: "1.21"
+    secrets: inherit


### PR DESCRIPTION
## Description

This is a good practice to generate releases including environment variables like the RUDDER URL/KEY

<!-- Provide a clear and concise description of the changes made in this pull request. If possible, please explain your motivation for the changes and how you tested your changes. -->