### PR TITLE
Changed the `WebsocketListeners` in the webapp from a `Map` to an array.

### DIFF
--- a/webapp/src/components/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post.tsx
@@ -93,8 +93,8 @@ export interface PostUpdateWebsocketMessage {
 
 interface Props {
     post: any;
-    websocketRegister: (postID: string, handler: (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => void) => void;
-    websocketUnregister: (postID: string) => void;
+    websocketRegister: (postID: string, listenerID: string, handler: (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => void) => void;
+    websocketUnregister: (postID: string, listenerID: string) => void;
 }
 
 export const LLMBotPost = (props: Props) => {
@@ -114,7 +114,8 @@ export const LLMBotPost = (props: Props) => {
     const rootPost = useSelector<GlobalState, any>((state) => state.entities.posts.posts[props.post.root_id]);
 
     useEffect(() => {
-        props.websocketRegister(props.post.id, (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => {
+        const listenerID = Math.random().toString(36).substring(7);
+        props.websocketRegister(props.post.id, listenerID, (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => {
             const data = msg.data;
             if (!data.control && !stoppedRef.current) {
                 setGenerating(true);
@@ -128,7 +129,7 @@ export const LLMBotPost = (props: Props) => {
             }
         });
         return () => {
-            props.websocketUnregister(props.post.id);
+            props.websocketUnregister(props.post.id, listenerID);
         };
     }, []);
 

--- a/webapp/src/websocket.ts
+++ b/webapp/src/websocket.ts
@@ -3,21 +3,34 @@ import {WebSocketMessage} from '@mattermost/client';
 import {PostUpdateWebsocketMessage} from './components/llmbot_post';
 
 type WebsocketListener = (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => void
-type WebsocketListeners = Map<string, WebsocketListener>
+type WebsocketListenerObject = {
+    postID: string;
+    listenerID: string;
+    listener: WebsocketListener;
+}
+type WebsocketListeners = WebsocketListenerObject[]
 
 export default class PostEventListener {
-    postUpdateWebsocketListeners: WebsocketListeners = new Map<string, WebsocketListener>();
+    postUpdateWebsocketListeners: WebsocketListeners = [];
 
-    public registerPostUpdateListener = (postID: string, listener: WebsocketListener) => {
-        this.postUpdateWebsocketListeners.set(postID, listener);
+    public registerPostUpdateListener = (postID: string, listenerID: string, listener: WebsocketListener) => {
+        this.postUpdateWebsocketListeners.push({postID, listenerID, listener});
     };
 
-    public unregisterPostUpdateListener = (postID: string) => {
-        this.postUpdateWebsocketListeners.delete(postID);
+    public unregisterPostUpdateListener = (postID: string, listenerID: string) => {
+        this.postUpdateWebsocketListeners = this.postUpdateWebsocketListeners.filter((listenerObject) => {
+            const isSamePostID = listenerObject.postID === postID;
+            const isSameListenerID = listenerObject.listenerID === listenerID;
+            return !(isSamePostID && isSameListenerID);
+        });
     };
 
     public handlePostUpdateWebsockets = (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => {
         const postID = msg.data.post_id;
-        this.postUpdateWebsocketListeners.get(postID)?.(msg);
+        this.postUpdateWebsocketListeners.forEach((listenerObject) => {
+            if (listenerObject.postID === postID) {
+                listenerObject.listener(msg);
+            }
+        });
     };
 }


### PR DESCRIPTION
# Closes #157

## Description

Hello!

We’ve recently adopted Mattermost, and I received a report about an issue similar to the one below, so I decided to address it:
https://github.com/mattermost/mattermost-plugin-ai/issues/157

The WebsocketListeners was defined as a Map, which seemed to prevent both the main screen and the RHS (right-hand side: thread view) from using WebsocketListeners simultaneously. I updated it by changing the Map to an array.

It appears to be working well, so I’ve submitted a pull request. If there are any issues, please feel free to leave a comment :)
