### PR TITLE
Fix Agents tour dismissal outside the tooltip

### DIFF
--- a/e2e/tests/agents-tour/basic-flow.spec.ts
+++ b/e2e/tests/agents-tour/basic-flow.spec.ts
@@ -1,7 +1,7 @@
 // spec: specs/agents-tour.md
 // seed: tests/seed.spec.ts
 
-import { test, expect } from '@playwright/test';
+import { test, expect, Locator, Page } from '@playwright/test';
 
 import RunContainer from 'helpers/plugincontainer';
 import MattermostContainer from 'helpers/mmcontainer';
@@ -19,6 +19,40 @@ const TOUR_FINISHED_VALUE = '999';
 
 let mattermost: MattermostContainer;
 let openAIMock: OpenAIMockContainer;
+
+const getTourPreferenceValue = async () => {
+    const client = await mattermost.getClient(username, password);
+    const prefs = await client.getMyPreferences();
+    const tourPref = prefs.find(
+        (p: { category: string; name: string; value: string }) =>
+            p.category === TOUR_PREFERENCE_CATEGORY && p.name === TOUR_PREFERENCE_NAME
+    );
+
+    return tourPref?.value;
+};
+
+const openTour = async (page: Page): Promise<{pulsatingDot: Locator; tourPopover: Locator}> => {
+    const pulsatingDot = page.getByTestId('agents-tour-dot').or(page.locator('[class*="DotContainer"]').first());
+    await expect(pulsatingDot).toBeVisible({timeout: 10000});
+    await pulsatingDot.click();
+
+    const tourPopover = page.locator('.tour-tip-tippy');
+    await expect(tourPopover).toBeVisible({timeout: 5000});
+    await expect(page.getByText('Agents are ready to help')).toBeVisible();
+    await expect(page.getByText('AI agents now live here')).toBeVisible();
+
+    return {pulsatingDot, tourPopover};
+};
+
+const expectTourFinished = async (page: Page, pulsatingDot: Locator, tourPopover: Locator) => {
+    await expect(tourPopover).not.toBeVisible({timeout: 5000});
+    expect(await getTourPreferenceValue()).toBe(TOUR_FINISHED_VALUE);
+
+    await page.reload();
+    await page.getByTestId('channel_view').waitFor({state: 'visible', timeout: 30000});
+    await expect(pulsatingDot).not.toBeVisible({timeout: 5000});
+    await expect(tourPopover).not.toBeVisible();
+};
 
 // Setup for all tests in the file
 test.beforeAll(async () => {
@@ -55,19 +89,7 @@ test.describe('Agents Tour - Basic Flow', () => {
         await mmPage.login(mattermost.url(), username, password);
         await page.getByTestId('channel_view').waitFor({ state: 'visible', timeout: 30000 });
 
-        const pulsatingDot = page.getByTestId('agents-tour-dot').or(page.locator('[class*="DotContainer"]').first());
-        await expect(pulsatingDot).toBeVisible({ timeout: 10000 });
-
-        // 3. Click on the pulsating dot to open the tour popover
-        await pulsatingDot.click();
-
-        // 4. Wait for tour popover to appear and verify content
-        const tourPopover = page.locator('.tour-tip-tippy');
-        await expect(tourPopover).toBeVisible({ timeout: 5000 });
-
-        // Verify meaningful content is displayed
-        await expect(page.getByText('Agents are ready to help')).toBeVisible();
-        await expect(page.getByText('AI agents now live here')).toBeVisible();
+        const {pulsatingDot, tourPopover} = await openTour(page);
 
         const overlay = page.getByTestId('agents-tour-overlay').or(page.locator('[class*="TourOverlay"]'));
         await expect(overlay).toBeVisible();
@@ -78,26 +100,43 @@ test.describe('Agents Tour - Basic Flow', () => {
         // 7. Verify popover disappears immediately
         await expect(tourPopover).not.toBeVisible({ timeout: 5000 });
 
-        // 8. Verify preference was saved via API
-        const client = await mattermost.getClient(username, password);
-        const user = await client.getMe();
-        const prefs = await client.getMyPreferences();
-        const tourPref = prefs.find(
-            (p: { category: string; name: string; value: string }) =>
-                p.category === TOUR_PREFERENCE_CATEGORY && p.name === TOUR_PREFERENCE_NAME
-        );
-        expect(tourPref?.value).toBe(TOUR_FINISHED_VALUE);
-
-        // 9. Reload page and verify tour does NOT reappear
-        await page.reload();
-        await page.getByTestId('channel_view').waitFor({ state: 'visible', timeout: 30000 });
-
-        // Wait for any delayed rendering, then verify no tour elements
-        await expect(pulsatingDot).not.toBeVisible({ timeout: 5000 });
-        await expect(tourPopover).not.toBeVisible();
+        await expectTourFinished(page, pulsatingDot, tourPopover);
 
         // 10. Verify Agents icon is still functional
         const appBarIcon = page.locator('#app-bar-icon-mattermost-ai');
         await expect(appBarIcon).toBeVisible();
+    });
+
+    test('Dismiss via outside click finishes the tour', async ({page}) => {
+        const mmPage = new MattermostPage(page);
+        await mmPage.login(mattermost.url(), username, password);
+        await page.getByTestId('channel_view').waitFor({state: 'visible', timeout: 30000});
+
+        const {pulsatingDot, tourPopover} = await openTour(page);
+
+        // Dispatching on the body exercises Tippy's outside-click handler.
+        await page.evaluate(() => {
+            for (const type of ['mousedown', 'mouseup', 'click']) {
+                document.body.dispatchEvent(new MouseEvent(type, {
+                    bubbles: true,
+                    cancelable: true,
+                    view: window,
+                }));
+            }
+        });
+
+        await expectTourFinished(page, pulsatingDot, tourPopover);
+    });
+
+    test('Dismiss via Escape finishes the tour', async ({page}) => {
+        const mmPage = new MattermostPage(page);
+        await mmPage.login(mattermost.url(), username, password);
+        await page.getByTestId('channel_view').waitFor({state: 'visible', timeout: 30000});
+
+        const {pulsatingDot, tourPopover} = await openTour(page);
+
+        await page.keyboard.press('Escape');
+
+        await expectTourFinished(page, pulsatingDot, tourPopover);
     });
 });

--- a/webapp/src/components/tutorial/tutorial_tour_tip.tsx
+++ b/webapp/src/components/tutorial/tutorial_tour_tip.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import ReactDOM from 'react-dom';
 import Tippy from '@tippyjs/react';
 import styled, {createGlobalStyle} from 'styled-components';
@@ -165,7 +165,7 @@ const TutorialTourTip: React.FC<Props> = ({
     onFinish,
 }) => {
     const triggerRef = useRef<HTMLDivElement>(null);
-    const {show, setShow, handleOpen, handleDismiss} = useTourManager(
+    const {show, handleOpen, handleDismiss} = useTourManager(
         tutorialCategory,
         onFinish,
     );
@@ -186,6 +186,26 @@ const TutorialTourTip: React.FC<Props> = ({
             </TourTipContent>
         </TourTipContainer>
     );
+
+    useEffect(() => {
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            handleDismiss();
+        };
+
+        if (show) {
+            document.addEventListener('keydown', handleEscape, true);
+        }
+
+        return () => {
+            document.removeEventListener('keydown', handleEscape, true);
+        };
+    }, [show, handleDismiss]);
 
     return (
         <>
@@ -220,7 +240,9 @@ const TutorialTourTip: React.FC<Props> = ({
                     reference={triggerRef}
                     interactive={true}
                     appendTo={rootPortal}
-                    onClickOutside={() => setShow(false)}
+                    onClickOutside={() => {
+                        handleDismiss();
+                    }}
                     offset={offset}
                     placement={placement}
                     arrow={true}


### PR DESCRIPTION
#### Summary
Fixes the Agents Apps Bar tutorial tip so outside clicks and Escape follow the same persistent dismissal path as the close button, removing the dot and marking the tour as complete.
Adds Chromium Playwright coverage for outside-click and Escape dismissals.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67884

#### Screenshots
| before | after |
|--------|-------|
| ![before](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/mm-67884-bug-fix-38d8/before.png) | ![after](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/mm-67884-bug-fix-38d8/after.png) |

#### Release Note
```release-note
Fixed the Agents Apps Bar tutorial tip so dismissing it with an outside click or Escape removes the dot and marks the tour as completed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Escape key support to dismiss the Agents Tour, providing users with an additional keyboard shortcut for closing the tour interface.
* **Tests**
  * Extended test coverage for tour dismissal scenarios, validating dismissal behavior triggered by both outside-click and Escape key interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->