### PR TITLE
feat: change tool approval message when no parameters are required

### DIFF
--- a/webapp/src/components/tool_card.tsx
+++ b/webapp/src/components/tool_card.tsx
@@ -388,7 +388,9 @@ const ToolCard: React.FC<ToolCardProps> = ({
         }
 
         const argumentsValue = tool.arguments ?? {};
-        const argumentsMarkdown = `\`\`\`json\n${JSON.stringify(argumentsValue, null, 2)}\n\`\`\``;
+        const isEmpty = typeof argumentsValue === 'object' && !Array.isArray(argumentsValue) && Object.keys(argumentsValue).length === 0;
+        const content = isEmpty ? 'No parameters required' : JSON.stringify(argumentsValue, null, 2);
+        const argumentsMarkdown = `\`\`\`json\n${content}\n\`\`\``;
         return messageHtmlToComponent(
             formatText(argumentsMarkdown, markdownOptions),
             messageHtmlToComponentOptions,

--- a/webapp/src/components/tool_card.tsx
+++ b/webapp/src/components/tool_card.tsx
@@ -389,13 +389,15 @@ const ToolCard: React.FC<ToolCardProps> = ({
 
         const argumentsValue = tool.arguments ?? {};
         const isEmpty = typeof argumentsValue === 'object' && !Array.isArray(argumentsValue) && Object.keys(argumentsValue).length === 0;
-        const content = isEmpty ? 'No parameters required' : JSON.stringify(argumentsValue, null, 2);
+        const content = isEmpty ?
+            formatMessage({id: 'ai.tool_call.no_parameters_required', defaultMessage: 'No parameters required'}) :
+            JSON.stringify(argumentsValue, null, 2);
         const argumentsMarkdown = `\`\`\`json\n${content}\n\`\`\``;
         return messageHtmlToComponent(
             formatText(argumentsMarkdown, markdownOptions),
             messageHtmlToComponentOptions,
         );
-    }, [showArguments, tool.arguments]);
+    }, [showArguments, tool.arguments, formatMessage]);
 
     const hasLocalDecision = localDecision != null;
 


### PR DESCRIPTION
## Summary
- Display "No parameters required" inside the tool call code block instead of an empty JSON object (`{}`) when a tool call has no arguments
- Makes it clear the empty state is intentional and the tool is not broken

<img width="390" height="170" alt="Screenshot 2026-04-17 at 09 42 25" src="https://github.com/user-attachments/assets/58c23ae8-a94f-45f8-88df-0c5d47deee35" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tool parameter display has been improved: tools with no parameters now show a clear, localized message instead of empty braces
  * Fixed parameter display updates to correctly reflect localization preferences
  * Enhanced how tool information is rendered to better communicate when no parameters are required

<!-- end of auto-generated comment: release notes by coderabbit.ai -->