### PR TITLE
Improve MCP integration test performance with shared container

### DIFF
--- a/mcp/client_integration_test.go
+++ b/mcp/client_integration_test.go
@@ -15,12 +15,7 @@ import (
 
 // TestClient_CreateClient tests creating a client and verifying its properties
 func TestClient_CreateClient(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	user, session := suite.CreateUserAndSession(t)
@@ -38,12 +33,7 @@ func TestClient_CreateClient(t *testing.T) {
 
 // TestClient_CreateClient_InvalidSession tests session validation in CreateClient
 func TestClient_CreateClient_InvalidSession(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	ctx := context.Background()
@@ -72,12 +62,7 @@ func TestClient_CreateClient_InvalidSession(t *testing.T) {
 
 // TestClient_CallTool_ReadChannel tests the Client.CallTool() method with proper output validation
 func TestClient_CallTool_ReadChannel(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	ctx := context.Background()
@@ -109,12 +94,7 @@ func TestClient_CallTool_ReadChannel(t *testing.T) {
 
 // TestClient_CallTool_SearchUsers tests search_users with output validation
 func TestClient_CallTool_SearchUsers(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	ctx := context.Background()
@@ -141,12 +121,7 @@ func TestClient_CallTool_SearchUsers(t *testing.T) {
 
 // TestClient_CallTool_ReadPost tests read_post with proper output validation
 func TestClient_CallTool_ReadPost(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	ctx := context.Background()
@@ -183,12 +158,7 @@ func TestClient_CallTool_ReadPost(t *testing.T) {
 
 // TestClient_CallTool_InvalidToolName tests error handling for non-existent tools
 func TestClient_CallTool_InvalidToolName(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	ctx := context.Background()
@@ -206,12 +176,7 @@ func TestClient_CallTool_InvalidToolName(t *testing.T) {
 
 // TestClient_CallTool_InvalidArguments tests error handling for invalid arguments
 func TestClient_CallTool_InvalidArguments(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	ctx := context.Background()
@@ -238,12 +203,7 @@ func TestClient_CallTool_InvalidArguments(t *testing.T) {
 
 // TestClient_Reconnection tests the automatic reconnection logic in Client.CallTool()
 func TestClient_Reconnection(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	ctx := context.Background()
@@ -277,12 +237,7 @@ func TestClient_Reconnection(t *testing.T) {
 
 // TestClient_Tools tests that Client.Tools() returns the correct tool list
 func TestClient_Tools(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	user, session := suite.CreateUserAndSession(t)
@@ -322,12 +277,7 @@ func TestClient_Tools(t *testing.T) {
 
 // TestClientManager_GetToolsForUser tests the ClientManager.GetToolsForUser() method
 func TestClientManager_GetToolsForUser(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	user, session := suite.CreateUserAndSession(t)

--- a/mcp/embedded_server_test.go
+++ b/mcp/embedded_server_test.go
@@ -15,12 +15,7 @@ import (
 
 // TestEmbeddedServer_InvalidSession tests that invalid session IDs are properly rejected
 func TestEmbeddedServer_InvalidSession(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	user, _ := suite.CreateUserAndSession(t)
@@ -44,12 +39,7 @@ func TestEmbeddedServer_InvalidSession(t *testing.T) {
 
 // TestEmbeddedServer_MissingSessionToken tests that missing/empty session tokens are rejected at connection time
 func TestEmbeddedServer_MissingSessionToken(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	user, session := suite.CreateUserAndSession(t)
@@ -76,12 +66,7 @@ func TestEmbeddedServer_MissingSessionToken(t *testing.T) {
 
 // TestEmbeddedServer_MultipleConnectionsPerUser tests that a user can have multiple concurrent connections
 func TestEmbeddedServer_MultipleConnectionsPerUser(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	ctx := context.Background()
@@ -114,12 +99,7 @@ func TestEmbeddedServer_MultipleConnectionsPerUser(t *testing.T) {
 // TestEmbeddedServer_SessionLifecycle tests the full lifecycle of a session connection
 // including auto-reconnect behavior
 func TestEmbeddedServer_SessionLifecycle(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	ctx := context.Background()
@@ -157,12 +137,7 @@ func TestEmbeddedServer_SessionLifecycle(t *testing.T) {
 
 // TestEmbeddedServer_TokenResolverCalledAsNeeded tests that the token resolver is called appropriately
 func TestEmbeddedServer_TokenResolverCalledAsNeeded(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	suite := SetupEmbeddedTestSuite(t)
-	defer suite.TearDown()
+	suite := GetSharedTestSuite(t)
 	suite.SetupEmbeddedServer()
 
 	ctx := context.Background()


### PR DESCRIPTION
#### Summary
Improve MCP integration test performance by sharing a single Mattermost container across all tests instead of starting a new container for each test.

Changes:
- Implement shared container via `TestMain` and `sync.Once` for lazy initialization
- Replace timestamp-based unique names (`model.GetMillis()`) with UUID-based names (`model.NewId()`) to prevent collisions in parallel tests
- Pass container config at creation time via `WithConfig()` instead of separate `SetConfig()` calls (eliminates 2 HTTP calls per container)
- Add context timeouts (2 min for startup, 30 sec for teardown) to prevent tests from hanging indefinitely

Result: All 14 MCP integration tests now complete in ~10 seconds with a single shared container, down from potentially minutes when each test started its own container.

#### Ticket Link
N/A - Test infrastructure improvement

#### Screenshots
N/A - No UI changes

#### Release Note
```release-note
NONE
```