### PR TITLE
MM-61474 Add option to restrict domains the LLM can request to contact upstream.

### DIFF
--- a/server/built_in_tools.go
+++ b/server/built_in_tools.go
@@ -17,7 +17,6 @@ import (
 	"github.com/mattermost/mattermost-plugin-ai/server/ai"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
-	"github.com/mattermost/mattermost/server/public/shared/httpservice"
 )
 
 type LookupMattermostUserArgs struct {
@@ -324,7 +323,7 @@ var fetchedFields = []string{
 }
 
 func (p *Plugin) getPublicJiraIssues(instanceURL string, issueKeys []string) ([]jira.Issue, error) {
-	httpClient := httpservice.MakeHTTPServicePlugin(p.API).MakeClient(false)
+	httpClient := p.createExternalHTTPClient()
 	client, err := jira.NewClient(httpClient, instanceURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Jira client: %w", err)

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -14,10 +14,11 @@ type Config struct {
 	TranscriptGenerator string             `json:"transcriptBackend"`
 	EnableLLMTrace      bool               `json:"enableLLMTrace"`
 
-	EnableUseRestrictions bool   `json:"enableUserRestrictions"`
-	AllowPrivateChannels  bool   `json:"allowPrivateChannels"`
-	AllowedTeamIDs        string `json:"allowedTeamIDs"`
-	OnlyUsersOnTeam       string `json:"onlyUsersOnTeam"`
+	EnableUseRestrictions    bool   `json:"enableUserRestrictions"`
+	AllowPrivateChannels     bool   `json:"allowPrivateChannels"`
+	AllowedTeamIDs           string `json:"allowedTeamIDs"`
+	OnlyUsersOnTeam          string `json:"onlyUsersOnTeam"`
+	AllowedUpstreamHostnames string `json:"allowedUpstreamHostnames"`
 }
 
 // configuration captures the plugin's external configuration as exposed in the Mattermost server

--- a/server/http_external.go
+++ b/server/http_external.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/shared/httpservice"
+)
+
+// hostnameAllowed checks if a hostname matches any of the allowed patterns
+func hostnameAllowed(hostname string, allowedPatterns []string) bool {
+	for _, pattern := range allowedPatterns {
+		if pattern == "*" {
+			return true
+		}
+
+		if strings.HasPrefix(pattern, "*.") {
+			suffix := pattern[1:] // Remove the *
+			if strings.HasSuffix(hostname, suffix) {
+				return true
+			}
+		} else if hostname == pattern {
+			return true
+		}
+	}
+	return false
+}
+
+// parseAllowedHostnames splits the comma-separated string into cleaned hostname patterns
+func parseAllowedHostnames(allowedHostnames string) []string {
+	allowedHostnames = strings.TrimSpace(allowedHostnames)
+	if allowedHostnames == "" {
+		return nil
+	}
+
+	patterns := strings.Split(allowedHostnames, ",")
+	cleaned := make([]string, 0, len(patterns))
+
+	for _, p := range patterns {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			cleaned = append(cleaned, p)
+		}
+	}
+
+	return cleaned
+}
+
+// restrictedTransport wraps an http.RoundTripper to enforce hostname restrictions
+type restrictedTransport struct {
+	wrapped      http.RoundTripper
+	allowedHosts []string
+}
+
+func (t *restrictedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL == nil {
+		return nil, fmt.Errorf("request has no URL")
+	}
+
+	hostname := req.URL.Hostname()
+	if !hostnameAllowed(hostname, t.allowedHosts) {
+		return nil, fmt.Errorf("hostname %q is not on allowed list, add this host to allowed upstream hosts", hostname)
+	}
+
+	return t.wrapped.RoundTrip(req)
+}
+
+// wrapTransportWithHostRestrictions wraps an existing transport with hostname restrictions
+func wrapTransportWithHostRestrictions(base http.RoundTripper, allowedHostnames []string) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	return &restrictedTransport{
+		wrapped:      base,
+		allowedHosts: allowedHostnames,
+	}
+}
+
+// createRestrictedClient creates an http.Client with hostname restrictions
+func createRestrictedClient(client *http.Client, allowedHostnames []string) *http.Client {
+	if client == nil {
+		client = &http.Client{}
+	}
+
+	// Wrap the existing transport or create new one
+	client.Transport = wrapTransportWithHostRestrictions(client.Transport, allowedHostnames)
+
+	return client
+}
+
+func (p *Plugin) createExternalHTTPClient() *http.Client {
+	baseClient := httpservice.MakeHTTPServicePlugin(p.API).MakeClient(false)
+	return createRestrictedClient(baseClient, parseAllowedHostnames(p.getConfiguration().AllowedUpstreamHostnames))
+}

