### PR TITLE
Add configurable bot account for embedded MCP server automated triggers

### DIFF
--- a/config/mcp_config.go
+++ b/config/mcp_config.go
@@ -33,6 +33,14 @@ func IsToolPolicyAutoRunEverywhere(policy string) bool {
 type MCPEmbeddedServerConfig struct {
 	Enabled     bool            `json:"enabled"`
 	ToolConfigs []MCPToolConfig `json:"tool_configs,omitempty"`
+
+	// AutomatedTriggerBotUsername is the username of the bot account whose identity is used
+	// when an automated invoker (webhook, bot, plugin, OAuth app) triggers an agent and
+	// the embedded Mattermost MCP server needs to authenticate API calls.
+	// Anything the selected bot can access (channels, teams, private or otherwise) will be
+	// accessible to the automated trigger. If empty, embedded MCP tools are unavailable
+	// for automated triggers.
+	AutomatedTriggerBotUsername string `json:"automatedTriggerBotUsername,omitempty"`
 }
 
 // MCPConfig contains the configuration for the MCP servers

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -196,14 +196,20 @@ func (m *ClientManager) GetToolsForUser(userID string, isAutomatedInvoker bool) 
 	// Get or create client for this user (connects to remote servers only)
 	userClient, mcpErrors := m.getClientForUser(userID, isAutomatedInvoker)
 
-	// Connect to embedded server using a dedicated per-user session (stored/created in KV)
+	// Connect to embedded server using a dedicated per-user session (stored/created in KV).
+	// For automated invokers, use the admin-configured bot account so that only what
+	// that specific bot can access (channels, teams) is available to the trigger.
+	// If no bot is configured, embedded MCP tools are unavailable for automated triggers.
 	if m.embeddedClient != nil && m.config.EmbeddedServer.Enabled {
-		ensuredSessionID, ensureErr := m.ensureEmbeddedSessionID(userID)
-		if ensureErr != nil {
-			m.log.Debug("Failed to ensure embedded session for user - embedded MCP tools will not be available", "userID", userID, "error", ensureErr)
-		} else if ensuredSessionID != "" {
-			if embeddedErr := userClient.ConnectToEmbeddedServerIfAvailable(ensuredSessionID, m.embeddedClient, m.config.EmbeddedServer); embeddedErr != nil {
-				m.log.Debug("Failed to connect to embedded server for user - embedded MCP tools will not be available", "userID", userID, "sessionID", ensuredSessionID, "error", embeddedErr)
+		embeddedUserID, connectEmbedded := m.resolveEmbeddedUserID(userID, isAutomatedInvoker)
+		if connectEmbedded {
+			ensuredSessionID, ensureErr := m.ensureEmbeddedSessionID(embeddedUserID)
+			if ensureErr != nil {
+				m.log.Debug("Failed to ensure embedded session for user - embedded MCP tools will not be available", "userID", embeddedUserID, "error", ensureErr)
+			} else if ensuredSessionID != "" {
+				if embeddedErr := userClient.ConnectToEmbeddedServerIfAvailable(ensuredSessionID, m.embeddedClient, m.config.EmbeddedServer); embeddedErr != nil {
+					m.log.Debug("Failed to connect to embedded server for user - embedded MCP tools will not be available", "userID", embeddedUserID, "sessionID", ensuredSessionID, "error", embeddedErr)
+				}
 			}
 		}
 	}
@@ -212,6 +218,29 @@ func (m *ClientManager) GetToolsForUser(userID string, isAutomatedInvoker bool) 
 	rawTools := userClient.GetTools()
 	filtered := filterToolsByConfig(rawTools, m.config, m.embeddedClient)
 	return filtered, mcpErrors
+}
+
+// resolveEmbeddedUserID determines which Mattermost user ID should be used for
+// the embedded MCP server session. For human invokers, the original userID is used.
+// For automated invokers, the admin-configured bot account is resolved; if not
+// configured, embedded MCP tools are skipped for that invocation.
+func (m *ClientManager) resolveEmbeddedUserID(userID string, isAutomatedInvoker bool) (string, bool) {
+	if !isAutomatedInvoker {
+		return userID, true
+	}
+
+	username := m.config.EmbeddedServer.AutomatedTriggerBotUsername
+	if username == "" {
+		m.log.Debug("Embedded MCP tools unavailable for automated trigger: no automatedTriggerBotUsername configured", "originalUserID", userID)
+		return "", false
+	}
+
+	user, err := m.pluginAPI.User.GetByUsername(username)
+	if err != nil {
+		m.log.Error("Failed to resolve automatedTriggerBotUsername - embedded MCP tools unavailable for automated trigger", "username", username, "error", err)
+		return "", false
+	}
+	return user.Id, true
 }
 
 // ProcessOAuthCallback processes the OAuth callback for a user

--- a/webapp/src/components/system_console/config.tsx
+++ b/webapp/src/components/system_console/config.tsx
@@ -426,6 +426,7 @@ const Config = (props: Props) => {
             >
                 <MCPServers
                     mcpConfig={mcpConfig}
+                    bots={(value.bots ?? []).map((b) => ({name: b.name, displayName: b.displayName}))}
                     onChange={(config) => {
                         // Ensure we're creating a valid structure for the server configuration
                         const updatedConfig = {

--- a/webapp/src/components/system_console/item.tsx
+++ b/webapp/src/components/system_console/item.tsx
@@ -59,7 +59,7 @@ export const TextItem = (props: TextItemProps) => {
 };
 
 export type SelectionItemProps = {
-    label: string
+    label: React.ReactNode
     value: string
     onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
     children: React.ReactNode

--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -12,7 +12,7 @@ import {getMCPTools, getVettedToolSeed} from '../../client';
 
 import MCPToolsViewer, {MCPToolsResponse} from './mcp_tools_viewer';
 
-import {BooleanItem, ItemList, TextItem} from './item';
+import {BooleanItem, ItemList, SelectionItem, SelectionItemOption, TextItem} from './item';
 
 export type MCPToolConfig = {
     name: string;
@@ -34,6 +34,7 @@ export type MCPServerConfig = {
 export type MCPEmbeddedServerConfig = {
     enabled: boolean;
     tool_configs?: MCPToolConfig[];
+    automatedTriggerBotUsername?: string;
 };
 
 export type MCPConfig = {
@@ -44,8 +45,14 @@ export type MCPConfig = {
     idleTimeoutMinutes?: number;
 };
 
+type BotOption = {
+    name: string;
+    displayName: string;
+};
+
 type Props = {
     mcpConfig: MCPConfig;
+    bots: BotOption[];
     onChange: (config: MCPConfig) => void;
 };
 
@@ -453,7 +460,7 @@ const MCPServer = ({
 };
 
 // Main component for MCP servers configuration
-const MCPServers = ({mcpConfig, onChange}: Props) => {
+const MCPServers = ({mcpConfig, bots, onChange}: Props) => {
     const intl = useIntl();
     const [activeTab, setActiveTab] = useState<'config' | 'tools'>('config');
     const [preloadedToolsData, setPreloadedToolsData] = useState<MCPToolsResponse | null>(null);
@@ -664,6 +671,32 @@ const MCPServers = ({mcpConfig, onChange}: Props) => {
                                         })}
                                         helpText={intl.formatMessage({defaultMessage: 'Enable the built-in Mattermost MCP server that provides AI tools for reading/creating channels, posts, searching content, and managing users and teams. Tools operate with the permissions of the user who invokes them.'})}
                                     />
+                                    {config.embeddedServer.enabled && (
+                                        <SelectionItem
+                                            label={intl.formatMessage({defaultMessage: 'Automated Trigger Bot Account'})}
+                                            value={config.embeddedServer.automatedTriggerBotUsername || ''}
+                                            onChange={(e) => onChange({
+                                                ...config,
+                                                embeddedServer: {
+                                                    ...config.embeddedServer,
+                                                    automatedTriggerBotUsername: e.target.value || undefined,
+                                                },
+                                            })}
+                                            helptext={intl.formatMessage({defaultMessage: 'The bot account used to authenticate with the Mattermost MCP server when an agent is triggered by a bot or webhook. Anything the selected bot can access (channels or teams it is a member of, private or otherwise) can then be accessed by the automated trigger. We recommend using your default bot or creating a dedicated one with minimal channel memberships. If not set, embedded Mattermost tools will be unavailable for automated triggers.'})}
+                                        >
+                                            <SelectionItemOption value=''>
+                                                {intl.formatMessage({defaultMessage: '-- None (disable for automated triggers) --'})}
+                                            </SelectionItemOption>
+                                            {bots.map((bot) => (
+                                                <SelectionItemOption
+                                                    key={bot.name}
+                                                    value={bot.name}
+                                                >
+                                                    {bot.displayName} {'(@' + bot.name + ')'}
+                                                </SelectionItemOption>
+                                            ))}
+                                        </SelectionItem>
+                                    )}
                                 </ItemList>
                                 <ServersList>
                                     {!Array.isArray(config.servers) || config.servers.length < 1 ? (

--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -679,7 +679,7 @@ const MCPServers = ({mcpConfig, bots, onChange}: Props) => {
                                                 ...config,
                                                 embeddedServer: {
                                                     ...config.embeddedServer,
-                                                    automatedTriggerBotUsername: e.target.value || undefined,
+                                                    automatedTriggerBotUsername: e.target.value || '',
                                                 },
                                             })}
                                             helptext={intl.formatMessage({defaultMessage: 'The bot account used to authenticate with the Mattermost MCP server when an agent is triggered by a bot or webhook. Anything the selected bot can access (channels or teams it is a member of, private or otherwise) can then be accessed by the automated trigger. We recommend using your default bot or creating a dedicated one with minimal channel memberships. If not set, embedded Mattermost tools will be unavailable for automated triggers.'})}

--- a/webapp/src/components/system_console/mcp_servers.tsx
+++ b/webapp/src/components/system_console/mcp_servers.tsx
@@ -673,7 +673,12 @@ const MCPServers = ({mcpConfig, bots, onChange}: Props) => {
                                     />
                                     {config.embeddedServer.enabled && (
                                         <SelectionItem
-                                            label={intl.formatMessage({defaultMessage: 'Automated Trigger Bot Account'})}
+                                            label={
+                                                <LabelWithPill>
+                                                    {intl.formatMessage({defaultMessage: 'Automated Trigger Bot Account'})}
+                                                    <Pill><FormattedMessage defaultMessage='EXPERIMENTAL'/></Pill>
+                                                </LabelWithPill>
+                                            }
                                             value={config.embeddedServer.automatedTriggerBotUsername || ''}
                                             onChange={(e) => onChange({
                                                 ...config,
@@ -1039,6 +1044,13 @@ const TabButton = styled.button.attrs<{active: boolean}>({type: 'button'})<{acti
 
 const TabContent = styled.div`
     /* Tab content styling */
+`;
+
+const LabelWithPill = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
 `;
 
 export default MCPServers;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Fixes a security vulnerability where automated triggers (webhooks, bots) could access private channels through the embedded Mattermost MCP server by inheriting the invoked agent bot's channel memberships.

**The problem:** When an automated trigger activates an agent, the embedded MCP server created a session using the agent's bot account. If that bot was a member of private channels (perhaps added months ago for other purposes), the automated trigger could access those channels — even if the webhook creator had no access to them.

**The fix:** Instead of implicitly using the agent's bot account, this PR adds an explicit admin configuration option (`automatedTriggerBotUsername`) that controls which bot account is used for embedded MCP server authentication during automated triggers. This gives admins explicit control over what automated triggers can access.

Key changes:
- **`config/mcp_config.go`**: Added `AutomatedTriggerBotUsername` field to `MCPEmbeddedServerConfig`
- **`mcp/client_manager.go`**: Added `resolveEmbeddedUserID()` method that resolves the configured bot for automated triggers, and updated `GetToolsForUser()` to use it. If no bot is configured, embedded MCP tools are simply unavailable for automated triggers (secure by default).
- **`webapp/src/components/system_console/mcp_servers.tsx`**: Added a bot selector dropdown under the "Enable Embedded Server" toggle, populated from the configured AI bots. Includes help text explaining the security implications.
- **`webapp/src/components/system_console/config.tsx`**: Passes bot list to the MCPServers component.

**Behavior changes:**
- Human users: No change — embedded MCP tools use the requesting user's session as before
- Automated triggers with bot configured: Embedded MCP tools operate with the selected bot's permissions
- Automated triggers without bot configured: Embedded MCP tools are unavailable (secure default)

#### Ticket Link

N/A

#### Screenshots

N/A — System Console UI change (dropdown selector for bot account under embedded MCP server settings)

#### Release Note
```release-note
Added a new configuration option "Automated Trigger Bot Account" under MCP Embedded Server settings. This controls which bot account is used to authenticate with the Mattermost MCP server when an agent is triggered by a webhook or bot. If not configured, embedded Mattermost tools are unavailable for automated triggers, preventing unintended access to private channels.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19345e37-fb8f-426b-9ebf-650409430044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19345e37-fb8f-426b-9ebf-650409430044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

