### PR TITLE
Fix additional typos and variable name colliding with package

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -30,10 +30,10 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	router.GET("/ai_bots", p.handleGetAIBots)
 	router.POST("/telemetry/track", p.handleTrackEvent)
 
-	botRequriedRouter := router.Group("")
-	botRequriedRouter.Use(p.aiBotRequired)
+	botRequiredRouter := router.Group("")
+	botRequiredRouter.Use(p.aiBotRequired)
 
-	postRouter := botRequriedRouter.Group("/post/:postid")
+	postRouter := botRequiredRouter.Group("/post/:postid")
 	postRouter.Use(p.postAuthorizationRequired)
 	postRouter.POST("/react", p.handleReact)
 	postRouter.POST("/summarize", p.handleSummarize)
@@ -43,7 +43,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	postRouter.POST("/regenerate", p.handleRegenerate)
 	postRouter.POST("/postback_summary", p.handlePostbackSummary)
 
-	channelRouter := botRequriedRouter.Group("/channel/:channelid")
+	channelRouter := botRequiredRouter.Group("/channel/:channelid")
 	channelRouter.Use(p.channelAuthorizationRequired)
 	channelRouter.POST("/since", p.handleSince)
 
@@ -92,7 +92,7 @@ func (p *Plugin) handleGetAIThreads(c *gin.Context) {
 			return
 		}
 
-		// Extra permissions checks are not totally nessiary since a user should always have permission to read their own DMs
+		// Extra permissions checks are not totally necessary since a user should always have permission to read their own DMs
 		if !p.pluginAPI.User.HasPermissionToChannel(userID, botDMChannel.Id, model.PermissionReadChannel) {
 			c.AbortWithError(http.StatusForbidden, errors.New("user doesn't have permission to read channel"))
 			return

--- a/server/api_post.go
+++ b/server/api_post.go
@@ -58,9 +58,9 @@ func (p *Plugin) handleReact(c *gin.Context) {
 		return
 	}
 
-	context := p.MakeConversationContext(bot, user, channel, post)
-	context.PromptParameters = map[string]string{"Message": post.Message}
-	prompt, err := p.prompts.ChatCompletion(ai.PromptEmojiSelect, context, ai.NewNoTools())
+	conversationContext := p.MakeConversationContext(bot, user, channel, post)
+	conversationContext.PromptParameters = map[string]string{"Message": post.Message}
+	prompt, err := p.prompts.ChatCompletion(ai.PromptEmojiSelect, conversationContext, ai.NewNoTools())
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
@@ -72,7 +72,7 @@ func (p *Plugin) handleReact(c *gin.Context) {
 		return
 	}
 
-	// Do some emoji post processing to hopefully make this an actual emoji.
+	// Do some emoji post-processing to hopefully make this an actual emoji.
 	emojiName = strings.Trim(strings.TrimSpace(emojiName), ":")
 
 	if _, found := model.GetSystemEmojiId(emojiName); !found {

--- a/server/built_in_tools.go
+++ b/server/built_in_tools.go
@@ -101,7 +101,7 @@ func (p *Plugin) toolResolveGetChannelPosts(context ai.ConversationContext, args
 	}
 
 	if context.Channel == nil || context.Channel.TeamId == "" {
-		//TODO: support DMs. This will require some way to disabiguate between channels with the same name on different teams.
+		//TODO: support DMs. This will require some way to disambiguate between channels with the same name on different teams.
 		return "Error: Ambiguous channel lookup. Unable to what channel the user is referring to because DMs do not belong to specific teams. Tell the user to ask outside a DM channel.", errors.New("ambiguous channel lookup")
 	}
 


### PR DESCRIPTION
## Description
- Change `context` to `conversationContext` to not collide with imported package
- Fix typos "Required", "necessary", "post-processing", "disambiguate"
