### PR TITLE
Fix broken MCP server configuration image link in admin guide

### DIFF
--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -469,7 +469,7 @@ The MCP server provides the following tools to AI agents and external clients:
 
 ### Deployment
 
-![MCP Server Configuration](img/system-console-mcp.PNG)
+![MCP Server Configuration](img/system-console-mcp.png)
 
 #### For AI Agents
 


### PR DESCRIPTION
## Summary
- Fixes the broken image link for the MCP Server Configuration screenshot in the admin guide
- The file on disk is `system-console-mcp.png` (lowercase) but the markdown referenced `system-console-mcp.PNG` (uppercase), which breaks on case-sensitive filesystems like GitHub's renderer

Fixes #473
## Test plan
- [ ] Verify the MCP Server Configuration image renders correctly in the [Deployment section](https://github.com/mattermost/mattermost-plugin-agents/blob/master/docs/admin_guide.md#deployment) of the admin guide