### PR TITLE
Add structured outputs support to Anthropic connector

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -48,6 +48,7 @@ func New(llmService llm.ServiceConfig, botConfig llm.BotConfig, httpClient *http
 	client := anthropicSDK.NewClient(
 		option.WithAPIKey(llmService.APIKey),
 		option.WithHTTPClient(httpClient),
+		option.WithHeader("anthropic-beta", "structured-outputs-2025-11-13"),
 	)
 
 	return &Anthropic{
@@ -206,7 +207,7 @@ func (a *Anthropic) streamChatWithTools(state messageState) {
 
 	// Only add tools if not explicitly disabled
 	if !state.config.ToolsDisabled {
-		params.Tools = convertTools(state.tools)
+		params.Tools = convertTools(state.tools, state.config.StrictToolUse)
 	}
 
 	// Only include system message if it's non-empty
@@ -232,6 +233,14 @@ func (a *Anthropic) streamChatWithTools(state messageState) {
 	// Enable thinking/reasoning for models that support it
 	if thinkingConfig, ok := a.calculateThinkingConfig(state.config.MaxGeneratedTokens); ok {
 		params.Thinking = thinkingConfig
+	}
+
+	// Add structured output format if configured
+	if state.config.JSONOutputFormat != nil {
+		params.OutputFormat = anthropicSDK.OutputFormatParam{
+			Type:   "json_schema",
+			Schema: convertJSONSchemaToMap(state.config.JSONOutputFormat),
+		}
 	}
 
 	stream := a.client.Messages.NewStreaming(context.Background(), params)
@@ -469,8 +478,31 @@ func (a *Anthropic) CountTokens(text string) int {
 	return 0
 }
 
+// convertJSONSchemaToMap converts a jsonschema.Schema to a map[string]interface{} for Anthropic API
+func convertJSONSchemaToMap(schema *jsonschema.Schema) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	if schema.Type != "" {
+		result["type"] = schema.Type
+	}
+	if schema.Properties != nil {
+		result["properties"] = schema.Properties
+	}
+	if len(schema.Required) > 0 {
+		result["required"] = schema.Required
+	}
+	if schema.AdditionalProperties != nil {
+		result["additionalProperties"] = schema.AdditionalProperties
+	}
+	if schema.Description != "" {
+		result["description"] = schema.Description
+	}
+
+	return result
+}
+
 // convertTools converts from llm.Tool to anthropicSDK.ToolUnionParam format
-func convertTools(tools []llm.Tool) []anthropicSDK.ToolUnionParam {
+func convertTools(tools []llm.Tool, strictToolUse bool) []anthropicSDK.ToolUnionParam {
 	converted := make([]anthropicSDK.ToolUnionParam, len(tools))
 	for i, tool := range tools {
 		// Convert schema to the format Anthropic expects
@@ -483,12 +515,19 @@ func convertTools(tools []llm.Tool) []anthropicSDK.ToolUnionParam {
 			inputSchema.Properties = schema.Properties
 		}
 
+		toolParam := &anthropicSDK.ToolParam{
+			Name:        tool.Name,
+			Description: anthropicSDK.String(tool.Description),
+			InputSchema: inputSchema,
+		}
+
+		// Enable strict mode for structured outputs if configured
+		if strictToolUse {
+			toolParam.Strict = anthropicSDK.Bool(true)
+		}
+
 		converted[i] = anthropicSDK.ToolUnionParam{
-			OfTool: &anthropicSDK.ToolParam{
-				Name:        tool.Name,
-				Description: anthropicSDK.String(tool.Description),
-				InputSchema: inputSchema,
-			},
+			OfTool: toolParam,
 		}
 	}
 	return converted

--- a/anthropic/structured_outputs_test.go
+++ b/anthropic/structured_outputs_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/mattermost/mattermost-plugin-ai/llm"
+)
+
+func TestConvertJSONSchemaToMap(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]interface{}{
+			"name":  map[string]interface{}{"type": "string"},
+			"email": map[string]interface{}{"type": "string"},
+		},
+		Required:             []string{"name", "email"},
+		AdditionalProperties: false,
+		Description:          "Test schema",
+	}
+
+	result := convertJSONSchemaToMap(schema)
+
+	if result["type"] != "object" {
+		t.Errorf("Expected type 'object', got %v", result["type"])
+	}
+	if result["description"] != "Test schema" {
+		t.Errorf("Expected description 'Test schema', got %v", result["description"])
+	}
+	if result["properties"] == nil {
+		t.Error("Expected properties to be set")
+	}
+	if result["required"] == nil {
+		t.Error("Expected required to be set")
+	}
+	if result["additionalProperties"] != false {
+		t.Errorf("Expected additionalProperties to be false, got %v", result["additionalProperties"])
+	}
+}
+
+func TestConvertToolsWithStrictMode(t *testing.T) {
+	tools := []llm.Tool{
+		{
+			Name:        "test_tool",
+			Description: "A test tool",
+			Schema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]interface{}{
+					"param1": map[string]interface{}{"type": "string"},
+				},
+			},
+		},
+	}
+
+	// Test with strict mode disabled
+	resultNoStrict := convertTools(tools, false)
+	if len(resultNoStrict) != 1 {
+		t.Errorf("Expected 1 tool, got %d", len(resultNoStrict))
+	}
+	if resultNoStrict[0].OfTool.Strict != nil {
+		t.Error("Expected Strict to be nil when strict mode is disabled")
+	}
+
+	// Test with strict mode enabled
+	resultStrict := convertTools(tools, true)
+	if len(resultStrict) != 1 {
+		t.Errorf("Expected 1 tool, got %d", len(resultStrict))
+	}
+	if resultStrict[0].OfTool.Strict == nil || !*resultStrict[0].OfTool.Strict {
+		t.Error("Expected Strict to be true when strict mode is enabled")
+	}
+}

--- a/llm/language_model.go
+++ b/llm/language_model.go
@@ -38,6 +38,7 @@ type LanguageModelConfig struct {
 	EnableVision       bool
 	JSONOutputFormat   *jsonschema.Schema
 	ToolsDisabled      bool
+	StrictToolUse      bool
 }
 
 type LanguageModelOption func(*LanguageModelConfig)
@@ -61,6 +62,12 @@ func WithJSONOutput[T any]() LanguageModelOption {
 func WithToolsDisabled() LanguageModelOption {
 	return func(cfg *LanguageModelConfig) {
 		cfg.ToolsDisabled = true
+	}
+}
+
+func WithStrictToolUse() LanguageModelOption {
+	return func(cfg *LanguageModelConfig) {
+		cfg.StrictToolUse = true
 	}
 }
 


### PR DESCRIPTION
#### Summary
Implement support for Claude API's structured outputs feature, which constrains Claude's responses to follow specific JSON schemas and enables strict validation of tool parameters.

Changes:
- Add anthropic-beta: structured-outputs-2025-11-13 header to API client
- Implement JSON output format support via output_format parameter
- Add helper function convertJSONSchemaToMap to convert JSON schemas
- Add StrictToolUse field to LanguageModelConfig for strict tool validation
- Add WithStrictToolUse() option function to enable strict mode
- Update convertTools to set strict: true on tools when enabled
- Add unit tests for structured outputs functionality

This enables two modes:
1. JSON outputs: Data extraction and formatting with guaranteed schema compliance
2. Strict tool use: Type-safe tool parameters with strict validation

Supported on Claude Sonnet 4.5 and Claude Opus 4.1 models.


#### Release Note
```release-note
NONE
```
