### PR TITLE
Add files to LLM context.

### DIFF
--- a/server/ai/configuration.go
+++ b/server/ai/configuration.go
@@ -21,6 +21,7 @@ type BotConfig struct {
 	Service            ServiceConfig `json:"service"`
 	EnableVision       bool          `json:"enableVision"`
 	DisableTools       bool          `json:"disableTools"`
+	MaxFileSize        int64         `json:"maxFileSize"`
 }
 
 func (c *BotConfig) IsValid() bool {


### PR DESCRIPTION
# Closes: #245
# Closes: #61

## Description

Adds files to the context of the context of the LLM. Any file that is supported by the server text extraction (including PDFs) should work as long as that text extraction works. For some reason that extraction doesn't work on text files so the ability to extract text files was added here. 
Docs on Text extraction: https://docs.mattermost.com/collaborate/search-for-messages.html

Many files will be over the limit of your LLM or will reach the token limit set in the system console. Files that are too long will cause the prompt to be cut off at the beginning. Set the token limit of your LLM in the system console to make sure this works correctly.

Use a high token limit LLM to use this effectively, all but the latest (llama3.2) on-prem models will have issues with large files. 