--- a/server/http_external_test.go
+++ b/server/http_external_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostnameAllowed(t *testing.T) {
+	tests := []struct {
+		name            string
+		hostname        string
+		allowedPatterns []string
+		want            bool
+	}{
+		{
+			name:            "exact match",
+			hostname:        "example.com",
+			allowedPatterns: []string{"example.com"},
+			want:            true,
+		},
+		{
+			name:            "wildcard subdomain match",
+			hostname:        "sub.example.com",
+			allowedPatterns: []string{"*.example.com"},
+			want:            true,
+		},
+		{
+			name:            "wildcard subdomain no match",
+			hostname:        "sub.different.com",
+			allowedPatterns: []string{"*.example.com"},
+			want:            false,
+		},
+		{
+			name:            "global wildcard match",
+			hostname:        "anything.com",
+			allowedPatterns: []string{"*"},
+			want:            true,
+		},
+		{
+			name:            "multiple patterns with match",
+			hostname:        "api.github.com",
+			allowedPatterns: []string{"*.example.com", "api.github.com", "*.mattermost.com"},
+			want:            true,
+		},
+		{
+			name:            "multiple patterns no match",
+			hostname:        "evil.com",
+			allowedPatterns: []string{"*.example.com", "api.github.com", "*.mattermost.com"},
+			want:            false,
+		},
+		{
+			name:            "empty patterns list",
+			hostname:        "example.com",
+			allowedPatterns: []string{},
+			want:            false,
+		},
+		{
+			name:            "nil patterns list",
+			hostname:        "example.com",
+			allowedPatterns: nil,
+			want:            false,
+		},
+		{
+			name:            "deep subdomain match",
+			hostname:        "deep.sub.example.com",
+			allowedPatterns: []string{"*.example.com"},
+			want:            true,
+		},
+		{
+			name:            "partial suffix no match",
+			hostname:        "notexample.com",
+			allowedPatterns: []string{"*.example.com"},
+			want:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hostnameAllowed(tt.hostname, tt.allowedPatterns)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCreateRestrictedClient(t *testing.T) {
+	// Start a test HTTP server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	// Parse the test server URL to get its hostname
+	tsURL, err := url.Parse(ts.URL)
+	assert.NoError(t, err)
+	testHostname := tsURL.Hostname()
+
+	tests := []struct {
+		name            string
+		allowedHosts    []string
+		targetURL       string
+		expectError     bool
+		errorSubstring  string
+	}{
+		{
+			name:            "allowed host",
+			allowedHosts:    []string{testHostname},
+			targetURL:       ts.URL,
+			expectError:     false,
+		},
+		{
+			name:            "blocked host",
+			allowedHosts:    []string{"allowed.com"},
+			targetURL:       ts.URL,
+			expectError:     true,
+			errorSubstring:  "not in allowed list",
+		},
+		{
+			name:            "wildcard allowed",
+			allowedHosts:    []string{"*"},
+			targetURL:       ts.URL,
+			expectError:     false,
+		},
+		{
+			name:            "multiple patterns with match",
+			allowedHosts:    []string{"other.com", testHostname, "another.com"},
+			targetURL:       ts.URL,
+			expectError:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := createRestrictedClient(nil, tt.allowedHosts)
+			
+			req, err := http.NewRequest("GET", tt.targetURL, nil)
+			assert.NoError(t, err)
+
+			resp, err := client.Do(req)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorSubstring != "" {
+					assert.Contains(t, err.Error(), tt.errorSubstring)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				if resp != nil {
+					resp.Body.Close()
+					assert.Equal(t, http.StatusOK, resp.StatusCode)
+				}
+			}
+		})
+	}
+}
+
+func TestParseAllowedHostnames(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "simple list",
+			input:    "example.com,test.com",
+			expected: []string{"example.com", "test.com"},
+		},
+		{
+			name:     "with spaces",
+			input:    " example.com , test.com ",
+			expected: []string{"example.com", "test.com"},
+		},
+		{
+			name:     "with empty entries",
+			input:    "example.com,,test.com,",
+			expected: []string{"example.com", "test.com"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "only spaces",
+			input:    "   ",
+			expected: nil,
+		},
+		{
+			name:     "with wildcards",
+			input:    "*.example.com,api.github.com",
+			expected: []string{"*.example.com", "api.github.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAllowedHostnames(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/server/http_external_test.go
+++ b/server/http_external_test.go
@@ -99,43 +99,43 @@ func TestCreateRestrictedClient(t *testing.T) {
 	testHostname := tsURL.Hostname()
 
 	tests := []struct {
-		name            string
-		allowedHosts    []string
-		targetURL       string
-		expectError     bool
-		errorSubstring  string
+		name           string
+		allowedHosts   []string
+		targetURL      string
+		expectError    bool
+		errorSubstring string
 	}{
 		{
-			name:            "allowed host",
-			allowedHosts:    []string{testHostname},
-			targetURL:       ts.URL,
-			expectError:     false,
+			name:         "allowed host",
+			allowedHosts: []string{testHostname},
+			targetURL:    ts.URL,
+			expectError:  false,
 		},
 		{
-			name:            "blocked host",
-			allowedHosts:    []string{"allowed.com"},
-			targetURL:       ts.URL,
-			expectError:     true,
-			errorSubstring:  "not in allowed list",
+			name:           "blocked host",
+			allowedHosts:   []string{"allowed.com"},
+			targetURL:      ts.URL,
+			expectError:    true,
+			errorSubstring: "not on allowed list",
 		},
 		{
-			name:            "wildcard allowed",
-			allowedHosts:    []string{"*"},
-			targetURL:       ts.URL,
-			expectError:     false,
+			name:         "wildcard allowed",
+			allowedHosts: []string{"*"},
+			targetURL:    ts.URL,
+			expectError:  false,
 		},
 		{
-			name:            "multiple patterns with match",
-			allowedHosts:    []string{"other.com", testHostname, "another.com"},
-			targetURL:       ts.URL,
-			expectError:     false,
+			name:         "multiple patterns with match",
+			allowedHosts: []string{"other.com", testHostname, "another.com"},
+			targetURL:    ts.URL,
+			expectError:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := createRestrictedClient(nil, tt.allowedHosts)
-			
+
 			req, err := http.NewRequest("GET", tt.targetURL, nil)
 			assert.NoError(t, err)
 

--- a/webapp/src/components/system_console/config.tsx
+++ b/webapp/src/components/system_console/config.tsx
@@ -179,7 +179,7 @@ const Config = (props: Props) => {
                         label={intl.formatMessage({defaultMessage: 'Allowed Upstream Hostnames (csv)'})}
                         value={value.allowedUpstreamHostnames}
                         onChange={(e) => props.onChange(props.id, {...value, allowedUpstreamHostnames: e.target.value})}
-                        helptext={intl.formatMessage({defaultMessage: 'Comma-separated list of hostnames that bots are allowed to contact.'})}
+                        helptext={intl.formatMessage({defaultMessage: 'Comma separated list of hostnames that LLMs are allowed to contact when using tools. Supports wildcards like *.mydomain.com. For instance to allow JIRA tool use to the Mattermost JIRA instance use mattermost.atlassian.net'})}
                     />
                 </ItemList>
             </Panel>

--- a/webapp/src/components/system_console/config.tsx
+++ b/webapp/src/components/system_console/config.tsx
@@ -8,7 +8,7 @@ import {ServiceData} from './service';
 import Panel, {PanelFooterText} from './panel';
 import Bots, {firstNewBot} from './bots';
 import {LLMBotConfig} from './bot';
-import {ItemList, SelectionItem, SelectionItemOption} from './item';
+import {BooleanItem, ItemList, SelectionItem, SelectionItemOption, TextItem} from './item';
 import NoBotsPage from './no_bots_page';
 
 type Config = {
@@ -23,6 +23,7 @@ type Config = {
     allowPrivateChannels: boolean
     allowedTeamIds: string
     onlyUsersOnTeam: string
+    allowedUpstreamHostnames: string
 }
 
 type Props = {
@@ -174,6 +175,12 @@ const Config = (props: Props) => {
                             </SelectionItemOption>
                         ))}
                     </SelectionItem>
+                    <TextItem
+                        label={intl.formatMessage({defaultMessage: 'Allowed Upstream Hostnames (csv)'})}
+                        value={value.allowedUpstreamHostnames}
+                        onChange={(e) => props.onChange(props.id, {...value, allowedUpstreamHostnames: e.target.value})}
+                        helptext={intl.formatMessage({defaultMessage: 'Comma-separated list of hostnames that bots are allowed to contact.'})}
+                    />
                 </ItemList>
             </Panel>
 
@@ -181,144 +188,47 @@ const Config = (props: Props) => {
                 title={intl.formatMessage({defaultMessage: 'User restrictions (experimental)'})}
                 subtitle={intl.formatMessage({defaultMessage: 'Restrict where Copilot can be used.'})}
             >
-                <div className='form-group'>
-                    <label
-                        className='control-label col-sm-4'
-                    >
-                        <FormattedMessage defaultMessage='Enable User Restrictions:'/>
-                    </label>
-                    <div className='col-sm-8'>
-                        <label className='radio-inline'>
-                            <input
-                                type='radio'
-                                value='true'
-                                checked={value.enableUserRestrictions}
-                                onChange={() => props.onChange(props.id, {...value, enableUserRestrictions: true})}
+                <ItemList>
+                    <BooleanItem
+                        label={intl.formatMessage({defaultMessage: 'Enable User Restrictions'})}
+                        value={value.enableUserRestrictions}
+                        onChange={(to) => props.onChange(props.id, {...value, enableUserRestrictions: to})}
+                        helpText={intl.formatMessage({defaultMessage: 'Global flag for all below settings.'})}
+                    />
+                    {value.enableUserRestrictions && (
+                        <>
+                            <BooleanItem
+                                label={intl.formatMessage({defaultMessage: 'Allow Private Channels'})}
+                                value={value.allowPrivateChannels}
+                                onChange={(to) => props.onChange(props.id, {...value, allowPrivateChannels: to})}
                             />
-                            <span><FormattedMessage defaultMessage='true'/></span>
-                        </label>
-                        <label className='radio-inline'>
-                            <input
-                                type='radio'
-                                value='false'
-                                checked={!value.enableUserRestrictions}
-                                onChange={() => props.onChange(props.id, {...value, enableUserRestrictions: false})}
+                            <TextItem
+                                label={intl.formatMessage({defaultMessage: 'Allow Team IDs (csv)'})}
+                                value={value.allowedTeamIds}
+                                onChange={(e) => props.onChange(props.id, {...value, allowedTeamIds: e.target.value})}
                             />
-                            <span><FormattedMessage defaultMessage='false'/></span>
-                        </label>
-                        <div className='help-text'>
-                            <span>
-                                <FormattedMessage defaultMessage='Global flag for all below settings.'/>
-                            </span>
-                        </div>
-                    </div>
-                </div>
-                {value.enableUserRestrictions && (
-                    <>
-                        <div className='form-group'>
-                            <label
-                                className='control-label col-sm-4'
-                            >
-                                <FormattedMessage defaultMessage='Allow Private Channels:'/>
-                            </label>
-                            <div className='col-sm-8'>
-                                <label className='radio-inline'>
-                                    <input
-                                        type='radio'
-                                        value='true'
-                                        checked={value.allowPrivateChannels}
-                                        onChange={() => props.onChange(props.id, {...value, allowPrivateChannels: true})}
-                                    />
-                                    <span><FormattedMessage defaultMessage='true'/></span>
-                                </label>
-                                <label className='radio-inline'>
-                                    <input
-                                        type='radio'
-                                        value='false'
-                                        checked={!value.allowPrivateChannels}
-                                        onChange={() => props.onChange(props.id, {...value, allowPrivateChannels: false})}
-                                    />
-                                    <span>
-                                        <FormattedMessage defaultMessage='false'/>
-                                    </span>
-                                </label>
-                            </div>
-                        </div>
-                        <div className='form-group'>
-                            <label
-                                className='control-label col-sm-4'
-                                htmlFor='ai-allow-team-ids'
-                            >
-                                <FormattedMessage defaultMessage='Allow Team IDs (csv):'/>
-                            </label>
-                            <div className='col-sm-8'>
-                                <input
-                                    id='ai-allow-team-ids'
-                                    className='form-control'
-                                    type='text'
-                                    value={value.allowedTeamIds}
-                                    onChange={(e) => props.onChange(props.id, {...value, allowedTeamIds: e.target.value})}
-                                />
-                            </div>
-                        </div>
-                        <div className='form-group'>
-                            <label
-                                className='control-label col-sm-4'
-                                htmlFor='ai-only-users-on-team'
-                            >
-                                <FormattedMessage defaultMessage='Only Users on Team:'/>
-                            </label>
-                            <div className='col-sm-8'>
-                                <input
-                                    id='ai-only-users-on-team'
-                                    className='form-control'
-                                    type='text'
-                                    value={value.onlyUsersOnTeam}
-                                    onChange={(e) => props.onChange(props.id, {...value, onlyUsersOnTeam: e.target.value})}
-                                />
-                            </div>
-                        </div>
-                    </>
-                )}
+                            <TextItem
+                                label={intl.formatMessage({defaultMessage: 'Only Users on Team'})}
+                                value={value.onlyUsersOnTeam}
+                                onChange={(e) => props.onChange(props.id, {...value, onlyUsersOnTeam: e.target.value})}
+                            />
+                        </>
+                    )}
+                </ItemList>
             </Panel>
 
             <Panel
                 title={intl.formatMessage({defaultMessage: 'Debug'})}
                 subtitle=''
             >
-                <div className='form-group'>
-                    <label
-                        className='control-label col-sm-4'
-                        htmlFor='ai-service-name'
-                    >
-                        <FormattedMessage defaultMessage='Enable LLM Trace:'/>
-                    </label>
-                    <div className='col-sm-8'>
-                        <label className='radio-inline'>
-                            <input
-                                type='radio'
-                                value='true'
-                                checked={value.enableLLMTrace}
-                                onChange={() => props.onChange(props.id, {...value, enableLLMTrace: true})}
-                            />
-                            <span><FormattedMessage defaultMessage='true'/></span>
-                        </label>
-                        <label className='radio-inline'>
-                            <input
-                                type='radio'
-                                value='false'
-                                checked={!value.enableLLMTrace}
-                                onChange={() => props.onChange(props.id, {...value, enableLLMTrace: false})}
-                            />
-                            <span><FormattedMessage defaultMessage='false'/></span>
-                        </label>
-                        <div className='help-text'>
-                            <span>
-                                <FormattedMessage defaultMessage='Enable tracing of LLM requests. Outputs full conversation data to the logs.'/>
-                            </span>
-                        </div>
-                    </div>
-                </div>
+                <ItemList>
+                    <BooleanItem
+                        label={intl.formatMessage({defaultMessage: 'Enable LLM Trace'})}
+                        value={value.enableLLMTrace}
+                        onChange={(to) => props.onChange(props.id, {...value, enableLLMTrace: to})}
+                        helpText={intl.formatMessage({defaultMessage: 'Enable tracing of LLM requests. Outputs full conversation data to the logs.'})}
+                    />
+                </ItemList>
             </Panel>
         </ConfigContainer>
     );


### PR DESCRIPTION
## Description

Adds the Allowed Upstream Hostnames option to restrict what hosts the LLM is allowed to contact upstream. None by default.

![image](https://github.com/user-attachments/assets/97c579ba-991c-4077-abe6-969871cda949)

