### PR TITLE
Fix MCP OAuth detection for bare 401 responses

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -268,11 +268,9 @@ func (c *Client) createSession(ctx context.Context, serverConfig ServerConfig) (
 	}
 
 	// Check for OAuth error from Streamable HTTP attempt
-	var streamableAuthErr *mcpUnauthorized
-	streamableAsOAuth := errors.As(errStreamable, &streamableAuthErr)
-	streamableMetadataURL, streamableStringOAuth := extractOAuthMetadataURL(errStreamable)
-	if streamableAsOAuth {
-		authURL, oauthErr := c.oauthManager.InitiateOAuthFlow(ctx, c.userID, c.config.Name, serverConfig.BaseURL, streamableAuthErr.MetadataURL())
+	var mcpAuthErr *mcpUnauthorized
+	if errors.As(errStreamable, &mcpAuthErr) {
+		authURL, oauthErr := c.oauthManager.InitiateOAuthFlow(ctx, c.userID, c.config.Name, serverConfig.BaseURL, mcpAuthErr.MetadataURL())
 		if oauthErr != nil {
 			return nil, fmt.Errorf("failed to initiate OAuth flow for server %s: %w", c.config.Name, oauthErr)
 		}
@@ -283,8 +281,8 @@ func (c *Client) createSession(ctx context.Context, serverConfig ServerConfig) (
 
 	// Temporary workaround: check for OAuth error by string matching since go-sdk does not preserve error chains with %w
 	// remove when go-sdk is updated to support oauth directly.
-	if streamableStringOAuth {
-		authURL, oauthErr := c.oauthManager.InitiateOAuthFlow(ctx, c.userID, c.config.Name, serverConfig.BaseURL, streamableMetadataURL)
+	if metadataURL, ok := extractOAuthMetadataURL(errStreamable); ok {
+		authURL, oauthErr := c.oauthManager.InitiateOAuthFlow(ctx, c.userID, c.config.Name, serverConfig.BaseURL, metadataURL)
 		if oauthErr != nil {
 			return nil, fmt.Errorf("failed to initiate OAuth flow for server %s: %w", c.config.Name, oauthErr)
 		}
@@ -304,11 +302,8 @@ func (c *Client) createSession(ctx context.Context, serverConfig ServerConfig) (
 	}
 
 	// Check for OAuth error from SSE attempt
-	var sseAuthErr *mcpUnauthorized
-	sseAsOAuth := errors.As(errSSE, &sseAuthErr)
-	sseMetadataURL, sseStringOAuth := extractOAuthMetadataURL(errSSE)
-	if sseAsOAuth {
-		authURL, oauthErr := c.oauthManager.InitiateOAuthFlow(ctx, c.userID, c.config.Name, serverConfig.BaseURL, sseAuthErr.MetadataURL())
+	if errors.As(errSSE, &mcpAuthErr) {
+		authURL, oauthErr := c.oauthManager.InitiateOAuthFlow(ctx, c.userID, c.config.Name, serverConfig.BaseURL, mcpAuthErr.MetadataURL())
 		if oauthErr != nil {
 			return nil, fmt.Errorf("failed to initiate OAuth flow for server %s: %w", c.config.Name, oauthErr)
 		}
@@ -319,8 +314,8 @@ func (c *Client) createSession(ctx context.Context, serverConfig ServerConfig) (
 
 	// Temporary workaround: check for OAuth error by string matching since go-sdk does not preserve error chains with %w
 	// remove when go-sdk is updated to support oauth directly.
-	if sseStringOAuth {
-		authURL, oauthErr := c.oauthManager.InitiateOAuthFlow(ctx, c.userID, c.config.Name, serverConfig.BaseURL, sseMetadataURL)
+	if metadataURL, ok := extractOAuthMetadataURL(errSSE); ok {
+		authURL, oauthErr := c.oauthManager.InitiateOAuthFlow(ctx, c.userID, c.config.Name, serverConfig.BaseURL, metadataURL)
 		if oauthErr != nil {
 			return nil, fmt.Errorf("failed to initiate OAuth flow for server %s: %w", c.config.Name, oauthErr)
 		}

--- a/mcp/user_clients.go
+++ b/mcp/user_clients.go
@@ -66,8 +66,7 @@ func (c *UserClients) ConnectToRemoteServers(servers []ServerConfig) *Errors {
 
 			// Check if this is an OAuth authentication error
 			var oauthErr *OAuthNeededError
-			isOAuthError := errors.As(err, &oauthErr)
-			if isOAuthError {
+			if errors.As(err, &oauthErr) {
 				mcpErrors.ToolAuthErrors = append(mcpErrors.ToolAuthErrors, llm.ToolAuthError{
 					ServerName: serverConfig.Name,
 					AuthURL:    oauthErr.AuthURL(),


### PR DESCRIPTION
#### Summary
Ensure MCP OAuth auth prompts still trigger when remote servers return HTTP 401 without a `WWW-Authenticate` header.

#### Ticket Link
NONE

#### Screenshots
NONE

#### Release Note
```release-note
Fixed MCP OAuth initiation for servers that return 401 responses without a WWW-Authenticate header.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth authentication error handling to ensure proper cleanup of HTTP resources across multiple error scenarios, improving reliability of authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->