### PR TITLE
MM-63635 - modify the register function to be able to open outside ch…

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -75,8 +75,23 @@ export default class Plugin {
 
         let rhs: any = null;
         if (isRHSCompatable()) {
-            rhs = registry.registerRightHandSidebarComponent(RHS, RHSTitle);
-            setOpenRHSAction(rhs.showRHSPlugin);
+            if (!registry.registerAppBarComponent) {
+                return;
+            }
+
+            // Register with the app bar
+            const appBarComponent = registry.registerAppBarComponent({
+                iconUrl: aiIcon,
+                tooltipText: 'Copilot',
+                supportedProductIds: null,
+                rhsComponent: RHS,
+                rhsTitle: RHSTitle,
+            });
+
+            if (typeof appBarComponent === 'object' && appBarComponent.rhsComponent) {
+                rhs = appBarComponent.rhsComponent;
+                setOpenRHSAction(rhs.showRHSPlugin);
+            }
         }
 
         let currentUserId = store.getState().entities.users.currentUserId;
@@ -137,7 +152,8 @@ export default class Plugin {
         }
 
         registry.registerAdminConsoleCustomSetting('Config', Config);
-        if (rhs) {
+
+        if (rhs && !registry.registerAppBarComponent) {
             registry.registerChannelHeaderButtonAction(<IconAIContainer src={aiIcon}/>, () => {
                 store.dispatch(rhs.toggleRHSPlugin);
             },


### PR DESCRIPTION
MM-63635 - modify the register function to be able to open outside channel context

## Description
In the webapp, during the app bar rendering process for the plugins there are validations to restrict which plugins must be only associated to channel context because those only make sense when run in a channel. Other plugins should be able to run even outside the context of a channel. By registering the plugin using the registerAppBarComponent the plugin component will contain the `rhsComponent` so the webapp will be able to open the RHS plugin in any context like in threads, drafts or scheduled messages.
