### PR TITLE
Fix OAuth discovery to strip path from MCP server URL

### DIFF
--- a/mcp/dcrp.go
+++ b/mcp/dcrp.go
@@ -198,9 +198,16 @@ func DiscoverAndRegisterClient(ctx context.Context, httpClient *http.Client, ser
 
 // GetRegistrationEndpoint discovers the registration endpoint from server metadata
 func GetRegistrationEndpoint(ctx context.Context, httpClient *http.Client, serverURL string) (string, error) {
+	// Strip path from server URL per MCP spec: the authorization base URL is derived
+	// by discarding the path component from the server URL.
+	parsedURL, err := url.Parse(serverURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse server URL %s: %w", serverURL, err)
+	}
+	baseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+
 	// Construct the metadata URL according to RFC 8414 Section 3.1
-	// The well-known URI must be inserted between the host and path components
-	metadataURL, err := constructWellKnownURL(serverURL, "oauth-authorization-server")
+	metadataURL, err := constructWellKnownURL(baseURL, "oauth-authorization-server")
 	if err != nil {
 		return "", fmt.Errorf("failed to construct metadata URL from server URL %s: %w", serverURL, err)
 	}

--- a/mcp/dcrp_test.go
+++ b/mcp/dcrp_test.go
@@ -211,6 +211,31 @@ func TestGetRegistrationEndpoint_NotSupported(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not support dynamic client registration")
 }
 
+func TestGetRegistrationEndpoint_ServerURLWithPath(t *testing.T) {
+	// Verifies that when the server URL has a path (e.g. /v1/mcp), the path is
+	// stripped before constructing the well-known URL. Per MCP spec, the
+	// authorization base URL is derived by discarding the path component.
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			metadata := map[string]string{
+				"registration_endpoint": serverURL + "/register",
+			}
+			_ = json.NewEncoder(w).Encode(metadata)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	endpoint, err := GetRegistrationEndpoint(context.Background(), http.DefaultClient, server.URL+"/v1/mcp")
+	require.NoError(t, err)
+	assert.Equal(t, server.URL+"/register", endpoint)
+}
+
 func TestDiscoverAndRegisterClient_Success(t *testing.T) {
 	// Create mock server to handle both metadata and registration endpoints
 	var serverURL string

--- a/mcp/oauth_manager.go
+++ b/mcp/oauth_manager.go
@@ -125,7 +125,7 @@ func (m *OAuthManager) createOAuthConfig(ctx context.Context, serverURL, metadat
 	// Try to discover OAuth endpoints using RFC 8414/9728
 	authURL := baseURL + "/authorize" // Fallback
 	tokenURL := baseURL + "/token"    // Fallback
-	authServerURL := serverURL        // Fallback - use protected resource as auth server
+	authServerURL := baseURL          // Fallback - per MCP spec, auth server is at base URL (path stripped)
 	var scopes []string
 
 	// Attempt discovery (best effort, fall back to hardcoded endpoints if it fails).
@@ -146,11 +146,12 @@ func (m *OAuthManager) createOAuthConfig(ctx context.Context, serverURL, metadat
 	} else {
 		// If protected resource metadata fails, assume the resource server is the authorization server
 		// and try the authorization server metadata endpoint directly (existing MCP server behavior).
-		// Use serverURL (not baseURL) so path-scoped issuers are preserved per RFC 8414 Section 3.1.
-		if authMetadata, authErr := discoverAuthorizationServerMetadata(ctx, m.httpClient, serverURL); authErr == nil {
+		// Use baseURL (path stripped) per MCP spec: the authorization base URL is derived by
+		// discarding the path component from the MCP server URL.
+		if authMetadata, authErr := discoverAuthorizationServerMetadata(ctx, m.httpClient, baseURL); authErr == nil {
 			authURL = authMetadata.AuthorizationEndpoint
 			tokenURL = authMetadata.TokenEndpoint
-			// authServerURL already set to serverURL above
+			// authServerURL already set to baseURL above
 		}
 	}
 

--- a/mcp/oauth_manager_test.go
+++ b/mcp/oauth_manager_test.go
@@ -5,7 +5,9 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -234,6 +236,45 @@ func TestLoadOrCreateClientCredentials_EmptyStaticCredsFallsBackToKVStore(t *tes
 	require.Equal(t, "kv-client-id", creds.ClientID)
 	require.Equal(t, "kv-client-secret", creds.ClientSecret)
 	mockClient.AssertCalled(t, "KVGet", mock.AnythingOfType("string"), mock.AnythingOfType("*mcp.ClientCredentials"))
+}
+
+func TestCreateOAuthConfig_FallbackStripsPathFromServerURL(t *testing.T) {
+	// Verifies the Atlassian JIRA MCP scenario: the server URL has a path
+	// (e.g. /v1/mcp), protected resource metadata is unavailable, and
+	// authorization server metadata is only at the base well-known URL.
+	// Per MCP spec, the path must be stripped for auth server discovery.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			metadata := AuthorizationServerMetadata{
+				Issuer:                "https://auth.example.com",
+				AuthorizationEndpoint: "https://auth.example.com/authorize",
+				TokenEndpoint:         "https://auth.example.com/token",
+			}
+			_ = json.NewEncoder(w).Encode(metadata)
+		default:
+			// Protected resource metadata and path-suffixed well-known both 404
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	manager, _ := setupTestOAuthManagerFull(t, nil, server.Client())
+
+	staticCreds := &StaticOAuthCredentials{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	}
+
+	ctx := context.Background()
+	config, err := manager.createOAuthConfig(ctx, server.URL+"/v1/mcp", "", staticCreds)
+
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	require.Equal(t, "https://auth.example.com/authorize", config.Endpoint.AuthURL)
+	require.Equal(t, "https://auth.example.com/token", config.Endpoint.TokenURL)
+	require.Equal(t, "test-client", config.ClientID)
 }
 
 func TestStaticCredsHelpers(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix OAuth metadata discovery to strip the path component from MCP server URLs before constructing `.well-known` URLs, per the MCP spec's authorization base URL requirement
- Add regression tests for both `GetRegistrationEndpoint` and `createOAuthConfig` with path-bearing server URLs

## Details

When connecting to MCP servers whose URL contains a path (e.g., `https://mcp.atlassian.com/v1/mcp`), OAuth discovery failed with:

```
server metadata request to https://mcp.atlassian.com/.well-known/oauth-authorization-server/v1/mcp failed with HTTP 404
```

**What went wrong:** The code passed the full MCP server URL (including path `/v1/mcp`) to `constructWellKnownURL`, which per RFC 8414 Section 3.1 inserts `/.well-known/oauth-authorization-server` between the host and path, producing `/.well-known/oauth-authorization-server/v1/mcp`. This path-aware construction is correct when the input is an OAuth **issuer identifier** with a path (for multi-tenant hosting), but the MCP server URL is a **resource URL**, not an issuer.

**What the MCP spec says:** The authorization base URL MUST be derived by discarding the path component from the MCP server URL. For `https://mcp.atlassian.com/v1/mcp`, the base URL is `https://mcp.atlassian.com`, and metadata should be fetched from `https://mcp.atlassian.com/.well-known/oauth-authorization-server`.

**What changed:**
- `oauth_manager.go`: `createOAuthConfig` now uses `baseURL` (path stripped) instead of `serverURL` for the fallback authorization server metadata discovery and the default `authServerURL`
- `dcrp.go`: `GetRegistrationEndpoint` now strips the path from the server URL before constructing the well-known URL

The protected resource metadata discovery (RFC 9728) path is unchanged — it correctly uses the full server URL with path, since RFC 9728 operates on the resource identifier.

## Test plan
- [x] `TestGetRegistrationEndpoint_ServerURLWithPath` — verifies `GetRegistrationEndpoint` strips the path and discovers metadata at the base URL
- [x] `TestCreateOAuthConfig_FallbackStripsPathFromServerURL` — verifies the full discovery fallback chain: protected resource metadata 404 → auth server metadata discovered at base URL
- [x] All existing `mcp` package tests continue to pass
- [x] Manually verified against `https://mcp.atlassian.com/v1/mcp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed OAuth server discovery to properly handle server URLs containing path components. The system now correctly strips the path and uses only the scheme and host for OAuth configuration discovery, ensuring reliable metadata retrieval when server URLs include additional path segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->