### PR TITLE
Disable tools when generating conversation titles

### DIFF
--- a/conversations/conversations.go
+++ b/conversations/conversations.go
@@ -225,7 +225,12 @@ func (c *Conversations) GenerateTitle(bot *bots.Bot, request string, postID stri
 		Context: context,
 	}
 
-	conversationTitle, err := bot.LLM().ChatCompletionNoStream(titleRequest, llm.WithMaxGeneratedTokens(25), llm.WithReasoningDisabled())
+	conversationTitle, err := bot.LLM().ChatCompletionNoStream(
+		titleRequest,
+		llm.WithMaxGeneratedTokens(25),
+		llm.WithReasoningDisabled(),
+		llm.WithToolsDisabled(),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to get title: %w", err)
 	}


### PR DESCRIPTION
#### Summary

This disables tool use for title generation.

I can't imagine any reason to use a tool during title generation and with a token limit of 25, I don't think it's even possible.

#### Ticket Link

This doesn't resolve #464 but it does seem to help significantly.

#### Release Note

```release-note
NONE
```

#### Other

I've signed the `Contributor License Agreement` but I'm not yet on the approved contributor list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation title generation by disabling tools during the process to ensure more reliable and consistent title creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->