### PR TITLE
Fix inter-plugin client calls with tool-enabled bots

### DIFF
--- a/api/api_inter_plugin.go
+++ b/api/api_inter_plugin.go
@@ -52,12 +52,14 @@ func (a *API) handleInterPluginSimpleCompletion(c *gin.Context) {
 	}
 
 	// Create a proper context for the LLM
+	// Note: Tools are disabled for inter-plugin requests because ChatCompletionNoStream()
+	// uses ReadAll() which explicitly fails when tool calls are present
 	context := a.contextBuilder.BuildLLMContextUserRequest(
 		bot,
 		user,
 		nil, // No channel for inter-plugin requests
 		a.contextBuilder.WithLLMContextParameters(req.Parameters),
-		a.contextBuilder.WithLLMContextDefaultTools(bot, true),
+		a.contextBuilder.WithLLMContextNoTools(), // Disable tools for inter-plugin non-streaming calls
 	)
 
 	// Format system prompt using template

--- a/llmcontext/llm_context.go
+++ b/llmcontext/llm_context.go
@@ -164,6 +164,15 @@ func (b *Builder) WithLLMContextDefaultTools(bot *bots.Bot, isDM bool) llm.Conte
 	}
 }
 
+// WithLLMContextNoTools explicitly disables tools for this context session only,
+// overriding the bot's DisableTools configuration. This allows inter-plugin requests
+// to work with tool-enabled bots by bypassing tools for non-streaming calls.
+func (b *Builder) WithLLMContextNoTools() llm.ContextOption {
+	return func(c *llm.Context) {
+		c.Tools = llm.NewNoTools()
+	}
+}
+
 func (b *Builder) WithLLMContextParameters(params map[string]interface{}) llm.ContextOption {
 	return func(c *llm.Context) {
 		c.Parameters = params


### PR DESCRIPTION
Inter-plugin client calls were failing when agents had tools enabled because the inter-plugin API uses ChatCompletionNoStream which internally calls ReadAll, and ReadAll explicitly rejects tool call events with an error. This created an architecture mismatch where regular conversations use streaming to handle tools properly, but inter-plugin requests use non-streaming which cannot handle tools.

The fix adds a WithLLMContextNoTools context option that allows inter-plugin requests to disable tools for that specific session only, without affecting the bot's overall tool configuration. This preserves the bot's ability to use tools in regular interactive conversations while allowing inter-plugin clients to work with simple completion requests.

🤖 Generated with [Claude Code](https://claude.ai/code)