### PR TITLE
Fix DM tool calls blocked by EnableChannelMentionToolCalling config

### DIFF
--- a/api/api_post.go
+++ b/api/api_post.go
@@ -275,15 +275,16 @@ func (a *API) handleToolCall(c *gin.Context) {
 	userID := c.GetHeader("Mattermost-User-Id")
 	post := c.MustGet(ContextPostKey).(*model.Post)
 	channel := c.MustGet(ContextChannelKey).(*model.Channel)
-	bot := c.MustGet(ContextBotKey).(*bots.Bot)
 
 	if !a.licenseChecker.IsBasicsLicensed() {
 		c.AbortWithError(http.StatusForbidden, errors.New("feature not licensed"))
 		return
 	}
 
-	// Defense-in-depth: block channel tool calls if config flag is off
-	isDM := mmapi.IsDMWith(bot.GetMMBot().UserId, channel)
+	// Defense-in-depth: block channel tool calls if config flag is off.
+	// Use post.UserId (the bot that created the post) to check the DM,
+	// because the botUsername query parameter may resolve to a different bot.
+	isDM := mmapi.IsDMWith(post.UserId, channel)
 	if !isDM && !a.config.EnableChannelMentionToolCalling() {
 		c.AbortWithError(http.StatusForbidden, errors.New("channel tool calling is disabled"))
 		return
@@ -324,15 +325,16 @@ func (a *API) handleToolCallPrivate(c *gin.Context) {
 	userID := c.GetHeader("Mattermost-User-Id")
 	post := c.MustGet(ContextPostKey).(*model.Post)
 	channel := c.MustGet(ContextChannelKey).(*model.Channel)
-	bot := c.MustGet(ContextBotKey).(*bots.Bot)
 
 	if !a.licenseChecker.IsBasicsLicensed() {
 		c.AbortWithError(http.StatusForbidden, errors.New("feature not licensed"))
 		return
 	}
 
-	// Defense-in-depth: block channel tool call access if config flag is off
-	isDM := mmapi.IsDMWith(bot.GetMMBot().UserId, channel)
+	// Defense-in-depth: block channel tool call access if config flag is off.
+	// Use post.UserId (the bot that created the post) to check the DM,
+	// because the botUsername query parameter may resolve to a different bot.
+	isDM := mmapi.IsDMWith(post.UserId, channel)
 	if !isDM && !a.config.EnableChannelMentionToolCalling() {
 		c.AbortWithError(http.StatusForbidden, errors.New("channel tool calling is disabled"))
 		return
@@ -362,15 +364,16 @@ func (a *API) handleToolResultPrivate(c *gin.Context) {
 	userID := c.GetHeader("Mattermost-User-Id")
 	post := c.MustGet(ContextPostKey).(*model.Post)
 	channel := c.MustGet(ContextChannelKey).(*model.Channel)
-	bot := c.MustGet(ContextBotKey).(*bots.Bot)
 
 	if !a.licenseChecker.IsBasicsLicensed() {
 		c.AbortWithError(http.StatusForbidden, errors.New("feature not licensed"))
 		return
 	}
 
-	// Defense-in-depth: block channel tool result access if config flag is off
-	isDM := mmapi.IsDMWith(bot.GetMMBot().UserId, channel)
+	// Defense-in-depth: block channel tool result access if config flag is off.
+	// Use post.UserId (the bot that created the post) to check the DM,
+	// because the botUsername query parameter may resolve to a different bot.
+	isDM := mmapi.IsDMWith(post.UserId, channel)
 	if !isDM && !a.config.EnableChannelMentionToolCalling() {
 		c.AbortWithError(http.StatusForbidden, errors.New("channel tool calling is disabled"))
 		return
@@ -400,15 +403,16 @@ func (a *API) handleToolResult(c *gin.Context) {
 	userID := c.GetHeader("Mattermost-User-Id")
 	post := c.MustGet(ContextPostKey).(*model.Post)
 	channel := c.MustGet(ContextChannelKey).(*model.Channel)
-	bot := c.MustGet(ContextBotKey).(*bots.Bot)
 
 	if !a.licenseChecker.IsBasicsLicensed() {
 		c.AbortWithError(http.StatusForbidden, errors.New("feature not licensed"))
 		return
 	}
 
-	// Defense-in-depth: block channel tool results if config flag is off
-	isDM := mmapi.IsDMWith(bot.GetMMBot().UserId, channel)
+	// Defense-in-depth: block channel tool results if config flag is off.
+	// Use post.UserId (the bot that created the post) to check the DM,
+	// because the botUsername query parameter may resolve to a different bot.
+	isDM := mmapi.IsDMWith(post.UserId, channel)
 	if !isDM && !a.config.EnableChannelMentionToolCalling() {
 		c.AbortWithError(http.StatusForbidden, errors.New("channel tool calling is disabled"))
 		return

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -561,6 +561,100 @@ func TestHandleGetAIBots(t *testing.T) {
 	}
 }
 
+func TestToolCallDMAllowedWhenChannelToolCallingDisabled(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	// These are the 4 tool-related endpoints that have the EnableChannelMentionToolCalling guard.
+	// They should all pass the isDM check when the post is in a DM with the bot,
+	// even when EnableChannelMentionToolCalling is false.
+	tests := []struct {
+		name     string
+		endpoint string
+		method   string
+		body     string
+	}{
+		{
+			name:     "tool_call in DM is allowed",
+			endpoint: "/post/postid/tool_call",
+			method:   http.MethodPost,
+			body:     `{"accepted_tool_ids": ["tool-1"]}`,
+		},
+		{
+			name:     "tool_call_private in DM is allowed",
+			endpoint: "/post/postid/tool_call_private",
+			method:   http.MethodGet,
+		},
+		{
+			name:     "tool_result_private in DM is allowed",
+			endpoint: "/post/postid/tool_result_private",
+			method:   http.MethodGet,
+		},
+		{
+			name:     "tool_result in DM is allowed",
+			endpoint: "/post/postid/tool_result",
+			method:   http.MethodPost,
+			body:     `{"accepted_tool_ids": ["tool-1"]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e := SetupTestEnvironment(t)
+			defer e.Cleanup(t)
+
+			// Disable channel tool calling — the fix ensures DMs still work.
+			e.config.enableChannelMentionToolCalling = false
+
+			botUserID := testBotUserID
+			userID := testUserID
+
+			e.setupTestBot(llm.BotConfig{Name: "permtest", DisplayName: "Permission Bot"})
+
+			e.api.licenseChecker = enterprise.NewLicenseChecker(e.client)
+			e.mockAPI.On("GetConfig").Return(&model.Config{}).Maybe()
+			e.mockAPI.On("GetLicense").Return(&model.License{SkuShortName: "advanced"}).Maybe()
+
+			post := &model.Post{
+				Id:        "postid",
+				UserId:    botUserID,
+				ChannelId: "channelid",
+			}
+			post.AddProp(streaming.LLMRequesterUserID, userID)
+
+			// DM channel name contains both user IDs
+			dmChannelName := botUserID + "__" + userID
+
+			e.mockAPI.On("GetPost", "postid").Return(post, nil)
+			e.mockAPI.On("GetChannel", "channelid").Return(&model.Channel{
+				Id:   "channelid",
+				Name: dmChannelName,
+				Type: model.ChannelTypeDirect,
+			}, nil)
+			e.mockAPI.On("HasPermissionToChannel", userID, "channelid", model.PermissionReadChannel).Return(true)
+			e.mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything).Maybe()
+			e.mockAPI.On("LogError", mock.Anything).Maybe()
+
+			var body io.Reader
+			if test.body != "" {
+				body = strings.NewReader(test.body)
+			}
+			request := httptest.NewRequest(test.method, test.endpoint, body)
+			request.Header.Add("Mattermost-User-ID", userID)
+
+			recorder := httptest.NewRecorder()
+			e.api.ServeHTTP(&plugin.Context{}, recorder, request)
+			resp := recorder.Result()
+
+			// Should NOT be 403 — the DM check should pass.
+			// The request may fail later (e.g., 400 or 500 due to missing KV data),
+			// but it must not be blocked by the config guard.
+			require.NotEqual(t, http.StatusForbidden, resp.StatusCode,
+				"DM tool call should not be blocked by EnableChannelMentionToolCalling config")
+		})
+	}
+}
+
 func TestToolPrivateRequiresRequester(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DefaultWriter = io.Discard

--- a/prompts/standard_personality_without_locale.tmpl
+++ b/prompts/standard_personality_without_locale.tmpl
@@ -17,11 +17,12 @@ The person’s message may contain a false statement or presupposition and {{.Bo
 {{.BotName}} does not start or end responses with unnecessary pleasantries, greetings, explanations, invitations, or instructions. Instead it responds directly without any unnecessary pleasantries.
 
 {{if .DisabledToolsInfo}}
-IMPORTANT: The following tools are available in a Direct Message (DM) or via the Agents tab, but cannot be used in this channel for security reasons:
+IMPORTANT: You have capabilities that can only be used in a Direct Message (DM) or via the Agents tab, not in this channel. These include:
 
 {{range .DisabledToolsInfo}}- {{.Name}}: {{.Description}}
 {{end}}
-If a user's request requires one of these tools, respond with a single concise sentence explaining that the capability is available only if they DM you directly or use the Agents tab on the right-hand side. Do not ask follow-up questions or offer to help them switch contexts.
+If a user's request requires one of these capabilities, respond with a single concise sentence explaining that the capability is available only if they DM you directly or use the Agents tab on the right-hand side. Do not ask follow-up questions or offer to help them switch contexts.
+CRITICAL: Do NOT attempt to invoke, simulate, or produce any tool call output (including XML, JSON, or any structured tool invocation syntax). You do not have the ability to call tools in this context. Simply tell the user to use a DM or the Agents tab.
 
 {{end}}
 


### PR DESCRIPTION
## Summary
- Fix `IsDMWith` checks in all 4 tool-related API handlers (`handleToolCall`, `handleToolCallPrivate`, `handleToolResultPrivate`, `handleToolResult`) to use `post.UserId` instead of `bot.GetMMBot().UserId`. The bot resolved from the `botUsername` query parameter could be wrong when the frontend doesn't pass it, causing DM tool calls to be incorrectly blocked with HTTP 403.
- Strengthen the disabled-tools system prompt to explicitly prevent LLMs from hallucinating tool call XML when tools are listed as unavailable in channel contexts.
- Add test `TestToolCallDMAllowedWhenChannelToolCallingDisabled` covering all 4 tool endpoints.

## Root Cause
PR #491 added defense-in-depth `IsDMWith` checks that used `bot.GetMMBot().UserId` from the `aiBotRequired` middleware. The frontend tool call functions don't pass the `botUsername` query parameter, so the middleware falls back to `GetBotByUsernameOrFirst("")` which returns the first configured bot. When the DM is with a different bot, the wrong user ID doesn't appear in the DM channel name, and the config check blocks the request.

## Test plan
- [x] `make test` passes (all api package tests pass)
- [ ] Set `EnableChannelMentionToolCalling` to `false`, open a DM with a bot, trigger a tool call, approve it — should succeed
- [ ] Same config, @mention bot in a channel, trigger a tool call — should be blocked and bot should redirect to DM instead of hallucinating XML
- [ ] Set `EnableChannelMentionToolCalling` to `true`, @mention bot in a channel, trigger a tool call — should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved DM (direct message) detection accuracy for tool-related requests to ensure proper access control

* **New Features**
  * Enhanced user guidance to clarify that tool capabilities are available exclusively in direct messages or the Agents tab, not in regular channels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->