### PR TITLE
feat: add OpenClaw as supported LLM provider

### DIFF
--- a/llm/configuration.go
+++ b/llm/configuration.go
@@ -145,6 +145,9 @@ func IsValidService(service ServiceConfig) bool {
 		return service.APIKey != ""
 	case ServiceTypeScale:
 		return service.APIKey != "" && service.APIURL != ""
+	case ServiceTypeOpenClaw:
+		// OpenClaw requires an API URL (the gateway address) and an API key (gateway auth token)
+		return service.APIURL != ""
 	default:
 		return false
 	}

--- a/llm/providers.go
+++ b/llm/providers.go
@@ -30,6 +30,9 @@ type OpenAICompatibleProvider struct {
 
 // openAICompatibleProviders is the registry of known OpenAI-compatible providers.
 var openAICompatibleProviders = map[string]OpenAICompatibleProvider{
+	ServiceTypeOpenClaw: {
+		DefaultModel: "anthropic/claude-sonnet-4-6",
+	},
 	ServiceTypeCohere: {
 		FixedAPIURL: "https://api.cohere.ai/compatibility/v1",
 	},

--- a/llm/providers_test.go
+++ b/llm/providers_test.go
@@ -30,6 +30,11 @@ func TestGetOpenAICompatibleProvider(t *testing.T) {
 			wantFound:   true,
 		},
 		{
+			name:        "openclaw returns provider",
+			serviceType: ServiceTypeOpenClaw,
+			wantFound:   true,
+		},
+		{
 			name:        "unregistered type returns false",
 			serviceType: "nonexistent",
 			wantFound:   false,
@@ -58,6 +63,29 @@ func TestGetOpenAICompatibleProvider(t *testing.T) {
 				t.Fatalf("GetOpenAICompatibleProvider(%q) found=%v, want %v", tc.serviceType, ok, tc.wantFound)
 			}
 		})
+	}
+}
+
+func TestOpenClawProviderConfig(t *testing.T) {
+	p, ok := GetOpenAICompatibleProvider(ServiceTypeOpenClaw)
+	if !ok {
+		t.Fatal("OpenClaw provider not found in registry")
+	}
+
+	if p.DefaultModel != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("DefaultModel = %q, want %q", p.DefaultModel, "anthropic/claude-sonnet-4-6")
+	}
+
+	if p.FixedAPIURL != "" {
+		t.Errorf("FixedAPIURL = %q, want empty (user-configurable URL)", p.FixedAPIURL)
+	}
+
+	if p.CreateTransport != nil {
+		t.Error("expected CreateTransport to be nil (standard Bearer auth)")
+	}
+
+	if p.DisableStreamOptions {
+		t.Error("expected DisableStreamOptions to be false for OpenClaw")
 	}
 }
 

--- a/llm/service_types.go
+++ b/llm/service_types.go
@@ -13,4 +13,5 @@ const (
 	ServiceTypeBedrock          = "bedrock"
 	ServiceTypeMistral          = "mistral"
 	ServiceTypeScale            = "scale"
+	ServiceTypeOpenClaw         = "openclaw"
 )

--- a/webapp/src/components/system_console/service.tsx
+++ b/webapp/src/components/system_console/service.tsx
@@ -42,6 +42,7 @@ const mapServiceTypeToDisplayName = new Map<string, string>([
     ['cohere', 'Cohere'],
     ['mistral', 'Mistral'],
     ['asage', 'asksage (Experimental)'],
+    ['openclaw', 'OpenClaw'],
 ]);
 
 function scaleAIToDisplayName(intl: IntlShape): string {
@@ -68,7 +69,7 @@ type ServiceFieldsProps = {
 const ServiceFields = (props: ServiceFieldsProps) => {
     const type = props.service.type;
     const intl = useIntl();
-    const isOpenAIType = type === 'openai' || type === 'openaicompatible' || type === 'azure' || type === 'cohere' || type === 'mistral' || type === 'scale';
+    const isOpenAIType = type === 'openai' || type === 'openaicompatible' || type === 'azure' || type === 'cohere' || type === 'mistral' || type === 'scale' || type === 'openclaw';
     const isCohere = type === 'cohere';
     const isMistral = type === 'mistral';
     const isScale = type === 'scale';
@@ -153,8 +154,9 @@ const ServiceFields = (props: ServiceFieldsProps) => {
                 <SelectionItemOption value='mistral'>{'Mistral'}</SelectionItemOption>
                 <SelectionItemOption value='scale'>{scaleAIToDisplayName(intl)}</SelectionItemOption>
                 <SelectionItemOption value='asage'>{'asksage (Experimental)'}</SelectionItemOption>
+                <SelectionItemOption value='openclaw'>{'OpenClaw'}</SelectionItemOption>
             </SelectionItem>
-            {(type === 'openaicompatible' || type === 'azure' || type === 'asage' || type === 'scale') && (
+            {(type === 'openaicompatible' || type === 'azure' || type === 'asage' || type === 'scale' || type === 'openclaw') && (
                 <TextItem
                     label={intl.formatMessage({defaultMessage: 'API URL'})}
                     value={props.service.apiURL}


### PR DESCRIPTION
## Summary

Adds [OpenClaw](https://openclaw.ai) as a first-class supported LLM provider type in the Agents plugin.

OpenClaw is an open-source personal AI gateway that exposes an OpenAI-compatible HTTP API. This PR allows users to point the Agents plugin at their local (or remote) OpenClaw gateway as the AI backend.

## Changes

- **`llm/service_types.go`** — adds `ServiceTypeOpenClaw = "openclaw"` constant
- **`llm/providers.go`** — registers OpenClaw in the `openAICompatibleProviders` map with default model `anthropic/claude-sonnet-4-6` and a user-configurable API URL (no fixed URL, same pattern as `openaicompatible`)
- **`llm/configuration.go`** — adds `openclaw` to the `IsValidService` switch; requires only `APIURL` (API key is optional since gateway auth is configured separately)
- **`webapp/src/components/system_console/service.tsx`** — adds OpenClaw to the provider display name map, dropdown, `isOpenAIType` check, and API URL field visibility
- **`llm/providers_test.go`** — adds `TestOpenClawProviderConfig` unit test

## Configuration

In the plugin admin console, select **OpenClaw** as the service type and set:
- **API URL**: your OpenClaw gateway's OpenAI-compatible endpoint (e.g. `http://localhost:18789/v1`)
- **API Key**: your OpenClaw gateway auth token
- **Default Model**: `openclaw:main` (routes to the main agent) or any model supported by your gateway

The `/v1/chat/completions` endpoint must be enabled in OpenClaw config:
```json5
{ gateway: { http: { endpoints: { chatCompletions: { enabled: true } } } } }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenClaw as a new supported LLM service provider.
  * OpenClaw is now available as a selectable option in service configuration settings.
  * Requires API URL configuration for OpenClaw integration.
  * OpenClaw defaults to using Claude Sonnet 4.6 model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->