### PR TITLE
Add Docker image build for MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Build artifacts
+dist/
+server/dist/
+bin/
+*.tar.gz
+
+# Frontend (not needed for MCP server)
+webapp/
+webapp/node_modules/
+
+# E2E tests
+e2e/
+
+# Git
+.git/
+.gitignore
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Documentation (except mcpserver README)
+*.md
+!mcpserver/README.md
+
+# CI/CD
+.github/
+
+# Build tools
+build/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,3 +292,36 @@ jobs:
                  -F "force=true" \
                  "$url/api/v4/plugins"
           done
+
+  docker-mcp-server-build-push:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: ci/setup-qemu
+        uses: docker/setup-qemu-action@v3
+
+      - name: ci/setup-buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: ci/docker-login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: ci/extract-version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: ci/build-push-mcp-server
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./mcpserver/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            mattermostdevelopment/mattermost-mcp-server:${{ steps.version.outputs.version }}
+            mattermostdevelopment/mattermost-mcp-server:latest

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,12 @@ mcp-server:
 	mkdir -p mcpserver/bin
 	$(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) $(GO_BUILD_LDFLAGS) -o bin/mattermost-mcp-server ./mcpserver/cmd/main.go
 
+## Builds the MCP server Docker image locally.
+.PHONY: mcp-server-docker
+mcp-server-docker:
+	@echo Building MCP server Docker image...
+	docker build -t mattermost-mcp-server -f mcpserver/Dockerfile .
+
 ## Builds the evalviewer binary.
 .PHONY: evalviewer
 evalviewer:

