### PR TITLE
Add AWS Bedrock setup guide

### DIFF
--- a/docs/aws_bedrock_setup.md
+++ b/docs/aws_bedrock_setup.md
@@ -120,6 +120,7 @@ Alternatively, install via `mmctl` on the server:
 | **Default Model** | The Bedrock model identifier (e.g., `amazon.nova-pro-v1:0`) |
 | **AWS Access Key ID** | Leave empty when using IAM instance profiles |
 | **AWS Secret Access Key** | Leave empty when using IAM instance profiles |
+| **API Key** | Optional. Bedrock console API key (base64 encoded). Suitable for short-term testing only—keys expire after 12 hours. Leave empty when using IAM instance profiles or IAM user credentials, as those methods take precedence. |
 
 4. Select **Save**.
 


### PR DESCRIPTION
## Summary
- Adds a step-by-step guide (`docs/aws_bedrock_setup.md`) for configuring Mattermost Agents with Amazon Bedrock
- Covers IAM policy/role/instance profile creation, plugin installation, Bedrock service configuration, agent creation, verification, and troubleshooting
- Documents all three authentication options (IAM instance profile, IAM user credentials, Bedrock API key)

## Context
The `mattermost/docs` repo references this file from the Agents Admin Guide toctree. A companion PR will be submitted to `mattermost/docs` to update the submodule reference and add the toctree/body links for this guide.

## Test plan
- [ ] Verify the markdown renders correctly on GitHub
- [ ] Verify the `mattermost/docs` build succeeds with this file present in the submodule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive setup guide for configuring Mattermost Agents with AWS Bedrock as the LLM provider.
  * Includes prerequisites, IAM resources (policy, role, instance profile), EC2 profile attachment, and plugin installation/configuration.
  * Provides step-by-step UI and CLI instructions for new and existing deployments, with example values.
  * Covers verification steps, troubleshooting tips, and authentication options (instance profiles, IAM user credentials, Bedrock API keys).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->