### PR TITLE
Fix migration always reporting wasUpdated=true on empty config

### DIFF
--- a/server/migrations.go
+++ b/server/migrations.go
@@ -152,13 +152,18 @@ func migrateServicesToBots(pluginAPI *pluginapi.Client, cfg config.Config) (bool
 		return false, cfg, nil
 	}
 
-	pluginAPI.Log.Debug("Migrating services to bots")
-
 	oldConfig := BotMigrationConfig{}
 	err := pluginAPI.Configuration.LoadPluginConfiguration(&oldConfig)
 	if err != nil {
 		return false, cfg, fmt.Errorf("failed to load plugin configuration for migration: %w", err)
 	}
+
+	// If there are no old services to migrate either, nothing to do
+	if len(oldConfig.Config.Services) == 0 {
+		return false, cfg, nil
+	}
+
+	pluginAPI.Log.Debug("Migrating services to bots")
 
 	// Create services first
 	existingConfig.Services = make([]llm.ServiceConfig, 0, len(oldConfig.Config.Services))

--- a/server/migrations_test.go
+++ b/server/migrations_test.go
@@ -1031,6 +1031,18 @@ func TestMigrateServicesToBots(t *testing.T) {
 			expectError:    false,
 		},
 		{
+			name:           "No bots and no old services - should skip",
+			existingBots:   []llm.BotConfig{},
+			oldConfigJSON:  `{"config": {"services": []}}`,
+			expectMigrated: false,
+			expectError:    false,
+			validateResult: func(t *testing.T, result config.Config) {
+				// Config should remain unchanged (empty)
+				assert.Empty(t, result.Services)
+				assert.Empty(t, result.Bots)
+			},
+		},
+		{
 			name:         "Single old service - should create service and bot with standard name",
 			existingBots: []llm.BotConfig{},
 			oldConfigJSON: `{


### PR DESCRIPTION
## Summary
Fixes a bug where `migrateServicesToBots()` incorrectly returned `wasUpdated=true` when the config had no bots AND no old services to migrate.

## Problem
When an empty config was loaded (no bots, no services), the migration would:
1. Pass the `len(existingConfig.Bots) != 0` check (since bots was empty)
2. Create empty slices for Services and Bots
3. Return `true` even though nothing was actually migrated

This caused unnecessary config saves and potential `OnConfigurationChange` callback loops.

## Solution
Added an early return after loading the old config format—if there are no old services to migrate, return `false` immediately.

## Testing
Added test case: "No bots and no old services - should skip"