### PR TITLE
Add disableStreaming setting to support moderation of LLM responses

### DIFF
--- a/e2e/helpers/plugincontainer.ts
+++ b/e2e/helpers/plugincontainer.ts
@@ -18,6 +18,7 @@ const RunContainer = async (): Promise<MattermostContainer> => {
 		  "allowPrivateChannels": true,
 		  "disableFunctionCalls": false,
 		  "enableLLMTrace": true,
+		  "disableStreaming": false,
 		  "enableUserRestrictions": false,
 		  "defaultBotName": "mock",
 		  "bots": [

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -17,6 +17,7 @@ type Config struct {
 	DefaultBotName           string                           `json:"defaultBotName"`
 	TranscriptGenerator      string                           `json:"transcriptBackend"`
 	EnableLLMTrace           bool                             `json:"enableLLMTrace"`
+	DisableStreaming         bool                             `json:"disableStreaming"`
 	AllowedUpstreamHostnames string                           `json:"allowedUpstreamHostnames"`
 	EmbeddingSearchConfig    embeddings.EmbeddingSearchConfig `json:"embeddingSearchConfig"`
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -262,3 +262,8 @@ func (p *Plugin) getTranscribe() Transcriber {
 	}
 	return nil
 }
+
+// IsStreamingDisabled returns whether streaming of AI responses is disabled
+func (p *Plugin) IsStreamingDisabled() bool {
+	return p.getConfiguration().DisableStreaming
+}

--- a/server/post_processing.go
+++ b/server/post_processing.go
@@ -275,6 +275,10 @@ func (p *Plugin) streamResultToPost(ctx context.Context, stream *llm.TextStreamR
 		select {
 		case next := <-stream.Stream:
 			post.Message += next
+			// Don't post intermediate updates if streaming is disabled
+			if p.IsStreamingDisabled() {
+				continue
+			}
 			p.sendPostStreamingUpdateEvent(post, post.Message)
 		case err, ok := <-stream.Err:
 			// Stream has closed cleanly

--- a/webapp/src/components/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post.tsx
@@ -96,6 +96,8 @@ export interface PostUpdateWebsocketMessage {
     next: string
     post_id: string
     control?: string
+    message?: string
+    post?: string
 }
 
 interface Props {
@@ -124,7 +126,9 @@ export const LLMBotPost = (props: Props) => {
         const listenerID = Math.random().toString(36).substring(7);
         props.websocketRegister(props.post.id, listenerID, (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => {
             const data = msg.data;
-            if (!data.control && !stoppedRef.current) {
+            if (data.message) {
+                setMessage(data.message);
+            } else if (!data.control && !stoppedRef.current) {
                 setGenerating(true);
                 setMessage(data.next);
             } else if (data.control === 'end') {

--- a/webapp/src/components/system_console/config.tsx
+++ b/webapp/src/components/system_console/config.tsx
@@ -22,6 +22,7 @@ type Config = {
     defaultBotName: string,
     transcriptBackend: string,
     enableLLMTrace: boolean,
+    disableStreaming: boolean,
     enableCallSummary: boolean,
     allowedUpstreamHostnames: string,
     embeddingSearchConfig: EmbeddingSearchConfig
@@ -65,6 +66,7 @@ const defaultConfig = {
     llmBackend: '',
     transcriptBackend: '',
     enableLLMTrace: false,
+    disableStreaming: false,
     embeddingSearchConfig: {
         type: 'disabled',
         vectorStore: {
@@ -210,6 +212,12 @@ const Config = (props: Props) => {
                         value={value.enableLLMTrace}
                         onChange={(to) => props.onChange(props.id, {...value, enableLLMTrace: to})}
                         helpText={intl.formatMessage({defaultMessage: 'Enable tracing of LLM requests. Outputs full conversation data to the logs.'})}
+                    />
+                    <BooleanItem
+                        label={intl.formatMessage({defaultMessage: 'Disable LLM Output Streaming'})}
+                        value={value.disableStreaming}
+                        onChange={(to) => props.onChange(props.id, {...value, disableStreaming: to})}
+                        helpText={intl.formatMessage({defaultMessage: 'Disable streaming of LLM response output. Users will not see the response until it is fully formed.'})}
                     />
                 </ItemList>
             </Panel>

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -34,6 +34,7 @@ import SearchHints from './components/search_hints';
 type WebappStore = Store<GlobalState, Action<Record<string, unknown>>>
 
 const StreamingPostWebsocketEvent = 'custom_mattermost-ai_postupdate';
+export const PostEditedWebsocketEvent = 'post_edited';
 
 const IconAIContainer = styled.img`
 	border-radius: 50%;
@@ -101,6 +102,7 @@ export default class Plugin {
         });
 
         registry.registerWebSocketEventHandler(StreamingPostWebsocketEvent, this.postEventListener.handlePostUpdateWebsockets);
+        registry.registerWebSocketEventHandler(PostEditedWebsocketEvent, this.postEventListener.handlePostUpdateWebsockets);
         const LLMBotPostWithWebsockets = (props: any) => {
             return (
                 <LLMBotPost


### PR DESCRIPTION
## Overview
This change enables content moderation of AI responses by delaying their display until fully generated. External plugins can now inspect and potentially modify responses before users see them, which is critical for organizations with compliance requirements or content policies.

More discussion about this effort can be found here: https://github.com/mattermost/mattermost-plugin-ai/pull/316#discussion_r2054724301

### Implementation Note

This PR introduces a new listener for the `post_edited` websocket event. Without this,  the UI will not update the post with the final contents after the call to `p.pluginAPI.Post.UpdatePost()` in `post_processing.go`.

## Demo
Here is a video demo of this new functionality in action. Note that with streaming disabled, the message does not appear until it is fully generated.

[streaming-disabled-demo.webm](https://github.com/user-attachments/assets/719f41ce-8fe9-4c68-821b-1fc8a18b296f)