### PR TITLE
MM-67560 Reduce log level from ERROR to WARN when search disabled

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -153,7 +153,7 @@ func (p *Plugin) OnActivate() error {
 		licenseChecker,
 	)
 	if err != nil {
-		pluginAPI.Log.Error("failed to initialize search infrastructure", "error", err)
+		pluginAPI.Log.Warn("failed to initialize search infrastructure", "error", err)
 		// Continue without search functionality
 	}
 


### PR DESCRIPTION
#### Summary
Error logs are emitted when search is disabled.  An error for an otherwise innocuous condition is creating alert noise.  Reduce to warn.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67560


#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved application stability by allowing the system to continue operating gracefully when search functionality initialization encounters issues, rather than stopping completely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->