### PR TITLE
Switch to MaxCompletionTokens parameter for OpenAI

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -448,7 +448,7 @@ func (s *OpenAI) completionRequestFromConfig(cfg llm.LanguageModelConfig) openai
 	request := openaiClient.ChatCompletionRequest{
 		Model: cfg.Model,
 	}
-	request.MaxTokens = cfg.MaxGeneratedTokens
+	request.MaxCompletionTokens = cfg.MaxGeneratedTokens
 
 	if cfg.JSONOutputFormat != nil {
 		request.ResponseFormat = &openaiClient.ChatCompletionResponseFormat{


### PR DESCRIPTION
# Closes #371

## Description

According to OpenAI documentation `max_completion_tokens` is an alias of `max_tokens` hence it should work for previous models and upcoming ones.