### PR TITLE
Allow empty API key for openai compatable

### DIFF
--- a/server/ai/configuration.go
+++ b/server/ai/configuration.go
@@ -26,7 +26,7 @@ func (c *BotConfig) IsValid() bool {
 	isInvalid := c.Name == "" ||
 		c.DisplayName == "" ||
 		c.Service.Type == "" ||
-		(c.Service.Type == "openaicompatable" && c.Service.APIURL == "") ||
-		(c.Service.Type != "asksage" && c.Service.APIKey == "")
+		(c.Service.Type == "openaicompatible" && c.Service.APIURL == "") ||
+		(c.Service.Type != "asksage" && c.Service.Type != "openaicompatible" && c.Service.APIKey == "")
 	return !isInvalid
 }

--- a/webapp/src/components/system_console/bot.tsx
+++ b/webapp/src/components/system_console/bot.tsx
@@ -57,7 +57,7 @@ const Bot = (props: Props) => {
     const missingInfo = props.bot.name === '' ||
 		props.bot.displayName === '' ||
 		props.bot.service.type === '' ||
-		(props.bot.service.type !== 'asksage' && props.bot.service.apiKey === '') ||
+		(props.bot.service.type !== 'asksage' && props.bot.service.type !== 'openaicompatible' && props.bot.service.apiKey === '') ||
 		(props.bot.service.type === 'openaicompatible' && props.bot.service.apiURL === '');
 
     const invalidUsername = props.bot.name !== '' && (!(/^[a-z0-9.\-_]+$/).test(props.bot.name) || !(/[a-z]/).test(props.bot.name.charAt(0)));


### PR DESCRIPTION
## Description

Allows empty OpenAI compatable API key. This allows for easier usage with local models run by Ollama and similar.
