### PR TITLE
Fix bot config changes not taking effect until plugin restart

### DIFF
--- a/bots/bots.go
+++ b/bots/bots.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"sync"
 
 	"github.com/mattermost/mattermost-plugin-ai/anthropic"
@@ -52,9 +53,12 @@ type MMBots struct {
 	botsLock sync.RWMutex
 	bots     []*Bot
 
-	// lastEnsuredBotCfgs stores the bot configs that were last successfully ensured
-	// This is used for optimistic checking to avoid unnecessary cluster mutex acquisition
+	// lastEnsuredBotCfgs stores the bot configs that were last successfully ensured.
+	// This is used for optimistic checking to avoid unnecessary cluster mutex acquisition.
 	lastEnsuredBotCfgs []llm.BotConfig
+	// lastEnsuredServiceCfgs stores the resolved service configs keyed by service ID
+	// that were last successfully ensured, for optimistic change detection.
+	lastEnsuredServiceCfgs map[string]llm.ServiceConfig
 }
 
 func New(mutexPluginAPI cluster.MutexPluginAPI, pluginAPI *pluginapi.Client, licenseChecker *enterprise.LicenseChecker, config Config, llmUpstreamHTTPClient *http.Client, tokenLogger *mlog.Logger, metrics llm.MetricsObserver) *MMBots {
@@ -69,14 +73,29 @@ func New(mutexPluginAPI cluster.MutexPluginAPI, pluginAPI *pluginapi.Client, lic
 	}
 }
 
