### PR TITLE
Fix reasoning persistence for OpenAI

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -583,8 +583,10 @@ func (s *OpenAI) streamResponsesAPIToChannels(params openai.ChatCompletionNewPar
 				// If we haven't sent the complete reasoning yet, send it now
 				if !reasoningComplete && reasoningSummaryBuffer.Len() > 0 {
 					output <- llm.TextStreamEvent{
-						Type:  llm.EventTypeReasoningEnd,
-						Value: reasoningSummaryBuffer.String(),
+						Type: llm.EventTypeReasoningEnd,
+						Value: llm.ReasoningData{
+							Text: reasoningSummaryBuffer.String(),
+						},
 					}
 					reasoningComplete = true
 				}
@@ -682,8 +684,10 @@ func (s *OpenAI) streamResponsesAPIToChannels(params openai.ChatCompletionNewPar
 				// If we haven't sent the complete reasoning yet and this is a tool call, send reasoning first
 				if !reasoningComplete && reasoningSummaryBuffer.Len() > 0 {
 					output <- llm.TextStreamEvent{
-						Type:  llm.EventTypeReasoningEnd,
-						Value: reasoningSummaryBuffer.String(),
+						Type: llm.EventTypeReasoningEnd,
+						Value: llm.ReasoningData{
+							Text: reasoningSummaryBuffer.String(),
+						},
 					}
 					reasoningComplete = true
 				}
@@ -747,8 +751,10 @@ func (s *OpenAI) streamResponsesAPIToChannels(params openai.ChatCompletionNewPar
 			// If we still have unsent reasoning (edge case: no output text), send it now
 			if !reasoningComplete && reasoningSummaryBuffer.Len() > 0 {
 				output <- llm.TextStreamEvent{
-					Type:  llm.EventTypeReasoningEnd,
-					Value: reasoningSummaryBuffer.String(),
+					Type: llm.EventTypeReasoningEnd,
+					Value: llm.ReasoningData{
+						Text: reasoningSummaryBuffer.String(),
+					},
 				}
 			}
 


### PR DESCRIPTION
#### Summary
During the bug bash I noticed that Thinking blocks weren't being shown in the center channel view for @ mentions nor in DMs. Upon investigation I realized this was actually just a bug with OpenAI specifically, Anthropic worked fine. 

In https://github.com/mattermost/mattermost-plugin-agents/pull/414 I added llm.ReasoningData return for Anthropic in order to be able to preserve both the reasoning text, and the signature (since that's a requirement of their API). OpenAI didn't get the same type update, so persistence of thinking was a regression from the change. 

This PR brings OpenAI return inline with Anthropic.
#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
