### PR TITLE
[MM-66115] Add support for Mattermost running on a subpath

### DIFF
--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -10,8 +10,12 @@ import manifest from './manifest';
 
 const Client4 = new Client4Class();
 
+export function setSiteURL(siteURL: string) {
+    Client4.setUrl(siteURL);
+}
+
 function baseRoute(): string {
-    return `/plugins/${manifest.id}`;
+    return `${Client4.url}/plugins/${manifest.id}`;
 }
 
 function postRoute(postid: string): string {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -19,7 +19,8 @@ import IconThreadSummarization from './components/assets/icon_thread_summarizati
 import IconReactForMe from './components/assets/icon_react_for_me';
 import RHS from './components/rhs/rhs';
 import Config from './components/system_console/config';
-import {doReaction, doRunSearch, doThreadAnalysis, getAIDirectChannel} from './client';
+import {setSiteURL, doReaction, doRunSearch, doThreadAnalysis, getAIDirectChannel} from './client';
+
 import {setOpenRHSAction} from './redux_actions';
 import PostEventListener from './websocket';
 import {BotsHandler, setupRedux} from './redux';
@@ -64,6 +65,14 @@ export default class Plugin {
     public async initialize(registry: any, store: WebappStore) {
         setupRedux(registry, store);
         this.store = store;
+
+        let siteURL = store.getState().entities.general.config.SiteURL;
+
+        // Site URL should always be set by this point if the workspace is to be properly functional, but fall back to the window.location.origin just in case
+        if (!siteURL) {
+            siteURL = window.location.origin;
+        }
+        setSiteURL(siteURL);
 
         registry.registerDesktopNotificationHook(this.blockFastBotNotifications.bind(this));
 


### PR DESCRIPTION
#### Summary
Agents plugin wasn't SiteURL aware so it wouldn't account for a subpath like https://somedomain.com/mattermost, which would break interactions with the plugin that would then try and hit https://somedomain.com/plugin/mattermost-ai instead of /mattermost/plugin/mattermost-ai

This PR consumes the SiteURL from redux config and leverages it for all requests in the basePath. It also includes a fallback to `window.location.origin` in the event SiteURL is not set.


#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-plugin-agents/issues/251
Jira ticket: https://mattermost.atlassian.net/browse/MM-66115

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Added support for running Agents plugin on Mattermost instances that leverage a subpath
```
