### PR TITLE
Add connect/disconnect controls to RHS tool providers

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -204,6 +204,7 @@ func (a *API) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Reques
 	router.GET("/mcp/tools", a.handleGetUserMCPTools)
 	router.GET("/mcp/user-preferences", a.handleGetUserPreferences)
 	router.PUT("/mcp/user-preferences", a.handlePutUserPreferences)
+	router.DELETE("/mcp/server-auth", a.handleDeleteUserMCPServerAuth)
 
 	// Raw search endpoint returns enriched semantic search results without LLM processing.
 	// Used by the MCP server for external search callbacks.

--- a/api/api_mcp.go
+++ b/api/api_mcp.go
@@ -25,6 +25,8 @@ type UserMCPServerInfo struct {
 	ServerOrigin  string            `json:"serverOrigin"`
 	Authenticated bool              `json:"authenticated"`
 	AuthEmail     string            `json:"authEmail,omitempty"`
+	AuthURL       string            `json:"authURL,omitempty"`
+	CanDisconnect bool              `json:"canDisconnect"`
 	Tools         []UserMCPToolInfo `json:"tools"`
 }
 
@@ -126,41 +128,54 @@ func buildUserMCPServerInfo(
 		return toolInfos[i].Name < toolInfos[j].Name
 	})
 
-	_, hasAuthError := authErrorsByOrigin[serverConfig.BaseURL]
+	authErr, hasAuthError := authErrorsByOrigin[serverConfig.BaseURL]
+	authenticated, canDisconnect := getUserMCPServerAuthState(
+		userID,
+		oauthManager,
+		serverConfig,
+		len(originTools) > 0,
+		hasAuthError,
+	)
 
 	return UserMCPServerInfo{
 		Name:          serverConfig.Name,
 		ServerOrigin:  serverConfig.BaseURL,
-		Authenticated: isUserMCPServerAuthenticated(userID, oauthManager, serverConfig, len(originTools) > 0, hasAuthError),
+		Authenticated: authenticated,
+		AuthURL:       authErr.AuthURL,
+		CanDisconnect: canDisconnect,
 		Tools:         toolInfos,
 	}
 }
 
