### PR TITLE
Fix Atlassian MCP OAuth metadata discovery for /v1 transport URLs

### DIFF
--- a/mcp/dcrp.go
+++ b/mcp/dcrp.go
@@ -200,7 +200,7 @@ func DiscoverAndRegisterClient(ctx context.Context, httpClient *http.Client, ser
 func GetRegistrationEndpoint(ctx context.Context, httpClient *http.Client, serverURL string) (string, error) {
 	// Construct the metadata URL according to RFC 8414 Section 3.1
 	// The well-known URI must be inserted between the host and path components
-	metadataURL, err := constructWellKnownURL(serverURL, "oauth-authorization-server")
+	metadataURL, err := constructWellKnownURL(oauthMetadataIssuerURL(serverURL), "oauth-authorization-server")
 	if err != nil {
 		return "", fmt.Errorf("failed to construct metadata URL from server URL %s: %w", serverURL, err)
 	}

--- a/mcp/oauth_manager.go
+++ b/mcp/oauth_manager.go
@@ -74,6 +74,7 @@ type StaticOAuthCredentials struct {
 // loadOrCreateClientCredentials gets existing client credentials or creates new ones using dynamic client registration.
 // If staticCreds is non-nil and has a ClientID, those credentials are used directly (skipping DCR).
 func (m *OAuthManager) loadOrCreateClientCredentials(ctx context.Context, serverURL string, staticCreds *StaticOAuthCredentials) (*ClientCredentials, error) {
+	serverURL = oauthMetadataIssuerURL(serverURL)
 	if staticCreds != nil && staticCreds.ClientID != "" {
 		return &ClientCredentials{
 			ClientID:     staticCreds.ClientID,

--- a/mcp/oauth_metadata.go
+++ b/mcp/oauth_metadata.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // ProtectedResourceMetadata represents the OAuth 2.0 Protected Resource Metadata (RFC 9728)
@@ -30,13 +31,29 @@ type AuthorizationServerMetadata struct {
 	RegistrationEndpoint   string   `json:"registration_endpoint,omitempty"`
 }
 
+// oauthMetadataIssuerURL returns the issuer or resource base URL used for RFC 8414/9728
+// well-known discovery. Atlassian MCP serves transports under paths such as /v1/sse or
+// /v1/mcp while publishing oauth-protected-resource and oauth-authorization-server
+// metadata at the host root only; including the transport path yields 404.
+func oauthMetadataIssuerURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "mcp.atlassian.com" || strings.HasSuffix(host, ".mcp.atlassian.com") {
+		return fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+	}
+	return raw
+}
+
 // discoverProtectedResourceMetadata fetches the OAuth 2.0 Protected Resource Metadata (RFC 9728)
 func discoverProtectedResourceMetadata(ctx context.Context, httpClient *http.Client, baseURL, metadataURL string) (*ProtectedResourceMetadata, error) {
 	if metadataURL == "" {
 		// The metadata URL is not provided, use the default well-known endpoint
 		// Construct according to RFC 9728 Section 3.1
 		var err error
-		metadataURL, err = constructWellKnownURL(baseURL, "oauth-protected-resource")
+		metadataURL, err = constructWellKnownURL(oauthMetadataIssuerURL(baseURL), "oauth-protected-resource")
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct metadata URL: %w", err)
 		}
@@ -77,6 +94,7 @@ func discoverProtectedResourceMetadata(ctx context.Context, httpClient *http.Cli
 
 // discoverAuthorizationServerMetadata fetches the OAuth 2.0 Authorization Server Metadata (RFC 8414)
 func discoverAuthorizationServerMetadata(ctx context.Context, httpClient *http.Client, authServerIssuer string) (*AuthorizationServerMetadata, error) {
+	authServerIssuer = oauthMetadataIssuerURL(authServerIssuer)
 	// Construct the well-known metadata URL according to RFC 8414 Section 3.1
 	// The well-known URI must be inserted between the host and path components
 	metadataURL, err := constructWellKnownURL(authServerIssuer, "oauth-authorization-server")

--- a/mcp/oauth_metadata_test.go
+++ b/mcp/oauth_metadata_test.go
@@ -8,6 +8,54 @@ import (
 	"testing"
 )
 
+func TestOauthMetadataIssuerURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "atlassian_mcp_sse_transport_strips_path",
+			in:   "https://mcp.atlassian.com/v1/sse",
+			want: "https://mcp.atlassian.com",
+		},
+		{
+			name: "atlassian_mcp_mcp_transport_strips_path",
+			in:   "https://mcp.atlassian.com/v1/mcp",
+			want: "https://mcp.atlassian.com",
+		},
+		{
+			name: "atlassian_subdomain",
+			in:   "https://tenant.mcp.atlassian.com/v1/sse",
+			want: "https://tenant.mcp.atlassian.com",
+		},
+		{
+			name: "non_atlassian_path_preserved",
+			in:   "https://example.com/issuer1",
+			want: "https://example.com/issuer1",
+		},
+		{
+			name: "atlassian_root_unchanged",
+			in:   "https://mcp.atlassian.com",
+			want: "https://mcp.atlassian.com",
+		},
+		{
+			name: "atlassian_with_nondefault_port_preserves_port",
+			in:   "https://mcp.atlassian.com:8443/v1/sse",
+			want: "https://mcp.atlassian.com:8443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := oauthMetadataIssuerURL(tt.in)
+			if got != tt.want {
+				t.Fatalf("oauthMetadataIssuerURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConstructWellKnownURL(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
#### Summary

Atlassian MCP serves SSE/MCP transports under paths such as `/v1/sse` while publishing `oauth-protected-resource` and `oauth-authorization-server` metadata at the host root. RFC 8414-style well-known URL construction was appending the transport path (e.g. `/.well-known/oauth-authorization-server/v1/sse`), which returns HTTP 404 and breaks dynamic client registration and OAuth setup.

This change normalizes the issuer to `scheme://host` for `mcp.atlassian.com` and `*.mcp.atlassian.com` before building well-known URLs, and applies the same normalization when storing OAuth client credentials so KV keys match the canonical host.

**QA:** Configure a remote MCP server with base URL `https://mcp.atlassian.com/v1/sse` (or `/v1/mcp`), connect, and confirm OAuth / DCR completes without a 404 on the authorization server metadata URL.

#### Ticket Link

N/A

#### Screenshots

N/A (server-side OAuth discovery only)

#### Release Note

```release-note
Fixed OAuth discovery for Atlassian MCP when the configured base URL includes transport paths such as `/v1/sse`, so dynamic client registration and initial authentication use the host-root well-known metadata endpoints.
```