--- a/docs/mcp_server_docker.md
+++ b/docs/mcp_server_docker.md
@@ -1,0 +1,204 @@
+# Mattermost MCP Server Docker Image
+
+> **WARNING: NOT FOR PRODUCTION USE**
+>
+> This Docker image is intended for **development, testing, and evaluation purposes only**. It provides a quick way to experiment with the Mattermost MCP Server without installing the full Agents plugin.
+>
+> **For production deployments**, use the embedded MCP Server that comes with the [Mattermost Agents plugin](admin_guide.md#mattermost-mcp-server). The embedded server provides:
+> - Seamless integration with Mattermost authentication
+> - Automatic configuration through the System Console
+> - Enterprise features and support
+> - Production-grade security and reliability
+
+## Overview
+
+The Mattermost MCP Server Docker image packages the standalone MCP (Model Context Protocol) server for easy deployment. This allows AI assistants like Claude Code, Claude Desktop, and other MCP-compatible clients to interact with your Mattermost instance.
+
+For detailed information about the MCP Server's capabilities, available tools, and use cases, see the [Mattermost MCP Server documentation](admin_guide.md#mattermost-mcp-server).
+
+## Quick Start
+
+### Prerequisites
+
+- Docker installed on your system
+- A running Mattermost instance (v10.0+)
+- A Personal Access Token (PAT) from your Mattermost account
+
+### Creating a Personal Access Token
+
+1. Log into your Mattermost instance
+2. Go to **User Settings > Security > Personal Access Tokens**
+3. Select **Create Token**
+4. Give your token a descriptive name (e.g., "MCP Server")
+5. Copy and save the token securely - you won't be able to see it again
+
+### Running the Container
+
+**STDIO Mode (Default)** - For piping to AI clients:
+
+```bash
+docker run -i --rm \
+  -e MM_SERVER_URL=https://your-mattermost-server.com \
+  -e MM_ACCESS_TOKEN=your-personal-access-token \
+  mattermostdevelopment/mattermost-mcp-server:latest
+```
+
+**HTTP Mode** - For network-accessible server:
+
+```bash
+docker run -d --rm \
+  -e MM_SERVER_URL=https://your-mattermost-server.com \
+  -p 8064:8064 \
+  mattermostdevelopment/mattermost-mcp-server:latest \
+  --transport http --http-bind-addr 0.0.0.0 --http-port 8064
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `MM_SERVER_URL` | Yes | Your Mattermost server URL (e.g., `https://mattermost.example.com`) |
+| `MM_ACCESS_TOKEN` | Yes (STDIO) | Personal Access Token for authentication |
+| `MM_INTERNAL_SERVER_URL` | No | Internal URL for API communication (if different from public URL) |
+
+### Command Line Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--transport` | `stdio` | Transport type: `stdio` or `http` |
+| `--debug`, `-d` | false | Enable debug logging |
+| `--logfile`, `-l` | - | Path to log file (logs to file in addition to stderr) |
+| `--http-port` | 8080 | Port for HTTP server (HTTP mode only). Recommend using `8064` to avoid conflicts. |
+| `--http-bind-addr` | 127.0.0.1 | Bind address for HTTP server (use `0.0.0.0` for external access) |
+| `--site-url` | - | External URL for OAuth/CORS (HTTP mode with external access) |
+| `--track-ai-generated` | false (stdio) / true (http) | Track AI-generated content in posts |
+| `--dev` | false | Enable development mode with additional tools |
+
+## Integration Examples
+
+### Claude Code
+
+Add the following to your Claude Code MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "mattermost": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "MM_SERVER_URL=https://your-mattermost-server.com",
+        "-e", "MM_ACCESS_TOKEN=your-personal-access-token",
+        "mattermostdevelopment/mattermost-mcp-server:latest"
+      ]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add to your Claude Desktop configuration file:
+
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "mattermost": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "MM_SERVER_URL=https://your-mattermost-server.com",
+        "-e", "MM_ACCESS_TOKEN=your-personal-access-token",
+        "mattermostdevelopment/mattermost-mcp-server:latest"
+      ]
+    }
+  }
+}
+```
+
+### HTTP Mode for Web Clients
+
+For MCP clients that connect over HTTP:
+
+```bash
+docker run -d \
+  --name mattermost-mcp \
+  -e MM_SERVER_URL=https://your-mattermost-server.com \
+  -p 8064:8064 \
+  mattermostdevelopment/mattermost-mcp-server:latest \
+  --transport http --http-bind-addr 0.0.0.0 --http-port 8064
+```
+
+The MCP server will be available at `http://localhost:8064/mcp`.
+
+## Available Tools
+
+The MCP server provides the following tools to AI clients:
+
+| Tool | Description |
+|------|-------------|
+| `read_post` | Read a specific post and its thread |
+| `read_channel` | Retrieve recent posts from a channel |
+| `search_posts` | Search across Mattermost content |
+| `create_post` | Create new posts or replies |
+| `create_channel` | Create new public or private channels |
+| `get_channel_info` | Retrieve channel details |
+| `get_team_info` | Retrieve team details |
+| `search_users` | Find users by username, email, or name |
+| `get_channel_members` | List all members of a channel |
+| `get_team_members` | List all members of a team |
+
+All operations respect Mattermost's permission system - users can only access content they're authorized to see.
+
+## Building Locally
+
+To build the Docker image locally:
+
+```bash
+git clone https://github.com/mattermost/mattermost-plugin-ai.git
+cd mattermost-plugin-ai
+make mcp-server-docker
+```
+
+This creates a local image tagged `mattermost-mcp-server:latest`.
+
+## Troubleshooting
+
+### Enable Debug Logging
+
+```bash
+docker run -i --rm \
+  -e MM_SERVER_URL=https://your-mattermost-server.com \
+  -e MM_ACCESS_TOKEN=your-token \
+  mattermostdevelopment/mattermost-mcp-server:latest \
+  --debug
+```
+
+### Connection Issues
+
+- Verify your Mattermost server URL is accessible from the container
+- Ensure your Personal Access Token is valid and has not expired
+- Check that your Mattermost server allows API access
+
+### Token Validation Errors
+
+- Confirm the token was created correctly in Mattermost
+- Verify the token has not been revoked
+- Check that Personal Access Tokens are enabled on your Mattermost server (**System Console > Integrations > Integration Management**)
+
+## Security Considerations
+
+- **Token Security**: Your Personal Access Token grants access to your Mattermost account. Keep it secure and rotate it regularly.
+- **Network Security**: When using HTTP mode with `--http-bind-addr 0.0.0.0`, the server is accessible from the network. Use appropriate firewall rules and consider TLS termination.
+- **Not for Production**: This Docker image is not designed for production workloads. Use the embedded MCP Server in the Agents plugin for production deployments.
+
+## Additional Resources
+
+- [Mattermost MCP Server Documentation](admin_guide.md#mattermost-mcp-server) - Full documentation for the embedded MCP Server
+- [Model Context Protocol](https://modelcontextprotocol.io/) - MCP specification and documentation
+- [Mattermost Agents Plugin](https://github.com/mattermost/mattermost-plugin-ai) - Source repository

--- a/mcpserver/Dockerfile
+++ b/mcpserver/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the MCP server binary
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -trimpath -o mattermost-mcp-server ./mcpserver/cmd/main.go
+
+# Runtime stage
+FROM alpine:3.19
+
+# Install CA certificates for HTTPS connections to Mattermost
+RUN apk --no-cache add ca-certificates
+
+# Copy binary from builder
+COPY --from=builder /build/mattermost-mcp-server /usr/local/bin/
+
+# Run as non-root user
+RUN adduser -D -u 1000 mcp
+USER mcp
+
+ENTRYPOINT ["mattermost-mcp-server"]


### PR DESCRIPTION
## Summary
- Adds CI workflow to build and push MCP server Docker image to Docker Hub on release tags
- Adds multi-stage Dockerfile for standalone MCP server container (linux/amd64 and linux/arm64)
- Adds `make mcp-server-docker` target for local builds
- Adds documentation for Docker-based deployment

## Test plan
- [ ] Verify local build with `make mcp-server-docker`
- [ ] Test STDIO mode with Claude Code/Desktop
- [ ] Test HTTP mode connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)