### PR TITLE
Remove EXPERIMENTAL label from Native Tools

### DIFF
--- a/e2e/tests/system-console/bot-native-tools.spec.ts
+++ b/e2e/tests/system-console/bot-native-tools.spec.ts
@@ -78,11 +78,7 @@ test.describe.serial('Bot Native Tools', () => {
         // 10. Verify section title shows 'Native Claude Tools'
         await expect(nativeToolsSection).toContainText('Native Claude Tools');
 
-        // 11. Verify an 'EXPERIMENTAL' pill/badge appears next to the title
-        const experimentalBadge = botCard.locator('text=EXPERIMENTAL');
-        await expect(experimentalBadge).toBeVisible();
-
-        // 12. Verify 'Web Search' checkbox is present
+        // 11. Verify 'Web Search' checkbox is present
         // For Anthropic with native tools, Web Search checkbox is the first checkbox (vision/tools use radios)
         const webSearchCheckbox = botCard.getByRole('checkbox').first();
         await expect(webSearchCheckbox).toBeVisible();
@@ -187,11 +183,7 @@ test.describe.serial('Bot Native Tools', () => {
         // 8. Verify section title shows 'Native OpenAI Tools'
         await expect(nativeToolsSection).toContainText('Native OpenAI Tools');
 
-        // 9. Verify 'EXPERIMENTAL' pill is present
-        const experimentalBadge = botCard.locator('text=EXPERIMENTAL');
-        await expect(experimentalBadge).toBeVisible();
-
-        // 10. Verify 'Web Search' checkbox is present
+        // 9. Verify 'Web Search' checkbox is present
         const webSearchCheckbox = botCard.getByRole('checkbox').first();
         await expect(webSearchCheckbox).toBeVisible();
 

--- a/webapp/src/components/system_console/bot.tsx
+++ b/webapp/src/components/system_console/bot.tsx
@@ -8,7 +8,7 @@ import {FormattedMessage, useIntl} from 'react-intl';
 import {TrashCanOutlineIcon, ChevronDownIcon, AlertOutlineIcon, ChevronUpIcon} from '@mattermost/compass-icons/components';
 
 import IconAI from '../assets/icon_ai';
-import {DangerPill, Pill} from '../pill';
+import {DangerPill} from '../pill';
 
 import {ButtonIcon} from '../assets/buttons';
 
@@ -92,10 +92,7 @@ const NativeToolsItem = (props: NativeToolsItemProps) => {
     return (
         <>
             <ItemLabel>
-                <Horizontal>
-                    {titleMessage}
-                    <Pill><FormattedMessage defaultMessage='EXPERIMENTAL'/></Pill>
-                </Horizontal>
+                {titleMessage}
             </ItemLabel>
             <div>
                 {availableNativeTools.map((tool) => (
@@ -425,13 +422,6 @@ const HeaderContainer = styled.div`
 	padding: 12px 16px 12px 20px;
 	border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.12);
 	cursor: pointer;
-`;
-
-const Horizontal = styled.div`
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	gap: 8px;
 `;
 
 const NativeToolContainer = styled.div`


### PR DESCRIPTION
## Summary
- Removes the EXPERIMENTAL pill/badge from the Native Tools (Web Search) configuration for Anthropic, OpenAI, and Azure services
- Updates e2e tests to remove assertions for the experimental badge

## Test plan
- [ ] Verify Native Claude Tools label displays without EXPERIMENTAL badge
- [ ] Verify Native OpenAI Tools label displays without EXPERIMENTAL badge
- [ ] Run e2e tests to confirm they pass