### PR TITLE
Fix bug where error message replaces partial AI responses (#433)

### DIFF
--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -309,7 +309,7 @@ func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.Text
 				}
 				p.mmClient.LogError("Streaming result to post failed partway", "error", err)
 				T := i18n.LocalizerFunc(p.i18n, userLocale)
-				post.Message = T("agents.stream_to_post_access_llm_error", "Sorry! An error occurred while accessing the LLM. See server logs for details.")
+				post.Message += T("agents.stream_to_post_access_llm_error", "Sorry! An error occurred while accessing the LLM. See server logs for details.")
 
 				// Persist any accumulated reasoning before erroring out
 				if reasoningBuffer.Len() > 0 {


### PR DESCRIPTION
When a streaming LLM response errors mid-generation (e.g., timeout),
the error handling code was replacing the entire message with just
the error text, losing all previously generated content.

Changed line 274 in streaming/streaming.go from assignment (=) to
append (+=) so that the error message is added after the partial
response instead of replacing it.

This preserves valuable partial responses that may have already been
streamed to the user before the error occurred.

Fixes #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during message streaming. When an error occurs, the error notification is now appended to any previously streamed content instead of replacing it, preserving partial messages for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->