-func isUserMCPServerAuthenticated(
+func getUserMCPServerAuthState(
 	userID string,
 	oauthManager *mcp.OAuthManager,
 	serverConfig *mcp.ServerConfig,
 	hasDiscoveredTools bool,
 	hasAuthError bool,
-) bool {
+) (bool, bool) {
 	if serverConfig.BaseURL == mcp.EmbeddedClientKey {
-		return true
+		return true, false
+	}
+
+	hasStoredToken := false
+	if oauthManager != nil {
+		var err error
+		hasStoredToken, err = oauthManager.HasStoredToken(userID, serverConfig.Name)
+		if err != nil {
+			hasStoredToken = false
+		}
 	}
 
 	if hasDiscoveredTools {
-		return true
+		return true, hasStoredToken
 	}
 
 	if hasAuthError {
-		return false
+		return false, hasStoredToken
 	}
 
-	if oauthManager == nil {
-		return false
-	}
-
-	hasToken, err := oauthManager.HasStoredToken(userID, serverConfig.Name)
-	return err == nil && hasToken
+	return hasStoredToken, hasStoredToken
 }
 
 // handleGetUserPreferences returns the user's MCP tool provider preferences.
@@ -204,6 +219,47 @@ func (a *API) handlePutUserPreferences(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, saved)
+}
+
+// handleDeleteUserMCPServerAuth disconnects the user from an MCP server by
+// deleting the stored OAuth token for the matching server origin.
+func (a *API) handleDeleteUserMCPServerAuth(c *gin.Context) {
+	userID := c.GetHeader("Mattermost-User-Id")
+	serverOrigin := c.Query("serverOrigin")
+	if serverOrigin == "" {
+		c.AbortWithError(http.StatusBadRequest, fmt.Errorf("serverOrigin is required"))
+		return
+	}
+
+	serverConfig, ok := findUserMCPServerConfigByOrigin(a.config.MCP(), serverOrigin)
+	if !ok {
+		c.AbortWithError(http.StatusNotFound, fmt.Errorf("server not found for origin %s", serverOrigin))
+		return
+	}
+
+	oauthManager := a.mcpClientManager.GetOAuthManager()
+	if oauthManager == nil {
+		c.AbortWithError(http.StatusServiceUnavailable, errors.New("oauth manager is not available"))
+		return
+	}
+
+	if err := oauthManager.DisconnectUser(userID, serverConfig.Name); err != nil {
+		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to disconnect server auth: %w", err))
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+func findUserMCPServerConfigByOrigin(mcpCfg mcp.Config, serverOrigin string) (*mcp.ServerConfig, bool) {
+	for i := range mcpCfg.Servers {
+		serverConfig := &mcpCfg.Servers[i]
+		if serverConfig.BaseURL == serverOrigin {
+			return serverConfig, true
+		}
+	}
+
+	return nil, false
 }
 
 // handleGetVettedToolSeed returns authoritative vetted default tool_configs for a base URL (admin).

--- a/api/api_mcp_test.go
+++ b/api/api_mcp_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -80,11 +81,15 @@ func TestHandleGetUserMCPToolsIncludesZeroToolConfiguredServers(t *testing.T) {
 	require.Equal(t, zeroToolServer.Name, response.Servers[0].Name)
 	require.Equal(t, zeroToolServer.BaseURL, response.Servers[0].ServerOrigin)
 	require.False(t, response.Servers[0].Authenticated)
+	require.False(t, response.Servers[0].CanDisconnect)
+	require.Empty(t, response.Servers[0].AuthURL)
 	require.Empty(t, response.Servers[0].Tools)
 
 	require.Equal(t, toolServer.Name, response.Servers[1].Name)
 	require.Equal(t, toolServer.BaseURL, response.Servers[1].ServerOrigin)
 	require.True(t, response.Servers[1].Authenticated)
+	require.False(t, response.Servers[1].CanDisconnect)
+	require.Empty(t, response.Servers[1].AuthURL)
 	require.Len(t, response.Servers[1].Tools, 2)
 	require.Equal(t, "a_tool", response.Servers[1].Tools[0].Name)
 	require.Equal(t, "z_tool", response.Servers[1].Tools[1].Name)
@@ -132,6 +137,8 @@ func TestHandleGetUserMCPToolsStoredTokenMarksZeroToolServerAuthenticated(t *tes
 	require.Len(t, response.Servers, 1)
 	require.Equal(t, server.Name, response.Servers[0].Name)
 	require.True(t, response.Servers[0].Authenticated)
+	require.True(t, response.Servers[0].CanDisconnect)
+	require.Empty(t, response.Servers[0].AuthURL)
 	require.Empty(t, response.Servers[0].Tools)
 }
 
@@ -187,6 +194,8 @@ func TestHandleGetUserMCPToolsAuthErrorsOverrideStoredTokensForZeroToolServers(t
 	require.Len(t, response.Servers, 1)
 	require.Equal(t, server.Name, response.Servers[0].Name)
 	require.False(t, response.Servers[0].Authenticated)
+	require.True(t, response.Servers[0].CanDisconnect)
+	require.Equal(t, "https://oauth.example.com/authorize", response.Servers[0].AuthURL)
 	require.Empty(t, response.Servers[0].Tools)
 }
 
@@ -213,7 +222,51 @@ func TestHandleGetUserMCPToolsIncludesEmbeddedZeroToolServer(t *testing.T) {
 	require.Equal(t, mcp.EmbeddedServerName, response.Servers[0].Name)
 	require.Equal(t, mcp.EmbeddedClientKey, response.Servers[0].ServerOrigin)
 	require.True(t, response.Servers[0].Authenticated)
+	require.False(t, response.Servers[0].CanDisconnect)
+	require.Empty(t, response.Servers[0].AuthURL)
 	require.Empty(t, response.Servers[0].Tools)
+}
+
+func TestHandleDeleteUserMCPServerAuthRemovesStoredToken(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	server := mcp.ServerConfig{
+		Name:    "OAuth Server",
+		Enabled: true,
+		BaseURL: "https://oauth.example.com",
+	}
+	e.config.mcpConfig = mcp.Config{
+		Enabled: true,
+		Servers: []mcp.ServerConfig{server},
+	}
+
+	mmClient := mmapimocks.NewMockClient(t)
+	mmClient.On("KVDelete", "mcp_oauth_token_v1_"+testUserID+"_"+server.Name).
+		Return(nil).
+		Once()
+
+	oauthManager := mcp.NewOAuthManager(mmClient, "https://mattermost.example.com/plugins/oauth/callback", &http.Client{}, func(serverID string) (mcp.ServerConfig, bool) {
+		if serverID == server.Name {
+			return server, true
+		}
+		return mcp.ServerConfig{}, false
+	})
+
+	e.api.mcpClientManager = &mockMCPClientManager{
+		oauthManager: oauthManager,
+	}
+
+	request := httptest.NewRequest(http.MethodDelete, "/mcp/server-auth?serverOrigin="+url.QueryEscape(server.BaseURL), nil)
+	request.Header.Add("Mattermost-User-Id", testUserID)
+
+	recorder := httptest.NewRecorder()
+	e.api.ServeHTTP(nil, recorder, request)
+
+	require.Equal(t, http.StatusNoContent, recorder.Result().StatusCode)
 }
 
 func getUserMCPToolsResponse(t *testing.T, api *API) UserMCPToolsResponse {

--- a/mcp/oauth_store.go
+++ b/mcp/oauth_store.go
@@ -65,6 +65,11 @@ func (m *OAuthManager) HasStoredToken(userID, serverID string) (bool, error) {
 	return true, nil
 }
 
+// DisconnectUser deletes any stored OAuth token for the user and server.
+func (m *OAuthManager) DisconnectUser(userID, serverID string) error {
+	return m.deleteToken(userID, serverID)
+}
+
 func (m *OAuthManager) storeToken(userID, serverID string, token *oauth2.Token) error {
 	tokenKey := buildTokenKey(userID, serverID)
 

--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -592,6 +592,23 @@ export async function getUserMCPTools(): Promise<{servers: any[]}> {
     });
 }
 
+export async function disconnectUserMCPServerAuth(serverOrigin: string): Promise<void> {
+    const url = `${baseRoute()}/mcp/server-auth?serverOrigin=${encodeURIComponent(serverOrigin)}`;
+    const response = await fetch(url, Client4.getOptions({
+        method: 'DELETE',
+    }));
+
+    if (response.ok) {
+        return;
+    }
+
+    throw new ClientError(Client4.url, {
+        message: '',
+        status_code: response.status,
+        url,
+    });
+}
+
 export async function getUserToolPreferences(): Promise<{disabled_servers: string[]}> {
     const url = `${baseRoute()}/mcp/user-preferences`;
     const response = await fetch(url, Client4.getOptions({

--- a/webapp/src/components/rhs/tool_provider_popover.tsx
+++ b/webapp/src/components/rhs/tool_provider_popover.tsx
@@ -1,13 +1,14 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useCallback, useEffect} from 'react';
+import React, {useState, useCallback, useEffect, useRef} from 'react';
 import styled from 'styled-components';
 import {FormattedMessage} from 'react-intl';
 import {ChevronDownIcon} from '@mattermost/compass-icons/components';
 
-import {getUserMCPTools, updateUserToolPreferences} from '@/client';
+import {disconnectUserMCPServerAuth, getUserMCPTools, updateUserToolPreferences} from '@/client';
 
+import {TertiaryButton} from '../assets/buttons';
 import DotMenu, {DotMenuButton, DropdownMenu} from '../dot_menu';
 import {ToggleSwitch} from '../toggle_switch';
 
@@ -15,6 +16,8 @@ export type UserMCPServerInfo = {
     name: string;
     serverOrigin: string;
     authenticated: boolean;
+    authURL?: string;
+    canDisconnect: boolean;
     tools: Array<{
         name: string;
         description: string;
@@ -32,12 +35,31 @@ type ToolProviderPopoverProps = {
 const ToolProviderPopover = ({disabledServers, onDisabledServersChange, preloadedServers}: ToolProviderPopoverProps) => {
     const [servers, setServers] = useState<UserMCPServerInfo[]>(preloadedServers || []);
     const [loading, setLoading] = useState(false);
+    const [connectingServerOrigin, setConnectingServerOrigin] = useState<string | null>(null);
+    const [disconnectingServerOrigin, setDisconnectingServerOrigin] = useState<string | null>(null);
+    const authRefreshIntervalRef = useRef<number | null>(null);
 
     useEffect(() => {
         if (preloadedServers && preloadedServers.length > 0) {
             setServers(preloadedServers);
         }
     }, [preloadedServers]);
+
+    const stopAuthRefreshPolling = useCallback(() => {
+        if (authRefreshIntervalRef.current !== null) {
+            window.clearInterval(authRefreshIntervalRef.current);
+            authRefreshIntervalRef.current = null;
+        }
+        setConnectingServerOrigin(null);
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            if (authRefreshIntervalRef.current !== null) {
+                window.clearInterval(authRefreshIntervalRef.current);
+            }
+        };
+    }, []);
 
     const fetchServers = useCallback(async () => {
         setLoading(true);
@@ -49,6 +71,14 @@ const ToolProviderPopover = ({disabledServers, onDisabledServersChange, preloade
         }
         setLoading(false);
     }, []);
+
+    useEffect(() => {
+        if (connectingServerOrigin && servers.some((server) => (
+            server.serverOrigin === connectingServerOrigin && server.authenticated
+        ))) {
+            stopAuthRefreshPolling();
+        }
+    }, [connectingServerOrigin, servers, stopAuthRefreshPolling]);
 
     const handleToggle = useCallback(async (serverOrigin: string, enabled: boolean) => {
         let updatedDisabled: string[];
@@ -66,6 +96,54 @@ const ToolProviderPopover = ({disabledServers, onDisabledServersChange, preloade
             onDisabledServersChange(disabledServers);
         }
     }, [disabledServers, onDisabledServersChange]);
+
+    const startAuthRefreshPolling = useCallback((serverOrigin: string) => {
+        stopAuthRefreshPolling();
+        setConnectingServerOrigin(serverOrigin);
+
+        let attempts = 0;
+        authRefreshIntervalRef.current = window.setInterval(async () => {
+            attempts += 1;
+
+            try {
+                const response = await getUserMCPTools();
+                setServers(response.servers);
+
+                const isAuthenticated = response.servers.some((server) => (
+                    server.serverOrigin === serverOrigin && server.authenticated
+                ));
+                if (isAuthenticated || attempts >= 15) {
+                    stopAuthRefreshPolling();
+                }
+            } catch {
+                if (attempts >= 15) {
+                    stopAuthRefreshPolling();
+                }
+            }
+        }, 2000);
+    }, [stopAuthRefreshPolling]);
+
+    const handleConnect = useCallback((serverOrigin: string, authURL?: string) => {
+        if (!authURL) {
+            return;
+        }
+
+        window.open(authURL, '_blank', 'noopener,noreferrer');
+        startAuthRefreshPolling(serverOrigin);
+    }, [startAuthRefreshPolling]);
+
+    const handleDisconnect = useCallback(async (serverOrigin: string) => {
+        setDisconnectingServerOrigin(serverOrigin);
+
+        try {
+            await disconnectUserMCPServerAuth(serverOrigin);
+            await fetchServers();
+        } catch {
+            // Silently fail - current state remains visible
+        } finally {
+            setDisconnectingServerOrigin(null);
+        }
+    }, [fetchServers]);
 
     return (
         <DotMenu
@@ -101,14 +179,58 @@ const ToolProviderPopover = ({disabledServers, onDisabledServersChange, preloade
             )}
             {servers.map((server) => (
                 <ProviderRow key={server.serverOrigin}>
-                    <ProviderAvatar>
-                        {server.name.charAt(0).toUpperCase()}
-                    </ProviderAvatar>
-                    <ProviderName>{server.name}</ProviderName>
-                    <ToggleSwitch
-                        checked={!disabledServers.includes(server.serverOrigin)}
-                        onChange={(checked) => handleToggle(server.serverOrigin, checked)}
-                    />
+                    <ProviderIdentity>
+                        <ProviderAvatar>
+                            {server.name.charAt(0).toUpperCase()}
+                        </ProviderAvatar>
+                        <ProviderText>
+                            <ProviderName>{server.name}</ProviderName>
+                            {(server.canDisconnect || server.authURL) && (
+                                <ProviderStatus $authenticated={server.authenticated}>
+                                    {server.authenticated ? (
+                                        <FormattedMessage defaultMessage='Connected'/>
+                                    ) : (
+                                        <FormattedMessage defaultMessage='Disconnected'/>
+                                    )}
+                                </ProviderStatus>
+                            )}
+                        </ProviderText>
+                    </ProviderIdentity>
+                    <ProviderActions>
+                        {(server.canDisconnect || server.authURL) && (
+                            <ProviderAuthButton
+                                type='button'
+                                onClick={() => {
+                                    if (server.canDisconnect) {
+                                        handleDisconnect(server.serverOrigin);
+                                        return;
+                                    }
+
+                                    handleConnect(server.serverOrigin, server.authURL);
+                                }}
+                                disabled={connectingServerOrigin === server.serverOrigin || disconnectingServerOrigin === server.serverOrigin}
+                            >
+                                {connectingServerOrigin === server.serverOrigin && (
+                                    <FormattedMessage defaultMessage='Connecting...'/>
+                                )}
+                                {disconnectingServerOrigin === server.serverOrigin && (
+                                    <FormattedMessage defaultMessage='Disconnecting...'/>
+                                )}
+                                {connectingServerOrigin !== server.serverOrigin && disconnectingServerOrigin !== server.serverOrigin && (
+                                    server.canDisconnect ? (
+                                        <FormattedMessage defaultMessage='Disconnect'/>
+                                    ) : (
+                                        <FormattedMessage defaultMessage='Connect'/>
+                                    )
+                                )}
+                            </ProviderAuthButton>
+                        )}
+                        <ToggleSwitch
+                            checked={!disabledServers.includes(server.serverOrigin)}
+                            onChange={(checked) => handleToggle(server.serverOrigin, checked)}
+                            ariaLabel={server.name}
+                        />
+                    </ProviderActions>
                 </ProviderRow>
             ))}
         </DotMenu>
@@ -158,12 +280,20 @@ const PopoverHeader = styled.div`
 const ProviderRow = styled.div`
     display: flex;
     align-items: center;
-    padding: 6px 16px;
-    gap: 8px;
+    justify-content: space-between;
+    padding: 8px 16px;
+    gap: 12px;
 
     &:hover {
         background: rgba(var(--center-channel-color-rgb), 0.08);
     }
+`;
+
+const ProviderIdentity = styled.div`
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    gap: 8px;
 `;
 
 const ProviderAvatar = styled.div`
@@ -181,12 +311,39 @@ const ProviderAvatar = styled.div`
 `;
 
 const ProviderName = styled.div`
-    flex: 1;
     font-size: 14px;
     font-weight: 400;
     color: var(--center-channel-color);
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+const ProviderText = styled.div`
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+`;
+
+const ProviderStatus = styled.div<{$authenticated: boolean}>`
+    font-size: 12px;
+    line-height: 16px;
+    color: ${({$authenticated}) => (
+        $authenticated ? 'rgba(var(--center-channel-color-rgb), 0.64)' : 'var(--button-bg)'
+    )};
+`;
+
+const ProviderActions = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+`;
+
+const ProviderAuthButton = styled(TertiaryButton)`
+    height: 28px;
+    padding: 0 10px;
+    font-size: 12px;
     white-space: nowrap;
 `;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Adds connect/disconnect controls to the end-user tool provider list in the Agents RHS so users can retry broken MCP auth without leaving the RHS. It also exposes the auth action metadata needed by the RHS and adds a user API endpoint to clear stored provider auth.

QA:
- `go test ./api -run 'TestHandleGetUserMCPTools|TestHandleDeleteUserMCPServerAuth'`
- `cd webapp && npm run lint -- src/components/rhs/tool_provider_popover.tsx src/client.tsx`
- `cd webapp && npm run check-types -- --pretty false`
- `cd webapp && npm run build`
- `make dist`

#### Ticket Link
NONE

#### Screenshots
Unable to capture a live RHS walkthrough in local Mattermost because the demo MCP provider remained blocked by the server's internal-network protections during manual validation attempts.

#### Release Note
```release-note
Added connect and disconnect controls to the Agents RHS tool provider list for MCP providers, and added a user API endpoint/response fields to support retrying provider authentication.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5862bb18-53dc-4bad-8683-5bd953e428ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5862bb18-53dc-4bad-8683-5bd953e428ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

