### PR TITLE
MCP: prefer static Authorization header over stored OAuth tokens

### DIFF
--- a/mcp/http_client.go
+++ b/mcp/http_client.go
@@ -3,7 +3,10 @@
 
 package mcp
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
 
 // headerTransport is a custom RoundTripper that adds headers to requests
 type headerTransport struct {
@@ -23,15 +26,28 @@ func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.base.RoundTrip(req)
 }
 
+// authorizationHeaderInCustomHeaders is true when MCP server custom headers
+// include Authorization. Then oauth2.Transport must not use KV OAuth tokens
+// (e.g. after switching from OAuth to API-key-only auth).
+func authorizationHeaderInCustomHeaders(headers map[string]string) bool {
+	for k := range headers {
+		if strings.EqualFold(k, "Authorization") {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Client) httpClientForMCP(headers map[string]string) *http.Client {
 	// Wrap with discovery-aware transport for 401 handling
 	authenticationTransport := &authenticationTransport{
-		userID:      c.userID,
-		serverName:  c.config.Name,
-		manager:     c.oauthManager,
-		serverURL:   c.config.BaseURL,
-		staticCreds: staticOAuthCreds(c.config),
-		base:        c.httpClient.Transport,
+		userID:                          c.userID,
+		serverName:                      c.config.Name,
+		manager:                         c.oauthManager,
+		serverURL:                       c.config.BaseURL,
+		staticCreds:                     staticOAuthCreds(c.config),
+		base:                            c.httpClient.Transport,
+		preferStaticAuthorizationHeader: authorizationHeaderInCustomHeaders(headers),
 	}
 
 	// Create HTTP client with discovery-aware transport

--- a/mcp/http_client_test.go
+++ b/mcp/http_client_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthorizationHeaderInCustomHeaders(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{name: "nil", headers: nil, want: false},
+		{name: "empty", headers: map[string]string{}, want: false},
+		{name: "Authorization", headers: map[string]string{"Authorization": "Bearer x"}, want: true},
+		{name: "lowercase", headers: map[string]string{"authorization": "Bearer x"}, want: true},
+		{name: "other only", headers: map[string]string{"X-Custom": "1"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, authorizationHeaderInCustomHeaders(tt.headers))
+		})
+	}
+}

--- a/mcp/oauth_transport.go
+++ b/mcp/oauth_transport.go
@@ -20,6 +20,8 @@ type authenticationTransport struct {
 	manager     *OAuthManager
 	staticCreds *StaticOAuthCredentials
 	base        http.RoundTripper
+	// If true, skip oauth2.Transport; see authorizationHeaderInCustomHeaders.
+	preferStaticAuthorizationHeader bool
 }
 
 type mcpUnauthorized struct {
@@ -60,15 +62,18 @@ func (t *authenticationTransport) RoundTrip(req *http.Request) (*http.Response, 
 		}()
 	}
 
-	token, err := t.manager.loadToken(t.userID, t.serverName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load token: %w", err)
+	var token *oauth2.Token
+	var err error
+	if !t.preferStaticAuthorizationHeader {
+		token, err = t.manager.loadToken(t.userID, t.serverName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load token: %w", err)
+		}
 	}
 
 	transport := t.base
 
-	// Include the token if found
-	if token != nil {
+	if !t.preferStaticAuthorizationHeader && token != nil {
 		oauthConfig, configErr := t.manager.createOAuthConfig(req.Context(), t.serverURL, "", t.staticCreds)
 		if configErr != nil {
 			return nil, fmt.Errorf("failed to create OAuth config: %w", configErr)


### PR DESCRIPTION
## Summary

When an MCP server is configured with a **custom `Authorization` header** (e.g. Outline API key `ol_api_*`), the HTTP client must not wrap requests with `oauth2.Transport` using a **previously stored** per-user OAuth token from the plugin KV store.

Without this, switching from **OAuth** to **token-only** auth leaves stale `mcp_oauth_token_v1_*` rows; the plugin still calls `createOAuthConfig` / token refresh on every request, which can fail (e.g. DCR rate limits) even though the admin intends to use only the static header.

## Changes

- If custom headers include `Authorization` (case-insensitive), skip loading the OAuth token and do not wrap with `oauth2.Transport`.
- Add `TestAuthorizationHeaderInCustomHeaders`.

## Test steps

1. Configure MCP with OAuth, complete flow (token in KV).
2. Add `Authorization: Bearer <api key>` in custom headers and remove OAuth client fields if any.
3. Requests should succeed using the header without requiring manual KV cleanup.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced authorization header handling to detect and respect custom Authorization headers (case-insensitive) in HTTP requests.
  * Updated OAuth token behavior to conditionally apply based on whether a static Authorization header is provided, preventing conflicts and improving request handling flexibility.
  * Added comprehensive test coverage for authorization header detection across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->