### PR TITLE
MM-62940 Require endpoints that don't have parameters in the body to have empty body

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -143,6 +144,15 @@ func (a *API) interPluginAuthorizationRequired(c *gin.Context) {
 		return
 	}
 	c.AbortWithStatus(http.StatusUnauthorized)
+}
+
+// enforceEmptyBody checks if the request body is empty returning an error if not
+func (a *API) enforceEmptyBody(c *gin.Context) error {
+	// Check the body is empty
+	if _, err := c.Request.Body.Read(make([]byte, 1)); err != io.EOF {
+		return fmt.Errorf("request body must be empty")
+	}
+	return nil
 }
 
 func (a *API) handleGetAIThreads(c *gin.Context) {

--- a/api/api_admin.go
+++ b/api/api_admin.go
@@ -15,6 +15,11 @@ import (
 
 // handleReindexPosts starts a background job to reindex all posts
 func (a *API) handleReindexPosts(c *gin.Context) {
+	if err := a.enforceEmptyBody(c); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
 	jobStatus, err := a.agents.HandleReindexPosts()
 	if err != nil {
 		switch err.Error() {
@@ -52,6 +57,11 @@ func (a *API) handleGetJobStatus(c *gin.Context) {
 
 // handleCancelJob cancels a running reindex job
 func (a *API) handleCancelJob(c *gin.Context) {
+	if err := a.enforceEmptyBody(c); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
 	jobStatus, err := a.agents.CancelJob()
 	if err != nil {
 		switch err.Error() {

--- a/api/api_inter_plugin.go
+++ b/api/api_inter_plugin.go
@@ -20,7 +20,7 @@ type SimpleCompletionRequest struct {
 
 func (a *API) handleInterPluginSimpleCompletion(c *gin.Context) {
 	var req SimpleCompletionRequest
-	if err := c.BindJSON(&req); err != nil {
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid request: %v", err)})
 		return
 	}

--- a/api/api_post.go
+++ b/api/api_post.go
@@ -52,6 +52,11 @@ func (a *API) handleReact(c *gin.Context) {
 	channel := c.MustGet(ContextChannelKey).(*model.Channel)
 	bot := c.MustGet(ContextBotKey).(*agents.Bot)
 
+	if err := a.enforceEmptyBody(c); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
 	requestingUser, err := a.pluginAPI.User.Get(userID)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
@@ -132,6 +137,11 @@ func (a *API) handleTranscribeFile(c *gin.Context) {
 	fileID := c.Param("fileid")
 	bot := c.MustGet(ContextBotKey).(*agents.Bot)
 
+	if err := a.enforceEmptyBody(c); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
 	result, err := a.agents.HandleTranscribeFile(userID, bot, post, channel, fileID)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
@@ -146,6 +156,11 @@ func (a *API) handleSummarizeTranscription(c *gin.Context) {
 	post := c.MustGet(ContextPostKey).(*model.Post)
 	channel := c.MustGet(ContextChannelKey).(*model.Channel)
 	bot := c.MustGet(ContextBotKey).(*agents.Bot)
+
+	if err := a.enforceEmptyBody(c); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
 
 	result, err := a.agents.HandleSummarizeTranscription(userID, bot, post, channel)
 	if err != nil {
@@ -163,6 +178,11 @@ func (a *API) handleSummarizeTranscription(c *gin.Context) {
 func (a *API) handleStop(c *gin.Context) {
 	userID := c.GetHeader("Mattermost-User-Id")
 	post := c.MustGet(ContextPostKey).(*model.Post)
+
+	if err := a.enforceEmptyBody(c); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
 
 	botID := post.UserId
 	if !a.agents.IsAnyBot(botID) {
@@ -183,6 +203,11 @@ func (a *API) handleRegenerate(c *gin.Context) {
 	userID := c.GetHeader("Mattermost-User-Id")
 	post := c.MustGet(ContextPostKey).(*model.Post)
 	channel := c.MustGet(ContextChannelKey).(*model.Channel)
+
+	if err := a.enforceEmptyBody(c); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
 
 	err := a.agents.HandleRegenerate(userID, post, channel)
 	if err != nil {
@@ -234,6 +259,11 @@ func (a *API) handleToolCall(c *gin.Context) {
 func (a *API) handlePostbackSummary(c *gin.Context) {
 	userID := c.GetHeader("Mattermost-User-Id")
 	post := c.MustGet(ContextPostKey).(*model.Post)
+
+	if err := a.enforceEmptyBody(c); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
 
 	result, err := a.agents.HandlePostbackSummary(userID, post)
 	if err != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -155,6 +156,110 @@ func TestAdminRouter(t *testing.T) {
 				require.Equal(t, test.expectedStatus, resp.StatusCode)
 			})
 		}
+	}
+}
+
+func TestEnforceEmptyBody(t *testing.T) {
+	// This just makes gin not output a whole bunch of debug stuff.
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	tests := []struct {
+		name          string
+		requestBody   string
+		expectedError bool
+	}{
+		{
+			name:          "empty body",
+			requestBody:   "",
+			expectedError: false,
+		},
+		{
+			name:          "non-empty body",
+			requestBody:   "some content",
+			expectedError: true,
+		},
+		{
+			name:          "whitespace only",
+			requestBody:   "   \n\t",
+			expectedError: true,
+		},
+		{
+			name:          "json object",
+			requestBody:   `{"key": "value"}`,
+			expectedError: true,
+		},
+		{
+			name:          "empty json object",
+			requestBody:   `{}`,
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e := SetupTestEnvironment(t)
+			defer e.Cleanup(t)
+
+			// Create a test context with the specified request body
+			w := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(w)
+
+			// Create request with the test body
+			bodyReader := strings.NewReader(test.requestBody)
+			req, err := http.NewRequest("POST", "/test", bodyReader)
+			require.NoError(t, err)
+
+			ctx.Request = req
+
+			// Test the enforceEmptyBody function
+			err = e.api.enforceEmptyBody(ctx)
+
+			if test.expectedError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "request body must be empty")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestEmptyBodyCheckerInApi tests the API endpoints that use enforceEmptyBody
+func TestEmptyBodyCheckerInApi(t *testing.T) {
+	// This just makes gin not output a whole bunch of debug stuff.
+	// maybe pipe this to the test log?
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	for urlName, url := range map[string]string{
+		"react":                   "/post/postid/react?botUsername=thebot",
+		"transcribe file":         "/post/postid/transcribe/file/fileid?botUsername=thebot",
+		"summarize transcription": "/post/postid/summarize_transcription?botUsername=thebot",
+		"regen":                   "/post/postid/regenerate",
+		"postback summary":        "/post/postid/postback_summary",
+		"reindex":                 "/admin/reindex",
+		"cancel":                  "/admin/reindex/cancel",
+	} {
+		t.Run(urlName, func(t *testing.T) {
+			e := SetupTestEnvironment(t)
+			defer e.Cleanup(t)
+
+			e.mockAPI.On("LogError", "request body must be empty")
+			e.mockAPI.On("GetPost", mock.Anything).Return(&model.Post{}, nil).Maybe()
+			e.mockAPI.On("GetChannel", mock.Anything).Return(&model.Channel{}, nil).Maybe()
+			e.mockAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PermissionReadChannel).Return(true).Maybe()
+			e.mockAPI.On("HasPermissionTo", mock.Anything, model.PermissionManageSystem).Return(true).Maybe()
+
+			e.agents.SetBots([]*agents.Bot{agents.NewBot(llm.BotConfig{Name: "thebot"}, nil)})
+
+			request := httptest.NewRequest(http.MethodPost, url, strings.NewReader("non-empty body"))
+			request.Header.Add("Mattermost-User-ID", "userid")
+			recorder := httptest.NewRecorder()
+			e.api.ServeHTTP(&plugin.Context{}, recorder, request)
+			resp := recorder.Result()
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

Enforces endpoints that don't take body parameters to error when a body is provided. 
