### PR TITLE
/completions accepts bot user ID instead of username

### DIFF
--- a/api/api_llm_bridge.go
+++ b/api/api_llm_bridge.go
@@ -107,11 +107,11 @@ func (a *API) convertRequestToLLMOptions(req bridgeclient.CompletionRequest) ([]
 	return options, nil
 }
 
-// getBotByAgent finds a bot by its username (agent name)
+// getBotByAgent finds a bot by its Bot ID
 func (a *API) getBotByAgent(agent string) (*bots.Bot, error) {
-	bot := a.bots.GetBotByUsername(agent)
+	bot := a.bots.GetBotByID(agent)
 	if bot == nil {
-		return nil, fmt.Errorf("agent not found: %s", agent)
+		return nil, fmt.Errorf("bot not found with ID: %s", agent)
 	}
 	return bot, nil
 }
@@ -304,7 +304,7 @@ func (a *API) handleAgentCompletionStreaming(c *gin.Context) {
 		return
 	}
 
-	// Find the bot by username
+	// Find the bot by ID
 	bot, err := a.getBotByAgent(agent)
 	if err != nil {
 		c.JSON(http.StatusNotFound, bridgeclient.ErrorResponse{
@@ -366,7 +366,7 @@ func (a *API) handleAgentCompletionNoStream(c *gin.Context) {
 		return
 	}
 
-	// Find the bot by username
+	// Find the bot by ID
 	bot, err := a.getBotByAgent(agent)
 	if err != nil {
 		c.JSON(http.StatusNotFound, bridgeclient.ErrorResponse{

--- a/api/api_llm_bridge_test.go
+++ b/api/api_llm_bridge_test.go
@@ -35,7 +35,7 @@ func TestBridgeClientAgentCompletion(t *testing.T) {
 	}{
 		{
 			name:  "successful completion",
-			agent: "testbot",
+			agent: "bot-user-id",
 			request: bridgeclient.CompletionRequest{
 				Posts: []bridgeclient.Post{
 					{Role: "user", Message: "Hello"},
@@ -49,7 +49,7 @@ func TestBridgeClientAgentCompletion(t *testing.T) {
 		},
 		{
 			name:  "multiple posts with different roles",
-			agent: "testbot",
+			agent: "bot-user-id",
 			request: bridgeclient.CompletionRequest{
 				Posts: []bridgeclient.Post{
 					{Role: "system", Message: "You are helpful"},
@@ -64,7 +64,7 @@ func TestBridgeClientAgentCompletion(t *testing.T) {
 		},
 		{
 			name:  "LLM returns error",
-			agent: "testbot",
+			agent: "bot-user-id",
 			request: bridgeclient.CompletionRequest{
 				Posts: []bridgeclient.Post{
 					{Role: "user", Message: "Hello"},
@@ -76,7 +76,7 @@ func TestBridgeClientAgentCompletion(t *testing.T) {
 		},
 		{
 			name:  "empty posts array",
-			agent: "testbot",
+			agent: "bot-user-id",
 			request: bridgeclient.CompletionRequest{
 				Posts: []bridgeclient.Post{},
 			},
@@ -85,8 +85,8 @@ func TestBridgeClientAgentCompletion(t *testing.T) {
 			errorMsg:    "posts array cannot be empty",
 		},
 		{
-			name:  "agent not found",
-			agent: "nonexistent",
+			name:  "bot not found",
+			agent: "nonexistent-bot-id",
 			request: bridgeclient.CompletionRequest{
 				Posts: []bridgeclient.Post{
 					{Role: "user", Message: "Hello"},
@@ -94,11 +94,11 @@ func TestBridgeClientAgentCompletion(t *testing.T) {
 			},
 			fakeLLM:     NewFakeLLM("test"),
 			expectError: true,
-			errorMsg:    "agent not found",
+			errorMsg:    "bot not found",
 		},
 		{
 			name:  "bot role alias works",
-			agent: "testbot",
+			agent: "bot-user-id",
 			request: bridgeclient.CompletionRequest{
 				Posts: []bridgeclient.Post{
 					{Role: "bot", Message: "I'm a bot"},
@@ -113,7 +113,7 @@ func TestBridgeClientAgentCompletion(t *testing.T) {
 		},
 		{
 			name:  "invalid role",
-			agent: "testbot",
+			agent: "bot-user-id",
 			request: bridgeclient.CompletionRequest{
 				Posts: []bridgeclient.Post{
 					{Role: "invalid", Message: "test"},
@@ -184,7 +184,7 @@ func TestBridgeClientAgentCompletionStream(t *testing.T) {
 	}{
 		{
 			name:  "successful streaming",
-			agent: "testbot",
+			agent: "bot-user-id",
 			request: bridgeclient.CompletionRequest{
 				Posts: []bridgeclient.Post{
 					{Role: "user", Message: "Count to 3"},
@@ -219,7 +219,7 @@ func TestBridgeClientAgentCompletionStream(t *testing.T) {
 		},
 		{
 			name:  "streaming with error event",
-			agent: "testbot",
+			agent: "bot-user-id",
 			request: bridgeclient.CompletionRequest{
 				Posts: []bridgeclient.Post{
 					{Role: "user", Message: "Hello"},
@@ -241,8 +241,8 @@ func TestBridgeClientAgentCompletionStream(t *testing.T) {
 			},
 		},
 		{
-			name:  "agent not found",
-			agent: "nonexistent",
+			name:  "bot not found",
+			agent: "nonexistent-bot-id",
 			request: bridgeclient.CompletionRequest{
 				Posts: []bridgeclient.Post{
 					{Role: "user", Message: "Hello"},
@@ -250,7 +250,7 @@ func TestBridgeClientAgentCompletionStream(t *testing.T) {
 			},
 			fakeLLM:     NewFakeLLM("test"),
 			expectError: true,
-			errorMsg:    "agent not found",
+			errorMsg:    "bot not found",
 		},
 	}
 
@@ -645,7 +645,7 @@ func TestBridgeClientPermissions(t *testing.T) {
 
 			// Create bridge client and make request
 			client := e.CreateBridgeClient()
-			_, err := client.AgentCompletion("testbot", request)
+			_, err := client.AgentCompletion("bot-user-id", request)
 
 			if tc.expectError {
 				require.Error(t, err)

--- a/public/bridgeclient/README.md
+++ b/public/bridgeclient/README.md
@@ -20,7 +20,9 @@ func (p *MyPlugin) OnActivate() error {
 }
 
 func (p *MyPlugin) handleCommand() {
-    response, err := p.llmClient.AgentCompletion("gpt4", bridgeclient.CompletionRequest{
+    // Get the bot ID first (e.g., from discovery or configuration)
+    botID := "bot-user-id-here"
+    response, err := p.llmClient.AgentCompletion(botID, bridgeclient.CompletionRequest{
         Posts: []bridgeclient.Post{
             {Role: "user", Message: "What is the capital of France?"},
         },
@@ -61,8 +63,8 @@ func (s *MyService) process() {
 ### Non-Streaming
 
 ```go
-// Request by agent username
-response, err := client.AgentCompletion("gpt4", request)
+// Request by agent Bot ID
+response, err := client.AgentCompletion("bot-user-id", request)
 
 // Request by service name
 response, err := client.ServiceCompletion("openai", request)
@@ -73,8 +75,8 @@ response, err := client.ServiceCompletion("openai", request)
 ```go
 import "github.com/mattermost/mattermost-plugin-ai/llm"
 
-// Start streaming request
-result, err := client.AgentCompletionStream("gpt4", request)
+// Start streaming request (using Bot ID)
+result, err := client.AgentCompletionStream("bot-user-id", request)
 if err != nil {
     return err
 }
@@ -119,15 +121,16 @@ request := bridgeclient.CompletionRequest{
 }
 
 // Returns 403 Forbidden if user lacks permission
-response, err := client.AgentCompletion("gpt4", request)
+response, err := client.AgentCompletion("bot-user-id", request)
 ```
 
 If not using built-in permission checks, your plugin must verify permissions before making requests.
 
 ## Agent vs Service
 
-- **Agent**: Target a specific bot by username (e.g., "gpt4")
+- **Agent**: Target a specific bot by its Bot ID (the immutable Mattermost Bot User ID)
   - Uses bot's custom configuration, tools, and prompts
+  - Get bot IDs via the `GetAgents()` discovery endpoint
 
 - **Service**: Target an LLM service by ID or name (e.g., "openai", "anthropic")
   - Uses any bot configured with that service
@@ -147,8 +150,11 @@ if err != nil {
 }
 
 for _, agent := range agents {
-    fmt.Printf("Agent: %s (%s) - Service: %s (%s)\n",
-        agent.DisplayName, agent.Username, agent.ServiceID, agent.ServiceType)
+    fmt.Printf("Agent: %s (ID: %s, Username: %s) - Service: %s (%s)\n",
+        agent.DisplayName, agent.ID, agent.Username, agent.ServiceID, agent.ServiceType)
+    
+    // Use agent.ID when making completion requests
+    // response, err := client.AgentCompletion(agent.ID, request)
 }
 ```
 

--- a/public/bridgeclient/completion.go
+++ b/public/bridgeclient/completion.go
@@ -15,7 +15,8 @@ import (
 	"github.com/mattermost/mattermost-plugin-ai/llm"
 )
 
-// AgentCompletion makes a non-streaming completion request to a specific agent by username.
+// AgentCompletion makes a non-streaming completion request to a specific agent by Bot ID.
+// The agent parameter should be the Mattermost Bot User ID (an immutable identifier).
 func (c *Client) AgentCompletion(agent string, request CompletionRequest) (string, error) {
 	url := fmt.Sprintf("/%s/bridge/v1/completion/agent/%s/nostream", aiPluginID, agent)
 	return c.doCompletionRequest(url, request)
@@ -28,7 +29,8 @@ func (c *Client) ServiceCompletion(service string, request CompletionRequest) (s
 	return c.doCompletionRequest(url, request)
 }
 
-// AgentCompletionStream makes a streaming completion request to a specific agent by username.
+// AgentCompletionStream makes a streaming completion request to a specific agent by Bot ID.
+// The agent parameter should be the Mattermost Bot User ID (an immutable identifier).
 // Returns a TextStreamResult with a Stream channel for processing events.
 func (c *Client) AgentCompletionStream(agent string, request CompletionRequest) (*llm.TextStreamResult, error) {
 	url := fmt.Sprintf("/%s/bridge/v1/completion/agent/%s", aiPluginID, agent)


### PR DESCRIPTION
#### Summary
Completions endpoint accepts bot's user ID instead of username. Makes it easier for persistence of what bot did what, as user IDs are immutable, while usernames are not. Prevents the need for Mattermost side to do a lookup of username based on a stored ID.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```
