### PR TITLE
Implement service/bot separation in backend

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -80,7 +80,7 @@ func (e *TestEnvironment) setupTestBot(botConfig llm.BotConfig) {
 	}
 
 	// Create the bot instance
-	bot := bots.NewBot(botConfig, mmBot)
+	bot := bots.NewBot(botConfig, llm.ServiceConfig{}, mmBot, nil)
 
 	// Set the bot directly for testing
 	e.bots.SetBotsForTesting([]*bots.Bot{bot})
@@ -311,7 +311,7 @@ func TestEmptyBodyCheckerInApi(t *testing.T) {
 			e.mockAPI.On("HasPermissionToChannel", mock.Anything, mock.Anything, model.PermissionReadChannel).Return(true).Maybe()
 			e.mockAPI.On("HasPermissionTo", mock.Anything, model.PermissionManageSystem).Return(true).Maybe()
 
-			e.bots.SetBotsForTesting([]*bots.Bot{bots.NewBot(llm.BotConfig{Name: "thebot"}, nil)})
+			e.bots.SetBotsForTesting([]*bots.Bot{bots.NewBot(llm.BotConfig{Name: "thebot"}, llm.ServiceConfig{}, nil, nil)})
 
 			request := httptest.NewRequest(http.MethodPost, url, strings.NewReader("non-empty body"))
 			request.Header.Add("Mattermost-User-ID", "userid")

--- a/bots/bot.go
+++ b/bots/bot.go
@@ -8,17 +8,22 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
+// Bot represents an AI bot instance with its configuration and dependencies.
+//
+// Source of truth for bot fields:
+//   - cfg: The bot's configuration (name, display name, permissions, etc.)
+//   - service: The RESOLVED service configuration (use GetService() to access).
+//     DO NOT use cfg.Service or cfg.ServiceID directly - those are internal references.
+//   - mmBot: The Mattermost bot user
+//   - llm: The initialized language model instance
+//
+// Bot instances should be created via EnsureBots() which properly resolves
+// service references and initializes all fields.
 type Bot struct {
-	cfg   llm.BotConfig
-	mmBot *model.Bot
-	llm   llm.LanguageModel
-}
-
-func NewBot(cfg llm.BotConfig, bot *model.Bot) *Bot {
-	return &Bot{
-		cfg:   cfg,
-		mmBot: bot,
-	}
+	cfg     llm.BotConfig
+	service llm.ServiceConfig
+	mmBot   *model.Bot
+	llm     llm.LanguageModel
 }
 
 func (b *Bot) GetConfig() llm.BotConfig {
@@ -33,6 +38,24 @@ func (b *Bot) LLM() llm.LanguageModel {
 	return b.llm
 }
 
+func (b *Bot) GetService() llm.ServiceConfig {
+	return b.service
+}
+
 func (b *Bot) SetLLMForTest(llm llm.LanguageModel) {
 	b.llm = llm
+}
+
+func (b *Bot) SetServiceForTest(service llm.ServiceConfig) {
+	b.service = service
+}
+
+// NewBot creates a new Bot instance with all fields initialized.
+func NewBot(cfg llm.BotConfig, service llm.ServiceConfig, mmBot *model.Bot, llmInstance llm.LanguageModel) *Bot {
+	return &Bot{
+		cfg:     cfg,
+		service: service,
+		mmBot:   mmBot,
+		llm:     llmInstance,
+	}
 }

--- a/bots/bots.go
+++ b/bots/bots.go
@@ -24,6 +24,8 @@ import (
 )
 
 type Config interface {
+	GetBots() []llm.BotConfig
+	GetServiceByID(id string) (llm.ServiceConfig, bool)
 	GetDefaultBotName() string
 	EnableLLMLogging() bool
 	EnableTokenUsageLogging() bool
@@ -58,7 +60,7 @@ func New(mutexPluginAPI cluster.MutexPluginAPI, pluginAPI *pluginapi.Client, lic
 	}
 }
 
-func (b *MMBots) EnsureBots(cfgBots []llm.BotConfig) error {
+func (b *MMBots) EnsureBots() error {
 	mtx, err := cluster.NewMutex(b.ensureBotsClusterMutex, "ai_ensure_bots")
 	if err != nil {
 		return fmt.Errorf("failed to create mutex: %w", err)
@@ -72,22 +74,47 @@ func (b *MMBots) EnsureBots(cfgBots []llm.BotConfig) error {
 	}
 
 	// Only allow one bot if not multi-LLM licensed
-	if len(cfgBots) > 1 && !b.licenseChecker.IsMultiLLMLicensed() {
+	botCfgs := b.config.GetBots()
+	if len(botCfgs) > 1 && !b.licenseChecker.IsMultiLLMLicensed() {
 		b.pluginAPI.Log.Error("Only one bot allowed with current license.")
-		cfgBots = cfgBots[:1]
+		botCfgs = botCfgs[:1]
 	}
 
-	aiBotConfigsByUsername := make(map[string]llm.BotConfig)
-	for _, bot := range cfgBots {
-		if !bot.IsValid() {
-			b.pluginAPI.Log.Error("Configured bot is not valid", "bot_name", bot.Name, "bot_display_name", bot.DisplayName)
+	var bots []*Bot
+	aiBotsByUsername := make(map[string]*Bot)
+	for _, botCfg := range botCfgs {
+		if !botCfg.IsValid() {
+			b.pluginAPI.Log.Error("Configured bot is not valid", "bot_name", botCfg.Name, "bot_display_name", botCfg.DisplayName)
 			continue
 		}
-		if _, ok := aiBotConfigsByUsername[bot.Name]; ok {
-			// Duplicate bot names have to be fatal because they would cause a bot to be modified inappropreately.
-			return fmt.Errorf("duplicate bot name: %s", bot.Name)
+
+		var service llm.ServiceConfig
+		if botCfg.Service != nil {
+			service = *botCfg.Service
+		} else {
+			// Validate service exists
+			var ok bool
+			service, ok = b.config.GetServiceByID(botCfg.ServiceID)
+			if !ok {
+				b.pluginAPI.Log.Error("Bot references non-existent service", "bot_name", botCfg.Name, "service_id", botCfg.ServiceID)
+				continue
+			}
+
+			// Validate service configuration
+			if !llm.IsValidService(service) {
+				b.pluginAPI.Log.Error("Bot references invalid service", "bot_name", botCfg.Name, "service_id", botCfg.ServiceID, "service_type", service.Type)
+				continue
+			}
 		}
-		aiBotConfigsByUsername[bot.Name] = bot
+
+		if _, ok := aiBotsByUsername[botCfg.Name]; ok {
+			// Duplicate bot names have to be fatal because they would cause a bot to be modified inappropreately.
+			return fmt.Errorf("duplicate bot name: %s", botCfg.Name)
+		}
+
+		bot := &Bot{cfg: botCfg, service: service}
+		bots = append(bots, bot)
+		aiBotsByUsername[botCfg.Name] = bot
 	}
 
 	prevousMMBotsByUsername := make(map[string]*model.Bot)
@@ -97,7 +124,7 @@ func (b *MMBots) EnsureBots(cfgBots []llm.BotConfig) error {
 
 	// For each of the bots we found, if it's not in the configuration, delete it.
 	for _, bot := range previousMMBots {
-		if _, ok := aiBotConfigsByUsername[bot.Username]; !ok {
+		if _, ok := aiBotsByUsername[bot.Username]; !ok {
 			if _, err := b.pluginAPI.Bot.UpdateActive(bot.UserId, false); err != nil {
 				b.pluginAPI.Log.Error("Failed to delete bot", "bot_name", bot.Username, "error", err.Error())
 				continue
@@ -107,68 +134,44 @@ func (b *MMBots) EnsureBots(cfgBots []llm.BotConfig) error {
 
 	// For each bot in the configuration, try to find an existing bot matching the username.
 	// If it exists, update it to match. Otherwise, create a new bot.
-	for _, bot := range cfgBots {
-		if !bot.IsValid() {
-			continue
-		}
-		description := "Powered by " + bot.Service.Type
-		if prevBot, ok := prevousMMBotsByUsername[bot.Name]; ok {
-			if _, err := b.pluginAPI.Bot.Patch(prevBot.UserId, &model.BotPatch{
-				DisplayName: &bot.DisplayName,
+	for _, bot := range bots {
+		description := "Powered by " + bot.service.Type
+		if prevBot, ok := prevousMMBotsByUsername[bot.cfg.Name]; ok {
+			var err error
+			bot.mmBot, err = b.pluginAPI.Bot.Patch(prevBot.UserId, &model.BotPatch{
+				DisplayName: &bot.cfg.DisplayName,
 				Description: &description,
-			}); err != nil {
-				b.pluginAPI.Log.Error("Failed to patch bot", "bot_name", bot.Name, "error", err.Error())
+			})
+			if err != nil {
+				b.pluginAPI.Log.Error("Failed to patch bot", "bot_name", bot.cfg.Name, "error", err.Error())
 				continue
 			}
 			if _, err := b.pluginAPI.Bot.UpdateActive(prevBot.UserId, true); err != nil {
-				b.pluginAPI.Log.Error("Failed to update bot active", "bot_name", bot.Name, "error", err.Error())
+				b.pluginAPI.Log.Error("Failed to update bot active", "bot_name", bot.cfg.Name, "error", err.Error())
 				continue
 			}
 		} else {
-			err := b.pluginAPI.Bot.Create(&model.Bot{
-				Username:    bot.Name,
-				DisplayName: bot.DisplayName,
+			bot.mmBot = &model.Bot{
+				Username:    bot.cfg.Name,
+				DisplayName: bot.cfg.DisplayName,
 				Description: description,
-			})
+			}
+			err := b.pluginAPI.Bot.Create(bot.mmBot)
 			if err != nil {
-				b.pluginAPI.Log.Error("Failed to ensure bot", "bot_name", bot.Name, "error", err.Error())
+				b.pluginAPI.Log.Error("Failed to ensure bot", "bot_name", bot.cfg.Name, "error", err.Error())
 				continue
 			}
 		}
-	}
-
-	if err := b.UpdateBotsCache(cfgBots); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (b *MMBots) UpdateBotsCache(cfgBots []llm.BotConfig) error {
-	bots, err := b.pluginAPI.Bot.List(0, 1000, pluginapi.BotOwner("mattermost-ai"))
-	if err != nil {
-		return fmt.Errorf("failed to list bots: %w", err)
-	}
-
-	b.botsLock.Lock()
-	defer b.botsLock.Unlock()
-	b.bots = make([]*Bot, 0, len(cfgBots))
-	for _, botCfg := range cfgBots {
-		for _, bot := range bots {
-			if bot.Username == botCfg.Name {
-				createdBot := NewBot(botCfg, bot)
-				b.bots = append(b.bots, createdBot)
-			}
-		}
-	}
-
-	for _, bot := range b.bots {
 		var err error
-		bot.llm, err = b.getLLM(*bot.cfg.Service, bot.cfg.Name)
+		bot.llm, err = b.getLLM(bot.service, bot.cfg.Name)
 		if err != nil {
 			return err
 		}
 	}
+
+	b.botsLock.Lock()
+	b.bots = bots
+	b.botsLock.Unlock()
 
 	return nil
 }
@@ -192,6 +195,9 @@ func (b *MMBots) getLLM(serviceConfig llm.ServiceConfig, botName string) (llm.La
 		cohereCfg := serviceConfig
 		cohereCfg.APIURL = "https://api.cohere.ai/compatibility/v1"
 		result = openai.NewCompatible(config.OpenAIConfigFromServiceConfig(cohereCfg), b.llmUpstreamHTTPClient)
+	default:
+		b.pluginAPI.Log.Error("Unsupported service type for bot", "bot_name", botName, "service_type", serviceConfig.Type)
+		return nil, fmt.Errorf("unsupported service type: %s", serviceConfig.Type)
 	}
 
 	// Truncation Support
@@ -219,7 +225,7 @@ func (b *MMBots) GetTranscribe() Transcriber {
 		return nil
 	}
 
-	service := *bot.GetConfig().Service
+	service := bot.service
 	switch service.Type {
 	case llm.ServiceTypeOpenAI:
 		return openai.New(config.OpenAIConfigFromServiceConfig(service), b.llmUpstreamHTTPClient)

--- a/bots/permissions_test.go
+++ b/bots/permissions_test.go
@@ -52,199 +52,199 @@ func TestUsageRestrictions(t *testing.T) {
 	}{
 		{
 			name: "All allowed",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelAll,
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  nil,
 		},
 		{
 			name: "Channel blocked",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelBlock,
 				ChannelIDs:         []string{"channel1"},
 				UserAccessLevel:    llm.UserAccessLevelAll,
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  ErrUsageRestriction,
 		},
 		{
 			name: "User blocked",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelBlock,
 				UserIDs:            []string{"user1"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  ErrUsageRestriction,
 		},
 		{
 			name: "Channel allowed",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAllow,
 				ChannelIDs:         []string{"channel1"},
 				UserAccessLevel:    llm.UserAccessLevelAll,
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  nil,
 		},
 		{
 			name: "User allowed",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelAllow,
 				UserIDs:            []string{"user1"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  nil,
 		},
 		{
 			name: "Channel not allowed",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAllow,
 				ChannelIDs:         []string{"channel2"},
 				UserAccessLevel:    llm.UserAccessLevelAll,
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  ErrUsageRestriction,
 		},
 		{
 			name: "User not allowed",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelAllow,
 				UserIDs:            []string{"user2"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  ErrUsageRestriction,
 		},
 		{
 			name: "Channel none",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelNone,
 				UserAccessLevel:    llm.UserAccessLevelAll,
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  ErrUsageRestriction,
 		},
 		{
 			name: "User none",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelNone,
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  ErrUsageRestriction,
 		},
 		{
 			name: "Channel block but not in list",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelBlock,
 				ChannelIDs:         []string{"channel2"},
 				UserAccessLevel:    llm.UserAccessLevelAll,
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  nil,
 		},
 		{
 			name: "User block but not in list",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelBlock,
 				UserIDs:            []string{"user2"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  nil,
 		},
 		{
 			name: "Channel allow and user allow",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAllow,
 				ChannelIDs:         []string{"channel1"},
 				UserAccessLevel:    llm.UserAccessLevelAllow,
 				UserIDs:            []string{"user1"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  nil,
 		},
 		{
 			name: "Channel allow but user not allowed",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAllow,
 				ChannelIDs:         []string{"channel1"},
 				UserAccessLevel:    llm.UserAccessLevelAllow,
 				UserIDs:            []string{"user2"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  ErrUsageRestriction,
 		},
 		{
 			name: "User allowed via team membership",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelAllow,
 				TeamIDs:            []string{"team1"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  nil,
 		},
 		{
 			name: "User blocked via team membership",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelBlock,
 				TeamIDs:            []string{"team1"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  ErrUsageRestriction,
 		},
 		{
 			name: "User not in allowed team",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelAllow,
 				TeamIDs:            []string{"team2"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  ErrUsageRestriction,
 		},
 		{
 			name: "User allowed via direct ID even if not in team",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelAllow,
 				UserIDs:            []string{"user1"},
 				TeamIDs:            []string{"team2"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  nil,
 		},
 		{
 			name: "User blocked via direct ID even if in allowed team",
-			bot: NewBot(llm.BotConfig{
+			bot: &Bot{cfg: llm.BotConfig{
 				ChannelAccessLevel: llm.ChannelAccessLevelAll,
 				UserAccessLevel:    llm.UserAccessLevelBlock,
 				UserIDs:            []string{"user1"},
 				TeamIDs:            []string{"team1"},
-			}, nil),
+			}, mmBot: nil},
 			channel:        &model.Channel{Id: "channel1"},
 			requestingUser: "user1",
 			expectedError:  ErrUsageRestriction,

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,16 @@ func (c *Config) Clone() *Config {
 	return &clone
 }
 
+// GetServiceByID returns the service configuration for the given ID
+func (c *Config) GetServiceByID(id string) (llm.ServiceConfig, bool) {
+	for i := range c.Services {
+		if c.Services[i].ID == id {
+			return c.Services[i], true
+		}
+	}
+	return llm.ServiceConfig{}, false
+}
+
 type UpdateListener func()
 
 type Container struct {
@@ -83,6 +93,15 @@ func (c *Container) RegisterUpdateListener(listener UpdateListener) {
 
 func (c *Container) EmbeddingSearchConfig() embeddings.EmbeddingSearchConfig {
 	return c.cfg.Load().EmbeddingSearchConfig
+}
+
+// GetServiceByID returns the service configuration for the given ID
+func (c *Container) GetServiceByID(id string) (llm.ServiceConfig, bool) {
+	cfg := c.cfg.Load()
+	if cfg == nil {
+		return llm.ServiceConfig{}, false
+	}
+	return cfg.GetServiceByID(id)
 }
 
 // Updates the current configuration

--- a/conversations/direct_message_eval_test.go
+++ b/conversations/direct_message_eval_test.go
@@ -132,24 +132,26 @@ func TestDirectMessageConversations(t *testing.T) {
 			)
 
 			// Create a mock bot for DM
-			bot := bots.NewBot(
-				llm.BotConfig{
-					ID:                 "testbotid",
-					Name:               "matty",
-					DisplayName:        "Matty",
-					CustomInstructions: "",
-					EnableVision:       false,
-					DisableTools:       false,
-					Service: &llm.ServiceConfig{
-						DefaultModel: "mattermodel-5.4",
-					},
-				},
-				&model.Bot{
-					UserId: "testbotid",
-				},
-			)
+			botConfig := llm.BotConfig{
+				ID:                 "testbotid",
+				Name:               "matty",
+				DisplayName:        "Matty",
+				CustomInstructions: "",
+				EnableVision:       false,
+				DisableTools:       false,
+				ServiceID:          "test-service",
+			}
+			serviceConfig := llm.ServiceConfig{
+				ID:           "test-service",
+				Type:         llm.ServiceTypeOpenAI,
+				DefaultModel: "mattermodel-5.4",
+			}
+			mmBot := &model.Bot{
+				UserId: "testbotid",
+			}
+			llmInstance := llm.NewLanguageModelTestLogWrapper(t.T, t.LLM)
 
-			bot.SetLLMForTest(llm.NewLanguageModelTestLogWrapper(t.T, t.LLM))
+			bot := bots.NewBot(botConfig, serviceConfig, mmBot, llmInstance)
 
 			// Process the DM request
 			textStream, err := conv.ProcessUserRequest(bot, threadData.RequestingUser(), threadData.Channel, threadData.LatestPost())

--- a/llm/configuration_test.go
+++ b/llm/configuration_test.go
@@ -15,6 +15,7 @@ func TestBotConfig_IsValid(t *testing.T) {
 		Name               string
 		DisplayName        string
 		CustomInstructions string
+		ServiceID          string
 		Service            *ServiceConfig
 		EnableVision       bool
 		DisableTools       bool
@@ -37,15 +38,7 @@ func TestBotConfig_IsValid(t *testing.T) {
 				Name:               "xxx",
 				DisplayName:        "xxx",
 				CustomInstructions: "",
-				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "openai",
-					APIKey:                  "sk-xyz",
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
-				},
+				ServiceID:          "service-id",
 				ChannelAccessLevel: ChannelAccessLevelAll,
 				UserAccessLevel:    UserAccessLevelAll,
 			},
@@ -58,15 +51,7 @@ func TestBotConfig_IsValid(t *testing.T) {
 				Name:               "xxx",
 				DisplayName:        "xxx",
 				CustomInstructions: "",
-				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "openai",
-					APIKey:                  "sk-xyz",
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
-				},
+				ServiceID:          "service-id",
 				ChannelAccessLevel: ChannelAccessLevelNone,
 				UserAccessLevel:    UserAccessLevelAll,
 			},
@@ -79,15 +64,7 @@ func TestBotConfig_IsValid(t *testing.T) {
 				Name:               "", // bad
 				DisplayName:        "xxx",
 				CustomInstructions: "",
-				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "openai",
-					APIKey:                  "sk-xyz",
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
-				},
+				ServiceID:          "service-id",
 				ChannelAccessLevel: ChannelAccessLevelAll,
 				UserAccessLevel:    UserAccessLevelAll,
 			},
@@ -100,36 +77,20 @@ func TestBotConfig_IsValid(t *testing.T) {
 				Name:               "xxx",
 				DisplayName:        "", // bad
 				CustomInstructions: "",
-				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "openai",
-					APIKey:                  "sk-xyz",
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
-				},
+				ServiceID:          "service-id",
 				ChannelAccessLevel: ChannelAccessLevelAll,
 				UserAccessLevel:    UserAccessLevelAll,
 			},
 			want: false,
 		},
 		{
-			name: "Service type must be one of the supported providers",
+			name: "ServiceID cannot be empty",
 			fields: fields{
 				ID:                 "xxx",
 				Name:               "xxx",
 				DisplayName:        "xxx",
 				CustomInstructions: "",
-				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "mattermostllm", // bad
-					APIKey:                  "sk-xyz",
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
-				},
+				ServiceID:          "", // bad - empty service ID
 				ChannelAccessLevel: ChannelAccessLevelAll,
 				UserAccessLevel:    UserAccessLevelAll,
 			},
@@ -142,15 +103,7 @@ func TestBotConfig_IsValid(t *testing.T) {
 				Name:               "xxx",
 				DisplayName:        "xxx",
 				CustomInstructions: "",
-				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "openai",
-					APIKey:                  "sk-xyz",
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
-				},
+				ServiceID:          "service-id",
 				ChannelAccessLevel: ChannelAccessLevelAll - 1, // bad
 				UserAccessLevel:    UserAccessLevelNone,
 			},
@@ -163,15 +116,7 @@ func TestBotConfig_IsValid(t *testing.T) {
 				Name:               "xxx",
 				DisplayName:        "xxx",
 				CustomInstructions: "",
-				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "openai",
-					APIKey:                  "sk-xyz",
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
-				},
+				ServiceID:          "service-id",
 				ChannelAccessLevel: ChannelAccessLevelNone + 1, // bad
 				UserAccessLevel:    UserAccessLevelNone,
 			},
@@ -184,15 +129,7 @@ func TestBotConfig_IsValid(t *testing.T) {
 				Name:               "xxx",
 				DisplayName:        "xxx",
 				CustomInstructions: "",
-				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "openai",
-					APIKey:                  "sk-xyz",
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
-				},
+				ServiceID:          "service-id",
 				ChannelAccessLevel: ChannelAccessLevelAll,
 				UserAccessLevel:    UserAccessLevelAll - 1, // bad
 			},
@@ -205,63 +142,84 @@ func TestBotConfig_IsValid(t *testing.T) {
 				Name:               "xxx",
 				DisplayName:        "xxx",
 				CustomInstructions: "",
-				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "openai",
-					APIKey:                  "sk-xyz",
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
-				},
+				ServiceID:          "service-id",
 				ChannelAccessLevel: ChannelAccessLevelAll,
 				UserAccessLevel:    UserAccessLevelNone + 1, // bad
 			},
 			want: false,
 		},
 		{
-			name: "OpenAI compatible service requires API URL to be set",
+			name: "Bot with valid ServiceID should pass",
 			fields: fields{
 				ID:                 "xxx",
 				Name:               "xxx",
 				DisplayName:        "xxx",
 				CustomInstructions: "",
-				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "openaicompatible",
-					APIKey:                  "sk-xyz",
-					APIURL:                  "", // bad
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
-				},
+				ServiceID:          "service-id",
 				ChannelAccessLevel: ChannelAccessLevelAll,
 				UserAccessLevel:    UserAccessLevelAll,
 			},
-			want: false,
+			want: true,
 		},
 		{
-			name: "OpenAI compatible service do not requires API Key to be set",
+			name: "Bot with valid ServiceID should pass (second case)",
 			fields: fields{
 				ID:                 "xxx",
 				Name:               "xxx",
 				DisplayName:        "xxx",
 				CustomInstructions: "",
+				ServiceID:          "service-id",
+				ChannelAccessLevel: ChannelAccessLevelAll,
+				UserAccessLevel:    UserAccessLevelAll,
+			},
+			want: true,
+		},
+		{
+			name: "DEPRECATED: Bot with embedded service (no ServiceID) should be valid",
+			fields: fields{
+				ID:          "xxx",
+				Name:        "xxx",
+				DisplayName: "xxx",
+				ServiceID:   "", // empty service ID
 				Service: &ServiceConfig{
-					Name:                    "Agents",
-					Type:                    "openaicompatible",
-					APIKey:                  "", // not bad
-					APIURL:                  "http://localhost",
-					OrgID:                   "org-xyz",
-					DefaultModel:            "gpt-40",
-					InputTokenLimit:         100,
-					StreamingTimeoutSeconds: 60,
+					ID:     "embedded-service",
+					Type:   ServiceTypeOpenAI,
+					APIKey: "sk-test",
 				},
 				ChannelAccessLevel: ChannelAccessLevelAll,
 				UserAccessLevel:    UserAccessLevelAll,
 			},
 			want: true,
+		},
+		{
+			name: "DEPRECATED: Bot with both ServiceID and embedded Service should be valid",
+			fields: fields{
+				ID:          "xxx",
+				Name:        "xxx",
+				DisplayName: "xxx",
+				ServiceID:   "service-id", // has both
+				Service: &ServiceConfig{
+					ID:     "embedded-service",
+					Type:   ServiceTypeOpenAI,
+					APIKey: "sk-test",
+				},
+				ChannelAccessLevel: ChannelAccessLevelAll,
+				UserAccessLevel:    UserAccessLevelAll,
+			},
+			want: true,
+		},
+		{
+			name: "Bot with neither ServiceID nor embedded Service should fail",
+			fields: fields{
+				ID:                 "xxx",
+				Name:               "xxx",
+				DisplayName:        "xxx",
+				ServiceID:          "",  // no service ID
+				Service:            nil, // no embedded service
+				ChannelAccessLevel: ChannelAccessLevelAll,
+				UserAccessLevel:    UserAccessLevelAll,
+			},
+			want: false,
 		},
 	}
 	for _, tt := range tests {
@@ -271,6 +229,7 @@ func TestBotConfig_IsValid(t *testing.T) {
 				Name:               tt.fields.Name,
 				DisplayName:        tt.fields.DisplayName,
 				CustomInstructions: tt.fields.CustomInstructions,
+				ServiceID:          tt.fields.ServiceID,
 				Service:            tt.fields.Service,
 				EnableVision:       tt.fields.EnableVision,
 				DisableTools:       tt.fields.DisableTools,
@@ -282,6 +241,201 @@ func TestBotConfig_IsValid(t *testing.T) {
 				MaxFileSize:        tt.fields.MaxFileSize,
 			}
 			assert.Equalf(t, tt.want, c.IsValid(), "IsValid() for test case %q", tt.name)
+		})
+	}
+}
+
+func TestIsValidService(t *testing.T) {
+	tests := []struct {
+		name    string
+		service ServiceConfig
+		want    bool
+	}{
+		{
+			name: "Valid OpenAI service with all required fields",
+			service: ServiceConfig{
+				ID:     "service-1",
+				Type:   ServiceTypeOpenAI,
+				APIKey: "sk-xyz",
+			},
+			want: true,
+		},
+		{
+			name: "Valid OpenAI service with optional fields",
+			service: ServiceConfig{
+				ID:                      "service-1",
+				Name:                    "My OpenAI Service",
+				Type:                    ServiceTypeOpenAI,
+				APIKey:                  "sk-xyz",
+				OrgID:                   "org-xyz",
+				DefaultModel:            "gpt-4",
+				InputTokenLimit:         100,
+				StreamingTimeoutSeconds: 60,
+			},
+			want: true,
+		},
+		{
+			name: "OpenAI service missing API key",
+			service: ServiceConfig{
+				ID:     "service-1",
+				Type:   ServiceTypeOpenAI,
+				APIKey: "", // bad
+			},
+			want: false,
+		},
+		{
+			name: "Valid OpenAI Compatible service with API URL",
+			service: ServiceConfig{
+				ID:     "service-2",
+				Type:   ServiceTypeOpenAICompatible,
+				APIURL: "http://localhost:8080",
+			},
+			want: true,
+		},
+		{
+			name: "OpenAI Compatible service missing API URL",
+			service: ServiceConfig{
+				ID:     "service-2",
+				Type:   ServiceTypeOpenAICompatible,
+				APIURL: "", // bad
+			},
+			want: false,
+		},
+		{
+			name: "OpenAI Compatible service does not require API key",
+			service: ServiceConfig{
+				ID:     "service-2",
+				Type:   ServiceTypeOpenAICompatible,
+				APIKey: "", // not required
+				APIURL: "http://localhost:8080",
+			},
+			want: true,
+		},
+		{
+			name: "Valid Azure service with API key and URL",
+			service: ServiceConfig{
+				ID:     "service-3",
+				Type:   ServiceTypeAzure,
+				APIKey: "azure-key",
+				APIURL: "https://myservice.openai.azure.com",
+			},
+			want: true,
+		},
+		{
+			name: "Azure service missing API key",
+			service: ServiceConfig{
+				ID:     "service-3",
+				Type:   ServiceTypeAzure,
+				APIKey: "", // bad
+				APIURL: "https://myservice.openai.azure.com",
+			},
+			want: false,
+		},
+		{
+			name: "Azure service missing API URL",
+			service: ServiceConfig{
+				ID:     "service-3",
+				Type:   ServiceTypeAzure,
+				APIKey: "azure-key",
+				APIURL: "", // bad
+			},
+			want: false,
+		},
+		{
+			name: "Valid Anthropic service with API key",
+			service: ServiceConfig{
+				ID:     "service-4",
+				Type:   ServiceTypeAnthropic,
+				APIKey: "sk-ant-xyz",
+			},
+			want: true,
+		},
+		{
+			name: "Anthropic service missing API key",
+			service: ServiceConfig{
+				ID:     "service-4",
+				Type:   ServiceTypeAnthropic,
+				APIKey: "", // bad
+			},
+			want: false,
+		},
+		{
+			name: "Valid ASage service with API key",
+			service: ServiceConfig{
+				ID:     "service-5",
+				Type:   ServiceTypeASage,
+				APIKey: "asage-key",
+			},
+			want: true,
+		},
+		{
+			name: "ASage service missing API key",
+			service: ServiceConfig{
+				ID:     "service-5",
+				Type:   ServiceTypeASage,
+				APIKey: "", // bad
+			},
+			want: false,
+		},
+		{
+			name: "Valid Cohere service with API key",
+			service: ServiceConfig{
+				ID:     "service-6",
+				Type:   ServiceTypeCohere,
+				APIKey: "cohere-key",
+			},
+			want: true,
+		},
+		{
+			name: "Cohere service missing API key",
+			service: ServiceConfig{
+				ID:     "service-6",
+				Type:   ServiceTypeCohere,
+				APIKey: "", // bad
+			},
+			want: false,
+		},
+		{
+			name: "Service with empty ID",
+			service: ServiceConfig{
+				ID:     "", // bad
+				Type:   ServiceTypeOpenAI,
+				APIKey: "sk-xyz",
+			},
+			want: false,
+		},
+		{
+			name: "Service with empty Type",
+			service: ServiceConfig{
+				ID:     "service-7",
+				Type:   "", // bad
+				APIKey: "sk-xyz",
+			},
+			want: false,
+		},
+		{
+			name: "Service with unsupported Type",
+			service: ServiceConfig{
+				ID:     "service-8",
+				Type:   "mattermostllm", // bad - unsupported
+				APIKey: "sk-xyz",
+			},
+			want: false,
+		},
+		{
+			name: "Service with invalid Type",
+			service: ServiceConfig{
+				ID:     "service-9",
+				Type:   "unknown", // bad - unsupported
+				APIKey: "sk-xyz",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsValidService(tt.service)
+			assert.Equalf(t, tt.want, result, "IsValidService() for test case %q", tt.name)
 		})
 	}
 }

--- a/llmcontext/llm_context.go
+++ b/llmcontext/llm_context.go
@@ -26,6 +26,7 @@ type MCPToolProvider interface {
 // ConfigProvider provides configuration access
 type ConfigProvider interface {
 	GetEnableLLMTrace() bool
+	GetServiceByID(id string) (llm.ServiceConfig, bool)
 }
 
 // Builder builds contexts for LLM requests
@@ -183,7 +184,7 @@ func (b *Builder) WithLLMContextBot(bot *bots.Bot) llm.ContextOption {
 	return func(c *llm.Context) {
 		c.BotName = bot.GetConfig().DisplayName
 		c.BotUsername = bot.GetConfig().Name
-		c.BotModel = bot.GetConfig().Service.DefaultModel
 		c.CustomInstructions = bot.GetConfig().CustomInstructions
+		c.BotModel = bot.GetService().DefaultModel
 	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -86,13 +86,13 @@ func (p *Plugin) OnActivate() error {
 
 	bots := bots.New(p.API, pluginAPI, licenseChecker, &p.configuration, llmUpstreamHTTPClient, tokenLogger)
 	p.configuration.RegisterUpdateListener(func() {
-		if ensureErr := bots.EnsureBots(p.configuration.GetBots()); ensureErr != nil {
+		if ensureErr := bots.EnsureBots(); ensureErr != nil {
 			pluginAPI.Log.Error("failed to ensure bots on configuration update", "error", ensureErr)
 			return
 		}
 	})
 
-	if ensureBotsErr := bots.EnsureBots(potentiallyUpdatedConfig.Bots); ensureBotsErr != nil {
+	if ensureBotsErr := bots.EnsureBots(); ensureBotsErr != nil {
 		// If we fail to ensure bots, we log the error but do not return
 		// as it would leave the plugin in a state where it can't be configured from the system console.
 		pluginAPI.Log.Error("failed to ensure bots", "error", ensureBotsErr)


### PR DESCRIPTION
This commit implements the backend logic to support service/bot separation, where bots reference shared services by ID rather than embedding service configurations directly. This enables multiple bots to share the same service definition and establishes the foundation for improved service management.

Changes include:
- Update Bot struct to hold resolved ServiceConfig alongside BotConfig, separating the bot definition from its service reference
- Modify EnsureBots() to resolve service references by looking up ServiceID in the configuration's service list during bot initialization
- Add Config interface methods GetBots() and GetServiceByID() to enable service lookup and resolution
- Implement service validation logic in standalone IsValidService() function to validate referenced services exist and are properly configured
- Update BotConfig.IsValid() to accept either ServiceID (new) or embedded Service (deprecated) but not require service-specific validation
- Consolidate bot initialization into single-pass logic, eliminating the separate UpdateBotsCache() method
- Add comprehensive test coverage for service references, embedded services (deprecated), and mixed configurations during migration period

This change maintains backward compatibility with embedded service configs while enabling the new architecture. Future commits will add UI changes to leverage this separation for improved service management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)