### PR TITLE
Exclude public/ directory from plugin bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ default: all
 # Verify environment, and define PLUGIN_ID, PLUGIN_VERSION, HAS_SERVER and HAS_WEBAPP as needed.
 include build/setup.mk
 
+# The public/ directory contains the bridgeclient Go module for external consumption,
+# not HTTP assets. Override HAS_PUBLIC to prevent bundling these files.
+# TODO: Move bridgeclient to a top-level client/ directory for a cleaner import path.
+HAS_PUBLIC :=
+$(info Note: public/ directory contains Go modules, not HTTP assets - skipping bundle)
+
 BUNDLE_NAME ?= $(PLUGIN_ID)-$(PLUGIN_VERSION).tar.gz
 
 # Include custom makefile, if present


### PR DESCRIPTION
#### Summary

The `public/` directory contains the `bridgeclient` Go module for external consumption by other plugins and the Mattermost server, not HTTP assets. However, the plugin build system auto-detects `public/` directories and bundles them as HTTP-served assets.

This was causing:
1. Go source files to be inadvertently served via HTTP (e.g., `https://hub.mattermost.com/plugins/mattermost-ai/public/bridgeclient/client.go`)
2. License check failures when building in the monorepo, as `make check-style` recurses into `public/bridgeclient`

This PR overrides `HAS_PUBLIC` to empty to prevent bundling these files, with a build-time message explaining why.

A future breaking change will move `bridgeclient` to a top-level `client/` directory (following the Playbooks pattern) for a cleaner import path.

#### Ticket Link

N/A

#### Release Note
```release-note
NONE
```