### PR TITLE
Add withUserId configuration for OpenAI

### DIFF
--- a/server/ai/configuration.go
+++ b/server/ai/configuration.go
@@ -11,6 +11,7 @@ type ServiceConfig struct {
 	Password                string `json:"password"`
 	TokenLimit              int    `json:"tokenLimit"`
 	StreamingTimeoutSeconds int    `json:"streamingTimeoutSeconds"`
+	WithUserId              bool   `json:"withUserId"`
 }
 
 type BotConfig struct {

--- a/server/ai/configuration.go
+++ b/server/ai/configuration.go
@@ -11,7 +11,7 @@ type ServiceConfig struct {
 	Password                string `json:"password"`
 	TokenLimit              int    `json:"tokenLimit"`
 	StreamingTimeoutSeconds int    `json:"streamingTimeoutSeconds"`
-	WithUserId              bool   `json:"withUserId"`
+	SendUserID              bool   `json:"sendUserID"`
 }
 
 type BotConfig struct {

--- a/server/ai/openai/openai.go
+++ b/server/ai/openai/openai.go
@@ -28,6 +28,7 @@ type OpenAI struct {
 	tokenLimit       int
 	streamingTimeout time.Duration
 	metricsService   metrics.LLMetrics
+	withUserId       bool
 }
 
 const StreamingTimeoutDefault = 10 * time.Second
@@ -94,6 +95,7 @@ func newOpenAI(
 		tokenLimit:       llmService.TokenLimit,
 		streamingTimeout: streamingTimeout,
 		metricsService:   metricsService,
+		withUserId:       llmService.WithUserId,
 	}
 }
 
@@ -404,6 +406,9 @@ func (s *OpenAI) ChatCompletion(conversation ai.BotConversation, opts ...ai.Lang
 	request := s.completionRequestFromConfig(s.createConfig(opts))
 	request = modifyCompletionRequestWithConversation(request, conversation)
 	request.Stream = true
+	if s.withUserId {
+		request.User = conversation.Context.RequestingUser.Username
+	}
 	return s.streamResult(request, conversation)
 }
 

--- a/server/ai/openai/openai.go
+++ b/server/ai/openai/openai.go
@@ -28,7 +28,7 @@ type OpenAI struct {
 	tokenLimit       int
 	streamingTimeout time.Duration
 	metricsService   metrics.LLMetrics
-	withUserId       bool
+	sendUserID       bool
 }
 
 const StreamingTimeoutDefault = 10 * time.Second
@@ -95,7 +95,7 @@ func newOpenAI(
 		tokenLimit:       llmService.TokenLimit,
 		streamingTimeout: streamingTimeout,
 		metricsService:   metricsService,
-		withUserId:       llmService.WithUserId,
+		sendUserID:       llmService.SendUserID,
 	}
 }
 
