### PR TITLE
MM-67546: Add test connection button to Agents system console

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -200,6 +200,7 @@ func (a *API) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Reques
 	adminRouter.GET("/mcp/tools", a.handleGetMCPTools)
 	adminRouter.POST("/mcp/tools/cache/clear", a.handleClearMCPToolsCache)
 	adminRouter.POST("/models/fetch", a.handleFetchModels)
+	adminRouter.POST("/connection/test", a.handleTestConnection)
 
 	searchRouter := botRequiredRouter.Group("/search")
 	// Only returns search results
@@ -374,6 +375,22 @@ type FetchModelsRequest struct {
 	OrgID       string `json:"orgID"`
 }
 
+type TestConnectionRequest struct {
+	ServiceType        string `json:"serviceType"`
+	APIKey             string `json:"apiKey"`
+	APIURL             string `json:"apiURL"`
+	OrgID              string `json:"orgID"`
+	Region             string `json:"region"`
+	AWSAccessKeyID     string `json:"awsAccessKeyID"`
+	AWSSecretAccessKey string `json:"awsSecretAccessKey"`
+}
+
+type TestConnectionResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+	Details string `json:"details,omitempty"`
+}
+
 func (a *API) handleFetchModels(c *gin.Context) {
 	var req FetchModelsRequest
 	if err := c.BindJSON(&req); err != nil {
@@ -417,4 +434,79 @@ func (a *API) handleFetchModels(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, models)
+}
+
+func (a *API) handleTestConnection(c *gin.Context) {
+	var req TestConnectionRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusOK, TestConnectionResponse{
+			Success: false,
+			Message: "Invalid request body",
+			Details: err.Error(),
+		})
+		return
+	}
+
+	if req.ServiceType == "" {
+		c.JSON(http.StatusOK, TestConnectionResponse{
+			Success: false,
+			Message: "Service type is required",
+		})
+		return
+	}
+
+	// API key is required for most services, but optional for openaicompatible (some don't require auth)
+	if req.APIKey == "" && req.ServiceType != "openaicompatible" {
+		c.JSON(http.StatusOK, TestConnectionResponse{
+			Success: false,
+			Message: "API key is required",
+		})
+		return
+	}
+
+	// For openaicompatible, require at least an API URL if no API key
+	if req.ServiceType == "openaicompatible" && req.APIKey == "" && req.APIURL == "" {
+		c.JSON(http.StatusOK, TestConnectionResponse{
+			Success: false,
+			Message: "API URL is required for OpenAI Compatible when API key is not provided",
+		})
+		return
+	}
+
+	var models []llm.ModelInfo
+	var err error
+
+	switch req.ServiceType {
+	case "anthropic":
+		models, err = anthropic.FetchModels(req.APIKey, a.llmUpstreamHTTPClient)
+	case "openai", "azure", "openaicompatible":
+		models, err = openai.FetchModels(req.APIKey, req.APIURL, req.OrgID, a.llmUpstreamHTTPClient)
+	case "bedrock", "cohere", "mistral", "asage":
+		c.JSON(http.StatusOK, TestConnectionResponse{
+			Success: false,
+			Message: fmt.Sprintf("Connection testing is not yet supported for %s", req.ServiceType),
+		})
+		return
+	default:
+		c.JSON(http.StatusOK, TestConnectionResponse{
+			Success: false,
+			Message: fmt.Sprintf("Unknown service type: %s", req.ServiceType),
+		})
+		return
+	}
+
+	if err != nil {
+		c.JSON(http.StatusOK, TestConnectionResponse{
+			Success: false,
+			Message: "Connection test failed. Please verify your credentials and try again.",
+			Details: err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, TestConnectionResponse{
+		Success: true,
+		Message: "Connection successful!",
+		Details: fmt.Sprintf("Found %d models", len(models)),
+	})
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -712,3 +712,103 @@ func TestToolPrivateRequiresRequester(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleTestConnection(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	t.Run("unauthorized user - non admin", func(t *testing.T) {
+		e := SetupTestEnvironment(t)
+		e.mockAPI.On("HasPermissionTo", "non-admin-user", model.PermissionManageSystem).Return(false)
+		e.mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything).Maybe()
+
+		reqBody := `{"serviceType":"anthropic","apiKey":"test-key"}`
+		request := httptest.NewRequest(http.MethodPost, "/admin/connection/test", strings.NewReader(reqBody))
+		request.Header.Add("Mattermost-User-ID", "non-admin-user")
+		request.Header.Add("Content-Type", "application/json")
+
+		recorder := httptest.NewRecorder()
+		e.api.ServeHTTP(&plugin.Context{}, recorder, request)
+		resp := recorder.Result()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("missing service type", func(t *testing.T) {
+		e := SetupTestEnvironment(t)
+		e.mockAPI.On("HasPermissionTo", "admin-user", model.PermissionManageSystem).Return(true)
+
+		reqBody := `{"apiKey":"test-key"}`
+		request := httptest.NewRequest(http.MethodPost, "/admin/connection/test", strings.NewReader(reqBody))
+		request.Header.Add("Mattermost-User-ID", "admin-user")
+		request.Header.Add("Content-Type", "application/json")
+
+		recorder := httptest.NewRecorder()
+		e.api.ServeHTTP(&plugin.Context{}, recorder, request)
+		resp := recorder.Result()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result map[string]interface{}
+		err := json.NewDecoder(resp.Body).Decode(&result)
+		require.NoError(t, err)
+		require.False(t, result["success"].(bool))
+		require.Contains(t, result["message"].(string), "Service type is required")
+	})
+
+	t.Run("missing api key for non-openaicompatible", func(t *testing.T) {
+		e := SetupTestEnvironment(t)
+		e.mockAPI.On("HasPermissionTo", "admin-user", model.PermissionManageSystem).Return(true)
+
+		reqBody := `{"serviceType":"anthropic"}`
+		request := httptest.NewRequest(http.MethodPost, "/admin/connection/test", strings.NewReader(reqBody))
+		request.Header.Add("Mattermost-User-ID", "admin-user")
+		request.Header.Add("Content-Type", "application/json")
+
+		recorder := httptest.NewRecorder()
+		e.api.ServeHTTP(&plugin.Context{}, recorder, request)
+		resp := recorder.Result()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result map[string]interface{}
+		err := json.NewDecoder(resp.Body).Decode(&result)
+		require.NoError(t, err)
+		require.False(t, result["success"].(bool))
+		require.Contains(t, result["message"].(string), "API key is required")
+	})
+
+	t.Run("unsupported service type - bedrock", func(t *testing.T) {
+		e := SetupTestEnvironment(t)
+		e.mockAPI.On("HasPermissionTo", "admin-user", model.PermissionManageSystem).Return(true)
+
+		reqBody := `{"serviceType":"bedrock","apiKey":"test-key"}`
+		request := httptest.NewRequest(http.MethodPost, "/admin/connection/test", strings.NewReader(reqBody))
+		request.Header.Add("Mattermost-User-ID", "admin-user")
+		request.Header.Add("Content-Type", "application/json")
+
+		recorder := httptest.NewRecorder()
+		e.api.ServeHTTP(&plugin.Context{}, recorder, request)
+		resp := recorder.Result()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result map[string]interface{}
+		err := json.NewDecoder(resp.Body).Decode(&result)
+		require.NoError(t, err)
+		require.False(t, result["success"].(bool))
+		require.Contains(t, result["message"].(string), "not yet supported")
+	})
+
+	t.Run("invalid request body", func(t *testing.T) {
+		e := SetupTestEnvironment(t)
+		e.mockAPI.On("HasPermissionTo", "admin-user", model.PermissionManageSystem).Return(true)
+		e.mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything).Maybe()
+
+		request := httptest.NewRequest(http.MethodPost, "/admin/connection/test", strings.NewReader("invalid json"))
+		request.Header.Add("Mattermost-User-ID", "admin-user")
+		request.Header.Add("Content-Type", "application/json")
+
+		recorder := httptest.NewRecorder()
+		e.api.ServeHTTP(&plugin.Context{}, recorder, request)
+		resp := recorder.Result()
+		// gin's BindJSON returns 400 for invalid JSON, which is caught by the error middleware
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}

--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -511,6 +511,32 @@ export async function fetchModels(serviceType: string, apiKey: string, apiURL: s
     });
 }
 
+export async function testConnection(serviceType: string, apiKey: string, apiURL: string, orgID: string, region: string, awsAccessKeyID: string, awsSecretAccessKey: string) {
+    const url = `${baseRoute()}/admin/connection/test`;
+    const response = await fetch(url, Client4.getOptions({
+        method: 'POST',
+        body: JSON.stringify({
+            serviceType,
+            apiKey,
+            apiURL,
+            orgID,
+            region,
+            awsAccessKeyID,
+            awsSecretAccessKey,
+        }),
+    }));
+
+    if (response.ok) {
+        return response.json();
+    }
+
+    throw new ClientError(Client4.url, {
+        message: '',
+        status_code: response.status,
+        url,
+    });
+}
+
 export async function getChannelInterval(
     channelID: string,
     startTime: number,

--- a/webapp/src/components/system_console/service.tsx
+++ b/webapp/src/components/system_console/service.tsx
@@ -9,9 +9,9 @@ import {TrashCanOutlineIcon, ChevronDownIcon, ChevronUpIcon} from '@mattermost/c
 
 import IconAI from '../assets/icon_ai';
 
-import {ButtonIcon} from '../assets/buttons';
+import {ButtonIcon, TertiaryButton} from '../assets/buttons';
 
-import {fetchModels} from '../../client';
+import {fetchModels, testConnection} from '../../client';
 
 import {BooleanItem, ItemList, SelectionItem, SelectionItemOption, TextItem, ComboboxItem} from './item';
 
@@ -68,6 +68,8 @@ const ServiceFields = (props: ServiceFieldsProps) => {
     const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
     const [loadingModels, setLoadingModels] = useState(false);
     const [modelsFetchError, setModelsFetchError] = useState<string>('');
+    const [testingConnection, setTestingConnection] = useState(false);
+    const [testResult, setTestResult] = useState<{success: boolean, message: string, details?: string} | null>(null);
 
     // Determine if we should support model fetching for this service type
     const supportsModelFetching = type === 'anthropic' || type === 'openai' || type === 'azure' || type === 'openaicompatible';
@@ -81,12 +83,14 @@ const ServiceFields = (props: ServiceFieldsProps) => {
         if (!supportsModelFetching || !hasRequiredCredentials) {
             setAvailableModels([]);
             setModelsFetchError('');
+            setTestResult(null);
             return;
         }
 
         const loadModels = async () => {
             setLoadingModels(true);
             setModelsFetchError('');
+            setTestResult(null);
 
             try {
                 const data: ModelInfo[] = await fetchModels(
@@ -126,6 +130,35 @@ const ServiceFields = (props: ServiceFieldsProps) => {
             loadModelsHelpText = modelsFetchError;
         }
     }
+
+    const handleTestConnection = async () => {
+        setTestingConnection(true);
+        setTestResult(null);
+
+        try {
+            const result = await testConnection(
+                type,
+                props.service.apiKey || '',
+                props.service.apiURL || '',
+                props.service.orgId || '',
+                props.service.region || '',
+                props.service.awsAccessKeyID || '',
+                props.service.awsSecretAccessKey || '',
+            );
+            setTestResult({
+                success: result.success,
+                message: result.message,
+                details: result.details,
+            });
+        } catch (error) {
+            setTestResult({
+                success: false,
+                message: intl.formatMessage({defaultMessage: 'Connection test failed. Please check your credentials and try again.'}),
+            });
+        } finally {
+            setTestingConnection(false);
+        }
+    };
 
     return (
         <>
@@ -192,6 +225,46 @@ const ServiceFields = (props: ServiceFieldsProps) => {
                 // eslint-disable-next-line no-undefined
                 helptext={type === 'bedrock' ? intl.formatMessage({defaultMessage: 'Optional. Bedrock console API key (base64 encoded). If IAM credentials above are set, they take precedence.'}) : undefined}
             />
+            <TertiaryButton
+                className='test-connection-button'
+                onClick={handleTestConnection}
+                disabled={testingConnection || !props.service.apiKey}
+            >
+                {testingConnection ?
+                    intl.formatMessage({defaultMessage: 'Testing...'}) :
+                    intl.formatMessage({defaultMessage: 'Test Connection'})
+                }
+            </TertiaryButton>
+            {testResult && testResult.success && (
+                <div
+                    style={{
+                        padding: '12px',
+                        marginTop: '8px',
+                        backgroundColor: '#E7F5E9',
+                        border: '1px solid #4CAF50',
+                        borderRadius: '4px',
+                        color: '#2E7D32',
+                    }}
+                >
+                    {testResult.message}
+                    {testResult.details && <div style={{fontSize: '0.9em', marginTop: '4px'}}>{testResult.details}</div>}
+                </div>
+            )}
+            {testResult && !testResult.success && (
+                <div
+                    style={{
+                        padding: '12px',
+                        marginTop: '8px',
+                        backgroundColor: '#FFEBEE',
+                        border: '1px solid #F44336',
+                        borderRadius: '4px',
+                        color: '#C62828',
+                    }}
+                >
+                    {testResult.message}
+                    {testResult.details && <div style={{fontSize: '0.9em', marginTop: '4px'}}>{testResult.details}</div>}
+                </div>
+            )}
             {isOpenAIType && (
                 <>
                     {!isCohere && !isMistral && (


### PR DESCRIPTION
#### Summary
This PR adds a "Test Connection" button to the LLM service configuration page in the Agents plugin system console. Administrators can now validate their LLM service credentials (API keys, URLs, etc.) immediately after configuration without needing to "test by talking" by actually sending messages through the agent.

**Changes:**
- Added `/admin/connection/test` API endpoint that validates credentials by attempting to fetch models from the configured service
- Added `testConnection` client method in webapp
- Added UI button with loading state and success/error feedback banners
- Supports testing for Anthropic, OpenAI, Azure, and OpenAI Compatible services
- Shows helpful "not yet supported" message for Bedrock, Cohere, Mistral, and asksage services
- Added comprehensive test coverage for the new endpoint

**QA Test Steps:**
1. Navigate to System Console > Plugins > Agents > Add Service
2. Configure an Anthropic service with a valid API key
3. Click the "Test Connection" button
4. Verify success message appears with model count
5. Change API key to an invalid value
6. Click "Test Connection" button again
7. Verify error message appears with details
8. Test with OpenAI, Azure, and OpenAI Compatible service types
9. Verify button is disabled when API key field is empty

#### Ticket Link
Jira: MM-67546

#### Screenshots
N/A - This is a new feature that adds a button and feedback banners to the existing service configuration UI.

#### Release Note
```release-note
Added "Test Connection" button to LLM service configuration in Agents plugin system console, allowing administrators to validate credentials without sending test messages.
```