### PR TITLE
Include channelIDs and rootIDs in the right places

### DIFF
--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -170,8 +170,27 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, argsGe
 	// Format the response
 	var result strings.Builder
 	if channelName != "" && teamName != "" {
-		result.WriteString(fmt.Sprintf("Channel: %s (Team: %s)\n\n", channelName, teamName))
+		result.WriteString(fmt.Sprintf("Channel: %s (Team: %s)\n", channelName, teamName))
 	}
+
+	// Add Channel ID and Root ID to header
+	if len(posts) > 0 {
+		result.WriteString(fmt.Sprintf("Channel ID: %s\n", posts[0].ChannelId))
+
+		// Find any post with a non-empty RootId - all replies share the same RootId
+		var rootID string
+		for _, post := range posts {
+			if post.RootId != "" {
+				rootID = post.RootId
+				break
+			}
+		}
+
+		if rootID != "" {
+			result.WriteString(fmt.Sprintf("Root ID: %s\n", rootID))
+		}
+	}
+	result.WriteString("\n")
 
 	if args.IncludeThread && len(posts) > 1 {
 		result.WriteString(fmt.Sprintf("Thread with %d posts:\n\n", len(posts)))

--- a/mcpserver/tools/search.go
+++ b/mcpserver/tools/search.go
@@ -130,7 +130,13 @@ func (p *MattermostToolProvider) toolSearchPosts(mcpContext *MCPToolContext, arg
 
 	// Format the response
 	var result strings.Builder
-	result.WriteString(fmt.Sprintf("Found %d posts matching '%s':\n\n", len(posts), args.Query))
+	result.WriteString(fmt.Sprintf("Found %d posts matching '%s':\n", len(posts), args.Query))
+
+	// If channelID was provided, include it once in the header
+	if args.ChannelID != "" {
+		result.WriteString(fmt.Sprintf("Channel ID: %s\n", args.ChannelID))
+	}
+	result.WriteString("\n")
 
 	for i, post := range posts {
 		// Get user info for the post
@@ -152,6 +158,13 @@ func (p *MattermostToolProvider) toolSearchPosts(mcpContext *MCPToolContext, arg
 		}
 
 		result.WriteString(fmt.Sprintf("Post ID: %s\n", post.Id))
+		// Only include Channel ID per-post if it wasn't provided as a search parameter
+		if args.ChannelID == "" {
+			result.WriteString(fmt.Sprintf("Channel ID: %s\n", post.ChannelId))
+		}
+		if post.RootId != "" {
+			result.WriteString(fmt.Sprintf("Root ID: %s\n", post.RootId))
+		}
 		result.WriteString(fmt.Sprintf("Message: %s\n\n", post.Message))
 	}
 


### PR DESCRIPTION
#### Summary
We weren't including rootIDs in search results so the LLM couldn't always reply to threads. Also include ChannelIDs where appropriate.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
