### PR TITLE
Close channels for the stream from string helper

### DIFF
--- a/server/ai/stream.go
+++ b/server/ai/stream.go
@@ -7,13 +7,17 @@ type TextStreamResult struct {
 
 func NewStreamFromString(text string) *TextStreamResult {
 	output := make(chan string)
+	err := make(chan error)
 
 	go func() {
 		output <- text
+		close(output)
+		close(err)
 	}()
 
 	return &TextStreamResult{
 		Stream: output,
+		Err:    err,
 	}
 }
 


### PR DESCRIPTION
## Description

The string helper for streaming doesn't close its channels. This fixes it to close its channels. 
