### PR TITLE
Updated detection of Azure OpenAI to include the Azure Government Endpoint

### DIFF
--- a/server/ai/openai/openai.go
+++ b/server/ai/openai/openai.go
@@ -48,7 +48,7 @@ func NewCompatible(llmService ai.ServiceConfig, httpClient *http.Client, metrics
 	config.HTTPClient = httpClient
 
 	parsedURL, err := url.Parse(endpointURL)
-	if err == nil && strings.HasSuffix(parsedURL.Host, "openai.azure.com") {
+	if err == nil && (strings.HasSuffix(parsedURL.Host, "openai.azure.com") || strings.HasSuffix(parsedURL.Host, "openai.azure.us")) {
 		config = openaiClient.DefaultAzureConfig(apiKey, endpointURL)
 		config.APIVersion = "2023-07-01-preview"
 	}


### PR DESCRIPTION
Azure OpenAI has the potential to exist at multiple endpoints, with the primary commercial endpoint being available at `openai.azure.com` and the government endpoint being available at `openai.azure.us`. Updated logic to check for both endpoints.

# Closes #239 

## Description

My team requires all systems that we leverage to exist within a managed boundary, suitable for management of CUI data (and is bound by NIST 800-171 requirements). As such, we're only able to leverage services within that boundary. In order to to access Azure OpenAI from Azure's Government cloud, the endpoint has a different hostname than Azure Commercial's endpoint for OpenAI.  The PR implements a trivial change to detect an azure-based OpenAI endpoint by comparing both possible hostnames.

The hostname for Azure Government is documented here: https://learn.microsoft.com/en-us/azure/azure-government/compare-azure-government-global-azure. Note that it _is plausible_ that MS/Azure may have already published or intends to publish additional endpoints beyond the two included in this PR. 

There very well may be better ways to implement this; however, this PR demonstrates the quick-and-dirty approach I used to get the plugin up and running for my team (and I have validated that it is functional).   A more flexible approach might be to formally introduce "Azure OpenAI" as a named-type within the plugin, or offering a user another way to indicate that the service is specifically Azure OpenAI.
