### PR TITLE
Multiple tool call acceptance

### DIFF
--- a/webapp/src/components/tool_approval_set.tsx
+++ b/webapp/src/components/tool_approval_set.tsx
@@ -198,9 +198,7 @@ const ToolApprovalSet: React.FC<ToolApprovalSetProps> = (props) => {
 
         const updatedDecisions = {...toolDecisionsRef.current};
         for (const tool of decisionToolCalls) {
-            if (!Object.hasOwn(updatedDecisions, tool.id)) {
-                updatedDecisions[tool.id] = approved;
-            }
+            updatedDecisions[tool.id] = approved;
         }
         toolDecisionsRef.current = updatedDecisions;
         setToolDecisions(updatedDecisions);
@@ -303,13 +301,19 @@ const ToolApprovalSet: React.FC<ToolApprovalSetProps> = (props) => {
                         />
                     </div>
                     <BatchButtonContainer>
-                        <BatchButton onClick={() => handleBatchDecision(true)}>
+                        <BatchButton
+                            type='button'
+                            onClick={() => handleBatchDecision(true)}
+                        >
                             <FormattedMessage
                                 id='ai.tool_call.accept_all'
                                 defaultMessage='Accept all'
                             />
                         </BatchButton>
-                        <BatchButton onClick={() => handleBatchDecision(false)}>
+                        <BatchButton
+                            type='button'
+                            onClick={() => handleBatchDecision(false)}
+                        >
                             <FormattedMessage
                                 id='ai.tool_call.reject_all'
                                 defaultMessage='Reject all'

--- a/webapp/src/components/tool_card.tsx
+++ b/webapp/src/components/tool_card.tsx
@@ -381,20 +381,6 @@ const ToolCard: React.FC<ToolCardProps> = ({
     const hasLocalDecision = localDecision != null;
 
     const renderDecisionButtons = () => {
-        if (isProcessing) {
-            return (
-                <StatusContainer>
-                    <ProcessingSpinnerContainer>
-                        <ProcessingSpinner/>
-                    </ProcessingSpinnerContainer>
-                    <FormattedMessage
-                        id='ai.tool_call.processing'
-                        defaultMessage='Processing...'
-                    />
-                </StatusContainer>
-            );
-        }
-
         if (hasLocalDecision) {
             return (
                 <StatusContainer>
@@ -410,6 +396,20 @@ const ToolCard: React.FC<ToolCardProps> = ({
                             defaultMessage='Rejected'
                         />
                     )}
+                </StatusContainer>
+            );
+        }
+
+        if (isProcessing) {
+            return (
+                <StatusContainer>
+                    <ProcessingSpinnerContainer>
+                        <ProcessingSpinner/>
+                    </ProcessingSpinnerContainer>
+                    <FormattedMessage
+                        id='ai.tool_call.processing'
+                        defaultMessage='Processing...'
+                    />
                 </StatusContainer>
             );
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
This PR fixes a bug where accepting multiple tool calls lacked immediate visual feedback and could suffer from stale closure issues with rapid clicks.

The changes introduce:
- Immediate "Accepted"/"Rejected" feedback on individual tool cards when a decision is made.
- "Accept all" and "Reject all" batch buttons in the status bar for multi-tool scenarios.
- A ref to prevent stale closure issues in `handleToolDecision`.
- Refactored decision button rendering to resolve ESLint issues (`no-nested-ternary`, `no-undefined`, `no-negated-condition`).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-67788

#### Screenshots
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/826b5140-6483-4f56-ac49-a8198a08f416" />
<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/257beb58-317c-4c30-83ce-b28df05a8b8d" />



#### Release Note
Fixed a bug where accepting multiple tool calls did not provide immediate visual feedback and could lose decisions with rapid clicks. Added immediate "Accepted"/"Rejected" feedback to individual tool cards and introduced "Accept all"/"Reject all" batch buttons for multi-tool scenarios.

---
<p><a href="https://cursor.com/agents/bc-e6710484-8db9-445d-a08c-ec1ed1c65b8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6710484-8db9-445d-a08c-ec1ed1c65b8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch action controls enabling simultaneous acceptance or rejection of all undecided tools
  * Enhanced tool decision display with real-time status tracking on individual tool cards
  * Improved approval workflow with better decision state visibility and submission handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->