### PR TITLE
Fix "Cannot read properties of undefined (reading 'username')"

### DIFF
--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -10,6 +10,9 @@ import manifest from './manifest';
 
 const Client4 = new Client4Class();
 
+// Export Client4 for use in other components
+export {Client4};
+
 export function setSiteURL(siteURL: string) {
     Client4.setUrl(siteURL);
 }

--- a/webapp/src/components/rhs/rhs_new_tab.tsx
+++ b/webapp/src/components/rhs/rhs_new_tab.tsx
@@ -15,7 +15,7 @@ import {useDispatch, useSelector} from 'react-redux';
 
 import RHSImage from '../assets/rhs_image';
 
-import {createPost, getBotDirectChannel} from '@/client';
+import {createPost, getBotDirectChannel, Client4} from '@/client';
 
 import {AdvancedTextEditor, CreatePost} from '@/mm_webapp';
 
@@ -113,6 +113,17 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
                 try {
                     // This will, as a side effect, create the direct channel for us
                     const newChannelID = await getBotDirectChannel(currentUserId, botId);
+
+                    // Load user profiles into Redux store for AdvancedTextEditor
+                    // This prevents "Cannot read properties of undefined (reading 'username')" error
+                    const currentUser = await Client4.getMe();
+                    const botUser = await Client4.getUser(botId);
+
+                    // Dispatch RECEIVED_PROFILES action to add user profiles to Redux store
+                    dispatch({
+                        type: 'RECEIVED_PROFILES',
+                        data: [currentUser, botUser],
+                    } as any);
 
                     // Update the bots list in Redux with the new channel ID
                     const updatedBots = currentBots.map((bot: LLMBot) => {


### PR DESCRIPTION
#### Summary
Fixes MM-66699 where users encountered "Cannot read properties of undefined (reading 'username')" when sending their first message in the RHS.

Root Cause:
When the RHS is opened for the first time and a direct channel is created using Client4.createDirectChannel(), the user profiles are not automatically loaded into the Redux store. The Mattermost AdvancedTextEditor component requires access to state.entities.users.profiles[userId] to create posts, but this data was missing on first use.

Solution:
After creating the direct channel, we now:
1. Fetch the current user profile using Client4.getMe()
2. Fetch the bot user profile using Client4.getUser(botId)
3. Dispatch RECEIVED_PROFILES action to add both profiles to Redux store

This ensures AdvancedTextEditor has access to the necessary user data when creating the first post.

Changes:
- webapp/src/client.tsx: Export Client4 instance
- webapp/src/components/rhs/rhs_new_tab.tsx: Load and dispatch user profiles after channel creation

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66699

#### Release Note
```release-note
NONE
```