@@ -406,8 +406,8 @@ func (s *OpenAI) ChatCompletion(conversation ai.BotConversation, opts ...ai.Lang
 	request := s.completionRequestFromConfig(s.createConfig(opts))
 	request = modifyCompletionRequestWithConversation(request, conversation)
 	request.Stream = true
-	if s.withUserId {
-		request.User = conversation.Context.RequestingUser.Username
+	if s.sendUserID {
+		request.User = conversation.Context.RequestingUser.Id
 	}
 	return s.streamResult(request, conversation)
 }

--- a/server/service.go
+++ b/server/service.go
@@ -68,7 +68,7 @@ func (p *Plugin) newConversation(bot *Bot, context ai.ConversationContext) error
 
 	go func() {
 		request := "Write a short title for the following request. Include only the title and nothing else, no quotations. Request:\n" + context.Post.Message
-		if err := p.generateTitle(bot, request, context.Post.Id); err != nil {
+		if err := p.generateTitle(bot, request, context); err != nil {
 			p.API.LogError("Failed to generate title", "error", err.Error())
 			return
 		}
@@ -77,9 +77,10 @@ func (p *Plugin) newConversation(bot *Bot, context ai.ConversationContext) error
 	return nil
 }
 
-func (p *Plugin) generateTitle(bot *Bot, request string, threadRootID string) error {
+func (p *Plugin) generateTitle(bot *Bot, request string, context ai.ConversationContext) error {
 	titleRequest := ai.BotConversation{
-		Posts: []ai.Post{{Role: ai.PostRoleUser, Message: request}},
+		Posts:   []ai.Post{{Role: ai.PostRoleUser, Message: request}},
+		Context: context,
 	}
 	conversationTitle, err := p.getLLM(bot.cfg).ChatCompletionNoStream(titleRequest, ai.WithMaxGeneratedTokens(25))
 	if err != nil {
@@ -88,7 +89,7 @@ func (p *Plugin) generateTitle(bot *Bot, request string, threadRootID string) er
 
 	conversationTitle = strings.Trim(conversationTitle, "\n \"'")
 
-	if err := p.saveTitle(threadRootID, conversationTitle); err != nil {
+	if err := p.saveTitle(context.Post.Id, conversationTitle); err != nil {
 		return fmt.Errorf("failed to save title: %w", err)
 	}
 

--- a/webapp/src/components/system_console/bot.tsx
+++ b/webapp/src/components/system_console/bot.tsx
@@ -22,7 +22,7 @@ export type LLMService = {
     password: string
     tokenLimit: number
     streamingTimeoutSeconds: number
-    withUserId: boolean
+    sendUserId: boolean
 }
 
 export type LLMBotConfig = {
@@ -138,7 +138,7 @@ const Bot = (props: Props) => {
                             value={props.bot.customInstructions}
                             onChange={(e) => props.onChange({...props.bot, customInstructions: e.target.value})}
                         />
-                        { (props.bot.service.type === 'openai' || props.bot.service.type === 'openaicompatible' || props.bot.service.type === 'azure') && (
+                        {(props.bot.service.type === 'openai' || props.bot.service.type === 'openaicompatible' || props.bot.service.type === 'azure') && (
                             <>
                                 <BooleanItem
                                     label={
@@ -211,9 +211,9 @@ const ServiceItem = (props: ServiceItemProps) => {
                     />
                     <BooleanItem
                         label={intl.formatMessage({defaultMessage: 'Send User ID'})}
-                        value={props.service.withUserId}
-                        onChange={(to: boolean) => props.onChange({...props.service, withUserId: to})}
-                        helpText={intl.formatMessage({defaultMessage: 'Sending end-user IDs in your requests can be useful OpenAI to monitor and detect abuse.'})}
+                        value={props.service.sendUserId}
+                        onChange={(to: boolean) => props.onChange({...props.service, sendUserId: to})}
+                        helpText={intl.formatMessage({defaultMessage: 'Sends the Mattermost user ID to the upstream LLM.'})}
                     />
                 </>
             )}

--- a/webapp/src/components/system_console/bot.tsx
+++ b/webapp/src/components/system_console/bot.tsx
@@ -22,6 +22,7 @@ export type LLMService = {
     password: string
     tokenLimit: number
     streamingTimeoutSeconds: number
+    withUserId: boolean
 }
 
 export type LLMBotConfig = {
@@ -202,11 +203,19 @@ const ServiceItem = (props: ServiceItemProps) => {
                 />
             )}
             {isOpenAIType && (
-                <TextItem
-                    label={intl.formatMessage({defaultMessage: 'Organization ID'})}
-                    value={props.service.orgId}
-                    onChange={(e) => props.onChange({...props.service, orgId: e.target.value})}
-                />
+                <>
+                    <TextItem
+                        label={intl.formatMessage({defaultMessage: 'Organization ID'})}
+                        value={props.service.orgId}
+                        onChange={(e) => props.onChange({...props.service, orgId: e.target.value})}
+                    />
+                    <BooleanItem
+                        label={intl.formatMessage({defaultMessage: 'Send User ID'})}
+                        value={props.service.withUserId}
+                        onChange={(to: boolean) => props.onChange({...props.service, withUserId: to})}
+                        helpText={intl.formatMessage({defaultMessage: 'Sending end-user IDs in your requests can be useful OpenAI to monitor and detect abuse.'})}
+                    />
+                </>
             )}
             {type === 'asksage' && (
                 <>

--- a/webapp/src/components/system_console/bots.tsx
+++ b/webapp/src/components/system_console/bots.tsx
@@ -10,13 +10,12 @@ import {useIsMultiLLMLicensed} from '@/license';
 import Bot, {LLMBotConfig} from './bot';
 import EnterpriseChip from './enterprise_chip';
 
-const defaultNewBot = {
+const defaultNewBot: LLMBotConfig = {
     id: '',
     name: '',
     displayName: '',
     customInstructions: '',
     service: {
-        id: '',
         type: 'openai',
         apiKey: '',
         apiURL: '',
@@ -26,7 +25,7 @@ const defaultNewBot = {
         password: '',
         tokenLimit: 0,
         streamingTimeoutSeconds: 0,
-        withUserId: false,
+        sendUserID: false,
     },
     enableVision: false,
     disableTools: false,

--- a/webapp/src/components/system_console/bots.tsx
+++ b/webapp/src/components/system_console/bots.tsx
@@ -25,7 +25,7 @@ const defaultNewBot: LLMBotConfig = {
         password: '',
         tokenLimit: 0,
         streamingTimeoutSeconds: 0,
-        sendUserID: false,
+        sendUserId: false,
     },
     enableVision: false,
     disableTools: false,

--- a/webapp/src/components/system_console/bots.tsx
+++ b/webapp/src/components/system_console/bots.tsx
@@ -26,6 +26,7 @@ const defaultNewBot = {
         password: '',
         tokenLimit: 0,
         streamingTimeoutSeconds: 0,
+        withUserId: false,
     },
     enableVision: false,
     disableTools: false,

--- a/webapp/src/components/system_console/service.tsx
+++ b/webapp/src/components/system_console/service.tsx
@@ -10,4 +10,5 @@ export type ServiceData = {
     password: string
     tokenLimit: number
     streamingTimeoutSeconds: number
+    withUserId: boolean
 }

--- a/webapp/src/components/system_console/service.tsx
+++ b/webapp/src/components/system_console/service.tsx
@@ -10,5 +10,5 @@ export type ServiceData = {
     password: string
     tokenLimit: number
     streamingTimeoutSeconds: number
-    withUserId: boolean
+    sendUserId: boolean
 }


### PR DESCRIPTION
# Closes #258 

## Description

Hello!

I'm thoroughly enjoying the Mattermost AI plugin and appreciate how useful it has been for our team. As I’ve been using it, I thought of a small enhancement that could add value, so I put together a PR to share with you.

The OpenAI Chat Completion API supports a [user parameter](https://platform.openai.com/docs/api-reference/chat/create#chat-create-user), which can help with user monitoring and detecting abuse. I’ve implemented a feature that allows admins to toggle whether or not to send the `Username` when using OpenAI models. This option is accessible in the plugin settings, providing greater flexibility and control.

Additionally, I have a suggestion that might improve the user experience for a more global audience. Currently, in direct messages (DMs), the plugin uses a combination of `Firstname` and `Lastname` to identify users.
https://github.com/mattermost/mattermost-plugin-ai/blob/master/server/ai/prompts/standard_personality_without_locale.tmpl#L9
```
{{if .RequestingUser.FirstName}}
Their full name is {{.RequestingUser.FirstName}} {{.RequestingUser.LastName}}.
{{end}}
```
Modifying this to pass the `Username` instead might feel more relatable for users from different cultural backgrounds, which could further support Mattermost’s positioning as a globally inclusive collaboration tool.

If you find the suggestion to use Username agreeable, I’d be happy to incorporate it into this PR.

Thank you for considering this enhancement!

<!-- Provide a clear and concise description of the changes made in this pull request. If possible, please explain your motivation for the changes and how you tested your changes. -->
