### PR TITLE
Anthropic structured output

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -6,6 +6,7 @@ package anthropic
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -233,6 +234,16 @@ func (a *Anthropic) buildAPIParams(state *messageState) anthropicSDK.MessageNewP
 	if !state.config.ReasoningDisabled {
 		if thinkingConfig, ok := a.calculateThinkingConfig(state.config.MaxGeneratedTokens); ok {
 			params.Thinking = thinkingConfig
+		}
+	}
+
+	if state.config.JSONOutputFormat != nil {
+		if schemaMap, err := jsonSchemaToMap(state.config.JSONOutputFormat); err == nil {
+			params.OutputConfig = anthropicSDK.OutputConfigParam{
+				Format: anthropicSDK.JSONOutputFormatParam{
+					Schema: schemaMap,
+				},
+			}
 		}
 	}
 
@@ -535,6 +546,26 @@ func convertTools(tools []llm.Tool) []anthropicSDK.ToolUnionParam {
 		}
 	}
 	return converted
+}
+
+func jsonSchemaToMap(schema *jsonschema.Schema) (map[string]any, error) {
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal JSON schema: %w", err)
+	}
+
+	// An empty schema may serialize to "true" (valid JSON Schema boolean form).
+	// Only object-shaped schemas are useful for structured output.
+	if len(data) == 0 || data[0] != '{' {
+		return nil, fmt.Errorf("JSON schema did not serialize to an object")
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON schema: %w", err)
+	}
+
+	return result, nil
 }
 
 func extractInputSchema(schema interface{}) anthropicSDK.ToolInputSchemaParam {

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	anthropicSDK "github.com/anthropics/anthropic-sdk-go"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -679,6 +680,124 @@ func TestThinkingBudgetConfiguration(t *testing.T) {
 			assert.True(t, ok, "Thinking config should be enabled")
 			require.NotNil(t, thinkingConfig.OfEnabled, "Thinking config should have OfEnabled set")
 			assert.Equal(t, tt.expectedBudget, thinkingConfig.OfEnabled.BudgetTokens, "Thinking budget should match expected value")
+		})
+	}
+}
+
+func TestJsonSchemaToMap(t *testing.T) {
+	tests := []struct {
+		name       string
+		schema     *jsonschema.Schema
+		wantErr    bool
+		wantFields []string
+	}{
+		{
+			name:    "empty schema returns error (serializes to boolean true)",
+			schema:  &jsonschema.Schema{},
+			wantErr: true,
+		},
+		{
+			name: "schema with properties",
+			schema: func() *jsonschema.Schema {
+				s := &jsonschema.Schema{}
+				s.Properties = map[string]*jsonschema.Schema{
+					"name": {},
+				}
+				return s
+			}(),
+			wantErr:    false,
+			wantFields: []string{"properties"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := jsonSchemaToMap(tt.schema)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			for _, field := range tt.wantFields {
+				assert.Contains(t, result, field)
+			}
+		})
+	}
+}
+
+type TestOutputFormat struct {
+	Score   int    `json:"score" jsonschema:"Score from 1 to 10"`
+	Summary string `json:"summary" jsonschema:"Brief summary of the output"`
+}
+
+func TestBuildAPIParamsStructuredOutput(t *testing.T) {
+	tests := []struct {
+		name               string
+		config             llm.LanguageModelConfig
+		expectOutputConfig bool
+	}{
+		{
+			name: "no JSON output format",
+			config: llm.LanguageModelConfig{
+				Model:              "claude-sonnet-4-20250514",
+				MaxGeneratedTokens: 1024,
+			},
+			expectOutputConfig: false,
+		},
+		{
+			name: "with JSON output format from struct",
+			config: llm.LanguageModelConfig{
+				Model:              "claude-sonnet-4-20250514",
+				MaxGeneratedTokens: 1024,
+				JSONOutputFormat:   llm.NewJSONSchemaFromStruct[TestOutputFormat](),
+			},
+			expectOutputConfig: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Anthropic{}
+			state := &messageState{
+				config: tt.config,
+				messages: []anthropicSDK.MessageParam{
+					{
+						Role: anthropicSDK.MessageParamRoleUser,
+						Content: []anthropicSDK.ContentBlockParamUnion{
+							anthropicSDK.NewTextBlock("test"),
+						},
+					},
+				},
+			}
+
+			params := a.buildAPIParams(state)
+
+			if !tt.expectOutputConfig {
+				assert.Empty(t, params.OutputConfig.Format.Schema, "OutputConfig.Format.Schema should be empty")
+				return
+			}
+
+			require.NotEmpty(t, params.OutputConfig.Format.Schema, "OutputConfig.Format.Schema should be set")
+
+			schemaMap := params.OutputConfig.Format.Schema
+			assert.Equal(t, "object", schemaMap["type"])
+			properties, ok := schemaMap["properties"].(map[string]any)
+			require.True(t, ok, "schema should have properties")
+			assert.Contains(t, properties, "score")
+			assert.Contains(t, properties, "summary")
+
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+
+			var raw map[string]any
+			require.NoError(t, json.Unmarshal(paramsJSON, &raw))
+			outputConfig, ok := raw["output_config"].(map[string]any)
+			require.True(t, ok, "serialized params should contain output_config")
+			format, ok := outputConfig["format"].(map[string]any)
+			require.True(t, ok, "output_config should contain format")
+			assert.Equal(t, "json_schema", format["type"])
+			assert.NotNil(t, format["schema"])
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.6
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/andygrunwald/go-jira v1.16.0
-	github.com/anthropics/anthropic-sdk-go v1.4.0
+	github.com/anthropics/anthropic-sdk-go v1.26.0
 	github.com/asticode/go-astisub v0.34.0
 	github.com/aws/aws-sdk-go-v2 v1.39.5
 	github.com/aws/aws-sdk-go-v2/config v1.31.16
@@ -177,6 +177,7 @@ require (
 	golang.org/x/arch v0.15.0 // indirect
 	golang.org/x/crypto v0.43.0 // indirect
 	golang.org/x/mod v0.29.0 // indirect
+	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251007200510-49b9836ed3ff // indirect
 	google.golang.org/grpc v1.76.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmg
 github.com/andygrunwald/go-jira v1.16.0 h1:PU7C7Fkk5L96JvPc6vDVIrd99vdPnYudHu4ju2c2ikQ=
 github.com/andygrunwald/go-jira v1.16.0/go.mod h1:UQH4IBVxIYWbgagc0LF/k9FRs9xjIiQ8hIcC6HfLwFU=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/anthropics/anthropic-sdk-go v1.4.0 h1:fU1jKxYbQdQDiEXCxeW5XZRIOwKevn/PMg8Ay1nnUx0=
-github.com/anthropics/anthropic-sdk-go v1.4.0/go.mod h1:AapDW22irxK2PSumZiQXYUFvsdQgkwIWlpESweWZI/c=
+github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
+github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/asticode/go-astikit v0.20.0/go.mod h1:h4ly7idim1tNhaVkdVBeXQZEE3L0xblP7fCWbgwipF0=
@@ -126,6 +126,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/docker v27.1.1+incompatible h1:hO/M4MtV36kzKldqnA37IWhebRA+LnqqcqDja6kVaKY=
 github.com/docker/docker v27.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Upgraded `github.com/anthropics/anthropic-sdk-go` to v1.26.0 to enable structured output. Implemented structured output support in the Anthropic connector by converting `JSONOutputFormat` to the Anthropic API's `OutputConfig` format. Added a `jsonSchemaToMap` helper and comprehensive unit tests.

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
```release-note
Added structured output support for the Anthropic LLM connector, allowing models to generate responses conforming to a specified JSON schema. This required upgrading the `anthropic-sdk-go` to v1.26.0.
```

---
<p><a href="https://cursor.com/agents/bc-3f8272f0-98ad-4b64-b8ad-58fa9b1dcbf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f8272f0-98ad-4b64-b8ad-58fa9b1dcbf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->