-// botConfigsEqual compares two bot config slices for equality
-// This is used for optimistic checking to avoid unnecessary cluster mutex acquisition
+// resolveServiceCfgs builds a map of service configs referenced by the given bot configs.
+func (b *MMBots) resolveServiceCfgs(botCfgs []llm.BotConfig) map[string]llm.ServiceConfig {
+	result := make(map[string]llm.ServiceConfig, len(botCfgs))
+	for _, botCfg := range botCfgs {
+		if _, exists := result[botCfg.ServiceID]; exists {
+			continue
+		}
+		if svc, ok := b.config.GetServiceByID(botCfg.ServiceID); ok {
+			result[botCfg.ServiceID] = svc
+		}
+	}
+	return result
+}
+
+// botConfigsEqual compares two bot config slices for equality.
+// Uses reflect.DeepEqual to compare all fields, ensuring changes to any field
+// (e.g., EnabledNativeTools, CustomInstructions, access levels) are detected.
+// Comparison is order-independent, matching configs by ID.
 func botConfigsEqual(a, b []llm.BotConfig) bool {
 	if len(a) != len(b) {
 		return false
 	}
 
-	// Build a map of bot configs by ID for efficient comparison
 	aMap := make(map[string]llm.BotConfig, len(a))
 	for _, cfg := range a {
 		aMap[cfg.ID] = cfg
@@ -87,11 +106,26 @@ func botConfigsEqual(a, b []llm.BotConfig) bool {
 		if !ok {
 			return false
 		}
-		// Compare all fields that affect bot setup
-		if aCfg.Name != cfg.Name ||
-			aCfg.DisplayName != cfg.DisplayName ||
-			aCfg.ServiceID != cfg.ServiceID ||
-			aCfg.Model != cfg.Model {
+		if !reflect.DeepEqual(aCfg, cfg) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// serviceConfigsEqual compares two service config maps for equality.
+func serviceConfigsEqual(a, b map[string]llm.ServiceConfig) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for id, aCfg := range a {
+		bCfg, ok := b[id]
+		if !ok {
+			return false
+		}
+		if !reflect.DeepEqual(aCfg, bCfg) {
 			return false
 		}
 	}
@@ -100,17 +134,19 @@ func botConfigsEqual(a, b []llm.BotConfig) bool {
 }
 
 func (b *MMBots) EnsureBots() error {
-	// Optimistic check: if bot configuration hasn't changed since last ensure,
+	// Optimistic check: if bot and service configuration hasn't changed since last ensure,
 	// skip the expensive cluster mutex acquisition. This prevents HA timeout issues
 	// when multiple nodes all try to acquire the mutex simultaneously on config changes.
 	currentBotCfgs := b.config.GetBots()
+	currentServiceCfgs := b.resolveServiceCfgs(currentBotCfgs)
 	b.botsLock.RLock()
 	botsAlreadyInitialized := len(b.bots) > 0
-	lastCfgs := b.lastEnsuredBotCfgs
+	lastBotCfgs := b.lastEnsuredBotCfgs
+	lastServiceCfgs := b.lastEnsuredServiceCfgs
 	b.botsLock.RUnlock()
 
-	if botsAlreadyInitialized && botConfigsEqual(lastCfgs, currentBotCfgs) {
-		b.pluginAPI.Log.Debug("EnsureBots: skipping - bot configuration unchanged")
+	if botsAlreadyInitialized && botConfigsEqual(lastBotCfgs, currentBotCfgs) && serviceConfigsEqual(lastServiceCfgs, currentServiceCfgs) {
+		b.pluginAPI.Log.Debug("EnsureBots: skipping - bot and service configuration unchanged")
 		return nil
 	}
 
@@ -123,13 +159,15 @@ func (b *MMBots) EnsureBots() error {
 
 	// Re-check after acquiring lock - another node may have already handled this
 	currentBotCfgs = b.config.GetBots()
+	currentServiceCfgs = b.resolveServiceCfgs(currentBotCfgs)
 	b.botsLock.RLock()
 	botsAlreadyInitialized = len(b.bots) > 0
-	lastCfgs = b.lastEnsuredBotCfgs
+	lastBotCfgs = b.lastEnsuredBotCfgs
+	lastServiceCfgs = b.lastEnsuredServiceCfgs
 	b.botsLock.RUnlock()
 
-	if botsAlreadyInitialized && botConfigsEqual(lastCfgs, currentBotCfgs) {
-		b.pluginAPI.Log.Debug("EnsureBots: skipping after lock - bot configuration unchanged")
+	if botsAlreadyInitialized && botConfigsEqual(lastBotCfgs, currentBotCfgs) && serviceConfigsEqual(lastServiceCfgs, currentServiceCfgs) {
+		b.pluginAPI.Log.Debug("EnsureBots: skipping after lock - bot and service configuration unchanged")
 		return nil
 	}
 
@@ -238,9 +276,16 @@ func (b *MMBots) EnsureBots() error {
 
 	b.botsLock.Lock()
 	b.bots = bots
-	// Store the successfully ensured bot configs for optimistic checking
-	b.lastEnsuredBotCfgs = make([]llm.BotConfig, len(currentBotCfgs))
-	copy(b.lastEnsuredBotCfgs, currentBotCfgs)
+	// Store deep copies of the successfully ensured configs for optimistic checking.
+	// Deep copy is needed because BotConfig contains slice fields (EnabledNativeTools, etc.)
+	// that would otherwise share backing arrays with the live config.
+	copiedBotCfgs, copyErr := config.DeepCopyJSON(currentBotCfgs)
+	if copyErr != nil {
+		b.botsLock.Unlock()
+		return fmt.Errorf("failed to deep copy bot configs for change tracking: %w", copyErr)
+	}
+	b.lastEnsuredBotCfgs = copiedBotCfgs
+	b.lastEnsuredServiceCfgs = currentServiceCfgs
 	b.botsLock.Unlock()
 
 	return nil

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -50,6 +50,356 @@ func (m *mockConfig) GetTranscriptGenerator() string {
 	return "testbot"
 }
 
+func TestBotConfigsEqual(t *testing.T) {
+	baseBotConfig := func() llm.BotConfig {
+		return llm.BotConfig{
+			ID:                 "bot1",
+			Name:               "testbot",
+			DisplayName:        "Test Bot",
+			CustomInstructions: "Be helpful",
+			ServiceID:          "svc1",
+			Model:              "gpt-4o",
+			EnableVision:       true,
+			DisableTools:       false,
+			ChannelAccessLevel: llm.ChannelAccessLevelAll,
+			ChannelIDs:         []string{"ch1", "ch2"},
+			UserAccessLevel:    llm.UserAccessLevelAll,
+			UserIDs:            []string{"u1"},
+			TeamIDs:            []string{"t1"},
+			MaxFileSize:        1024,
+			EnabledNativeTools: []string{"web_search"},
+			ReasoningEnabled:   true,
+			ReasoningEffort:    "medium",
+			ThinkingBudget:     4096,
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		a        []llm.BotConfig
+		b        []llm.BotConfig
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			a:        []llm.BotConfig{},
+			b:        []llm.BotConfig{},
+			expected: true,
+		},
+		{
+			name:     "both nil",
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			name:     "identical configs",
+			a:        []llm.BotConfig{baseBotConfig()},
+			b:        []llm.BotConfig{baseBotConfig()},
+			expected: true,
+		},
+		{
+			name:     "different lengths",
+			a:        []llm.BotConfig{baseBotConfig()},
+			b:        []llm.BotConfig{},
+			expected: false,
+		},
+		{
+			name: "different Name",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.Name = "otherbot"
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different EnabledNativeTools",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.EnabledNativeTools = []string{}
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "EnabledNativeTools added",
+			a: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.EnabledNativeTools = nil
+				return []llm.BotConfig{c}
+			}(),
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.EnabledNativeTools = []string{"web_search"}
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different CustomInstructions",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.CustomInstructions = "Be concise"
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different EnableVision",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.EnableVision = false
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different DisableTools",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.DisableTools = true
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different ChannelAccessLevel",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.ChannelAccessLevel = llm.ChannelAccessLevelBlock
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different ChannelIDs",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.ChannelIDs = []string{"ch3"}
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different UserIDs",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.UserIDs = []string{"u2", "u3"}
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different TeamIDs",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.TeamIDs = []string{"t2"}
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different MaxFileSize",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.MaxFileSize = 2048
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different ReasoningEnabled",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.ReasoningEnabled = false
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different ReasoningEffort",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.ReasoningEffort = "high"
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different ThinkingBudget",
+			a:    []llm.BotConfig{baseBotConfig()},
+			b: func() []llm.BotConfig {
+				c := baseBotConfig()
+				c.ThinkingBudget = 8192
+				return []llm.BotConfig{c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different order same configs",
+			a: func() []llm.BotConfig {
+				c1 := baseBotConfig()
+				c2 := baseBotConfig()
+				c2.ID = "bot2"
+				c2.Name = "testbot2"
+				return []llm.BotConfig{c1, c2}
+			}(),
+			b: func() []llm.BotConfig {
+				c1 := baseBotConfig()
+				c2 := baseBotConfig()
+				c2.ID = "bot2"
+				c2.Name = "testbot2"
+				return []llm.BotConfig{c2, c1}
+			}(),
+			expected: true,
+		},
+		{
+			name: "missing bot ID in second slice",
+			a: func() []llm.BotConfig {
+				c1 := baseBotConfig()
+				c2 := baseBotConfig()
+				c2.ID = "bot2"
+				return []llm.BotConfig{c1, c2}
+			}(),
+			b: func() []llm.BotConfig {
+				c1 := baseBotConfig()
+				c3 := baseBotConfig()
+				c3.ID = "bot3"
+				return []llm.BotConfig{c1, c3}
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := botConfigsEqual(tc.a, tc.b)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestServiceConfigsEqual(t *testing.T) {
+	baseServiceConfig := func() llm.ServiceConfig {
+		return llm.ServiceConfig{
+			ID:                      "svc1",
+			Name:                    "OpenAI Service",
+			Type:                    llm.ServiceTypeOpenAI,
+			APIKey:                  "sk-test",
+			DefaultModel:            "gpt-4o",
+			APIURL:                  "https://api.openai.com/v1",
+			InputTokenLimit:         128000,
+			OutputTokenLimit:        4096,
+			StreamingTimeoutSeconds: 30,
+			UseResponsesAPI:         true,
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		a        map[string]llm.ServiceConfig
+		b        map[string]llm.ServiceConfig
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			a:        map[string]llm.ServiceConfig{},
+			b:        map[string]llm.ServiceConfig{},
+			expected: true,
+		},
+		{
+			name:     "both nil",
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			name:     "identical configs",
+			a:        map[string]llm.ServiceConfig{"svc1": baseServiceConfig()},
+			b:        map[string]llm.ServiceConfig{"svc1": baseServiceConfig()},
+			expected: true,
+		},
+		{
+			name:     "different lengths",
+			a:        map[string]llm.ServiceConfig{"svc1": baseServiceConfig()},
+			b:        map[string]llm.ServiceConfig{},
+			expected: false,
+		},
+		{
+			name: "different APIURL",
+			a:    map[string]llm.ServiceConfig{"svc1": baseServiceConfig()},
+			b: func() map[string]llm.ServiceConfig {
+				c := baseServiceConfig()
+				c.APIURL = "https://custom.api.com/v1"
+				return map[string]llm.ServiceConfig{"svc1": c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different OutputTokenLimit",
+			a:    map[string]llm.ServiceConfig{"svc1": baseServiceConfig()},
+			b: func() map[string]llm.ServiceConfig {
+				c := baseServiceConfig()
+				c.OutputTokenLimit = 8192
+				return map[string]llm.ServiceConfig{"svc1": c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different UseResponsesAPI",
+			a:    map[string]llm.ServiceConfig{"svc1": baseServiceConfig()},
+			b: func() map[string]llm.ServiceConfig {
+				c := baseServiceConfig()
+				c.UseResponsesAPI = false
+				return map[string]llm.ServiceConfig{"svc1": c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "different APIKey",
+			a:    map[string]llm.ServiceConfig{"svc1": baseServiceConfig()},
+			b: func() map[string]llm.ServiceConfig {
+				c := baseServiceConfig()
+				c.APIKey = "sk-new-key"
+				return map[string]llm.ServiceConfig{"svc1": c}
+			}(),
+			expected: false,
+		},
+		{
+			name: "missing service ID",
+			a: map[string]llm.ServiceConfig{
+				"svc1": baseServiceConfig(),
+				"svc2": baseServiceConfig(),
+			},
+			b: map[string]llm.ServiceConfig{
+				"svc1": baseServiceConfig(),
+				"svc3": baseServiceConfig(),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := serviceConfigsEqual(tc.a, tc.b)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestEnsureBots(t *testing.T) {
 	testCases := []struct {
 		name               string


### PR DESCRIPTION
#### Summary

`botConfigsEqual()` only compared 4 of ~18 `BotConfig` fields (`Name`, `DisplayName`, `ServiceID`, `Model`), so changes to settings like `EnabledNativeTools` (web search), `CustomInstructions`, `ReasoningEnabled`, access levels, etc. were silently ignored until plugin restart.

This PR:
- Replaces the manual 4-field comparison with `reflect.DeepEqual` per config pair, automatically covering all current and future fields
- Adds service config change detection so changes to service settings (API URL, token limits, etc.) also trigger bot re-initialization
- Replaces shallow `copy()` of stored bot configs with `config.DeepCopyJSON()` to prevent shared backing arrays for slice fields

**QA steps:**
1. Change the web search setting on an agent, save — verify it takes effect without restarting
2. Change a service config (e.g. token limit), save — verify the bot picks up the change without restarting

#### Ticket Link

N/A

#### Screenshots

N/A — no UI changes.

#### Release Note

```release-note
Fixed an issue where bot configuration changes (e.g., enabling web search, changing custom instructions, or updating service settings) did not take effect until the plugin was restarted.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced bot configuration management with improved comparison mechanisms to ensure more reliable and efficient handling of configuration updates and service synchronization.

* **Tests**
  * Added comprehensive test coverage for bot and service configuration comparison functionality, including various scenarios and edge cases for robust validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->