### PR TITLE
Fix channel tool approvals for automated mention invokers

### DIFF
--- a/conversations/handle_messages.go
+++ b/conversations/handle_messages.go
@@ -14,17 +14,43 @@ import (
 )
 
 const (
-	ActivateAIProp  = "activate_ai"
-	FromWebhookProp = "from_webhook"
-	FromBotProp     = "from_bot"
-	FromPluginProp  = "from_plugin"
-	WranglerProp    = "wrangler"
+	ActivateAIProp   = "activate_ai"
+	FromWebhookProp  = "from_webhook"
+	FromBotProp      = "from_bot"
+	FromPluginProp   = "from_plugin"
+	FromOAuthAppProp = "from_oauth_app"
+	WranglerProp     = "wrangler"
 )
 
 var (
 	// ErrNoResponse is returned when no response is posted under a normal condition.
 	ErrNoResponse = errors.New("no response")
 )
+
+// isAutomatedInvoker returns true when the post originates from automation (bot, webhook,
+// plugin, or OAuth app). Used to disable channel tool calling for automated invokers
+// since they cannot interactively approve tool calls.
+func isAutomatedInvoker(post *model.Post, postingUser *model.User) bool {
+	if postingUser != nil && postingUser.IsBot {
+		return true
+	}
+	if post == nil {
+		return false
+	}
+	automationProps := []string{FromWebhookProp, FromPluginProp, FromBotProp, FromOAuthAppProp}
+	for _, prop := range automationProps {
+		if post.GetProp(prop) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// computeAllowToolsInChannel returns whether tools should be allowed for a channel mention,
+// given the config flag and whether the invoker is automated.
+func computeAllowToolsInChannel(configEnabled bool, post *model.Post, postingUser *model.User) bool {
+	return configEnabled && !isAutomatedInvoker(post, postingUser)
+}
 
 func (c *Conversations) MessageHasBeenPosted(ctx *plugin.Context, post *model.Post) {
 	if err := c.handleMessages(post); err != nil {
@@ -96,7 +122,8 @@ func (c *Conversations) handleMentions(bot *bots.Bot, post *model.Post, postingU
 	}
 
 	// Check config to determine if tools should be allowed in channel mentions
-	allowToolsInChannel := c.configProvider != nil && c.configProvider.EnableChannelMentionToolCalling()
+	configEnabled := c.configProvider != nil && c.configProvider.EnableChannelMentionToolCalling()
+	allowToolsInChannel := computeAllowToolsInChannel(configEnabled, post, postingUser)
 
 	stream, err := c.ProcessUserRequest(bot, postingUser, channel, post, allowToolsInChannel)
 	if err != nil {

--- a/conversations/handle_messages_test.go
+++ b/conversations/handle_messages_test.go
@@ -82,3 +82,67 @@ func TestHandleMessages(t *testing.T) {
 		require.ErrorIs(t, err, ErrNoResponse)
 	})
 }
+
+func TestIsAutomatedInvoker(t *testing.T) {
+	tests := []struct {
+		name        string
+		post        *model.Post
+		postingUser *model.User
+		want        bool
+	}{
+		{"nil post and user", nil, nil, false},
+		{"nil post", nil, &model.User{Id: "u1", IsBot: false}, false},
+		{"nil user, no automation props", &model.Post{UserId: "u1"}, nil, false},
+		{"human user, no props", &model.Post{UserId: "u1"}, &model.User{Id: "u1", IsBot: false}, false},
+		{"bot user", &model.Post{UserId: "b1"}, &model.User{Id: "b1", IsBot: true}, true},
+		{"from_webhook prop", postWithProp(FromWebhookProp), &model.User{Id: "u1", IsBot: false}, true},
+		{"from_plugin prop", postWithProp(FromPluginProp), &model.User{Id: "u1", IsBot: false}, true},
+		{"from_bot prop", postWithProp(FromBotProp), &model.User{Id: "u1", IsBot: false}, true},
+		{"from_oauth_app prop", postWithProp(FromOAuthAppProp), &model.User{Id: "u1", IsBot: false}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAutomatedInvoker(tt.post, tt.postingUser)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func postWithProp(prop string) *model.Post {
+	p := &model.Post{UserId: "u1"}
+	p.AddProp(prop, true)
+	return p
+}
+
+func TestComputeAllowToolsInChannel(t *testing.T) {
+	humanUser := &model.User{Id: "u1", IsBot: false}
+	botUser := &model.User{Id: "b1", IsBot: true}
+	humanPost := &model.Post{UserId: "u1"}
+	webhookPost := postWithProp(FromWebhookProp)
+	pluginPost := postWithProp(FromPluginProp)
+	botPropPost := postWithProp(FromBotProp)
+	oauthAppPost := postWithProp(FromOAuthAppProp)
+
+	tests := []struct {
+		name          string
+		configEnabled bool
+		post          *model.Post
+		postingUser   *model.User
+		want          bool
+	}{
+		{"config disabled, human", false, humanPost, humanUser, false},
+		{"config enabled, human", true, humanPost, humanUser, true},
+		{"config enabled, bot user", true, humanPost, botUser, false},
+		{"config enabled, from_webhook post", true, webhookPost, humanUser, false},
+		{"config enabled, from_plugin post", true, pluginPost, humanUser, false},
+		{"config enabled, from_bot post", true, botPropPost, humanUser, false},
+		{"config enabled, from_oauth_app post", true, oauthAppPost, humanUser, false},
+		{"config disabled, bot user", false, humanPost, botUser, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeAllowToolsInChannel(tt.configEnabled, tt.post, tt.postingUser)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/prompts/standard_personality_without_locale.tmpl
+++ b/prompts/standard_personality_without_locale.tmpl
@@ -22,7 +22,7 @@ IMPORTANT: You have capabilities that can only be used in a Direct Message (DM) 
 {{range .DisabledToolsInfo}}- {{.Name}}: {{.Description}}
 {{end}}
 If a user's request requires one of these capabilities, respond with a single concise sentence explaining that the capability is available only if they DM you directly or use the Agents tab on the right-hand side. Do not ask follow-up questions or offer to help them switch contexts.
-CRITICAL: Do NOT attempt to invoke, simulate, or produce any tool call output (including XML, JSON, or any structured tool invocation syntax). You do not have the ability to call tools in this context. Simply tell the user to use a DM or the Agents tab.
+CRITICAL: Do NOT attempt to invoke, simulate, or produce any tool call output for the tools listed above (including XML, JSON, or any structured tool invocation syntax). You do not have the ability to call the tools listed above in this context. Simply tell the user to use a DM or the Agents tab.
 
 {{end}}
 


### PR DESCRIPTION
#### Summary
- Disable channel plugin tool-calling for automated mention invokers to avoid stuck approval flows.
- Preserve native web search behavior in channels when that setting is enabled.
- Add table-driven tests for automated invoker detection and allow-tools decisions.

#### Ticket Link
- None

#### Screenshots
<img width="551" height="539" alt="image" src="https://github.com/user-attachments/assets/9348f5c7-bc63-449a-b792-a7733c35762c" />


#### Release Note
```release-note
Fixed channel mentions triggered by automated invokers to disable plugin tool-calling approval flows while still allowing native web search in channels when enabled.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced detection of automated message sources, now including OAuth app origins.
  * Improved tool allowance logic for channel mentions with configuration-based control over automation scenarios.

* **Tests**
  * Added comprehensive test coverage for automated source detection and tool allowance behavior across various configurations.

* **Documentation**
  * Clarified system prompts regarding tool applicability boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->