### PR TITLE
fix bifrost responses schema serialization

### DIFF
--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -236,17 +236,208 @@ func (b *LLM) createConfig(opts []llm.LanguageModelOption) llm.LanguageModelConf
 }
 
 func buildResponsesJSONSchema(schemaMap map[string]interface{}) (*schemas.ResponsesTextConfigFormatJSONSchema, error) {
-	data, err := json.Marshal(schemaMap)
+	responseSchema := &schemas.ResponsesTextConfigFormatJSONSchema{}
+
+	if typeVal, ok := schemaMap["type"].(string); ok {
+		responseSchema.Type = Ptr(typeVal)
+	} else if typeList, ok := schemaMap["type"].([]interface{}); ok {
+		anyOf := make([]map[string]any, 0, len(typeList))
+		for i, item := range typeList {
+			typeName, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("responses JSON schema type[%d] must be a string", i)
+			}
+			anyOf = append(anyOf, map[string]any{"type": typeName})
+		}
+		if len(anyOf) > 0 {
+			responseSchema.AnyOf = anyOf
+		}
+	}
+	if properties, ok := schemaMap["properties"].(map[string]interface{}); ok {
+		responseSchema.Properties = &properties
+	}
+	if required := extractStringSlice(schemaMap["required"]); len(required) > 0 {
+		responseSchema.Required = required
+	}
+	if description, ok := schemaMap["description"].(string); ok {
+		responseSchema.Description = Ptr(description)
+	}
+	if additionalProps, ok := schemaMap["additionalProperties"].(bool); ok {
+		responseSchema.AdditionalProperties = &schemas.AdditionalPropertiesStruct{
+			AdditionalPropertiesBool: &additionalProps,
+		}
+	} else if additionalProps, ok := schemas.SafeExtractOrderedMap(schemaMap["additionalProperties"]); ok {
+		responseSchema.AdditionalProperties = &schemas.AdditionalPropertiesStruct{
+			AdditionalPropertiesMap: additionalProps,
+		}
+	}
+	if name, ok := schemaMap["name"].(string); ok {
+		responseSchema.Name = Ptr(name)
+	} else if title, ok := schemaMap["title"].(string); ok {
+		responseSchema.Name = Ptr(title)
+	}
+	if defs, ok := schemaMap["$defs"].(map[string]interface{}); ok {
+		responseSchema.Defs = &defs
+	}
+	if definitions, ok := schemaMap["definitions"].(map[string]interface{}); ok {
+		responseSchema.Definitions = &definitions
+	}
+	if ref, ok := schemaMap["$ref"].(string); ok {
+		responseSchema.Ref = Ptr(ref)
+	}
+	if items, ok := schemaMap["items"].(map[string]interface{}); ok {
+		responseSchema.Items = &items
+	}
+	if minItems, ok := toInt64(schemaMap["minItems"]); ok {
+		responseSchema.MinItems = &minItems
+	}
+	if maxItems, ok := toInt64(schemaMap["maxItems"]); ok {
+		responseSchema.MaxItems = &maxItems
+	}
+	if anyOf := extractSchemaList(schemaMap["anyOf"]); len(anyOf) > 0 {
+		responseSchema.AnyOf = append(responseSchema.AnyOf, anyOf...)
+	}
+	if oneOf := extractSchemaList(schemaMap["oneOf"]); len(oneOf) > 0 {
+		responseSchema.OneOf = oneOf
+	}
+	if allOf := extractSchemaList(schemaMap["allOf"]); len(allOf) > 0 {
+		responseSchema.AllOf = allOf
+	}
+	if format, ok := schemaMap["format"].(string); ok {
+		responseSchema.Format = Ptr(format)
+	}
+	if pattern, ok := schemaMap["pattern"].(string); ok {
+		responseSchema.Pattern = Ptr(pattern)
+	}
+	if minLength, ok := toInt64(schemaMap["minLength"]); ok {
+		responseSchema.MinLength = &minLength
+	}
+	if maxLength, ok := toInt64(schemaMap["maxLength"]); ok {
+		responseSchema.MaxLength = &maxLength
+	}
+	if minimum, ok := toFloat64(schemaMap["minimum"]); ok {
+		responseSchema.Minimum = &minimum
+	}
+	if maximum, ok := toFloat64(schemaMap["maximum"]); ok {
+		responseSchema.Maximum = &maximum
+	}
+	if title, ok := schemaMap["title"].(string); ok {
+		responseSchema.Title = Ptr(title)
+	}
+	if defaultVal, exists := schemaMap["default"]; exists {
+		responseSchema.Default = defaultVal
+	}
+	if nullable, ok := schemaMap["nullable"].(bool); ok {
+		responseSchema.Nullable = &nullable
+	}
+
+	enumValues, err := extractStringEnum(schemaMap["enum"])
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal responses JSON schema: %w", err)
+		return nil, err
+	}
+	if len(enumValues) > 0 {
+		responseSchema.Enum = enumValues
 	}
 
-	var responseSchema schemas.ResponsesTextConfigFormatJSONSchema
-	if err := json.Unmarshal(data, &responseSchema); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal responses JSON schema: %w", err)
+	return responseSchema, nil
+}
+
+func extractStringSlice(value interface{}) []string {
+	switch items := value.(type) {
+	case []string:
+		if len(items) == 0 {
+			return nil
+		}
+		return append([]string(nil), items...)
+	case []interface{}:
+		result := make([]string, 0, len(items))
+		for _, item := range items {
+			str, ok := item.(string)
+			if !ok {
+				continue
+			}
+			result = append(result, str)
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func extractStringEnum(value interface{}) ([]string, error) {
+	switch items := value.(type) {
+	case nil:
+		return nil, nil
+	case []string:
+		if len(items) == 0 {
+			return nil, nil
+		}
+		return append([]string(nil), items...), nil
+	case []interface{}:
+		result := make([]string, 0, len(items))
+		for i, item := range items {
+			str, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("responses JSON schema enum[%d] must be a string, got %T", i, item)
+			}
+			result = append(result, str)
+		}
+		if len(result) == 0 {
+			return nil, nil
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("responses JSON schema enum must be an array, got %T", value)
+	}
+}
+
+func extractSchemaList(value interface{}) []map[string]any {
+	items, ok := value.([]interface{})
+	if !ok {
+		return nil
 	}
 
-	return &responseSchema, nil
+	result := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		schemaMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		result = append(result, schemaMap)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func toInt64(value interface{}) (int64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return int64(v), true
+	case int:
+		return int64(v), true
+	case int64:
+		return v, true
+	default:
+		return 0, false
+	}
+}
+
+func toFloat64(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
 }
 
 // ChatCompletion performs a streaming chat completion request.
@@ -922,15 +1113,15 @@ func buildChatResponseFormat(schema *jsonschema.Schema) *interface{} {
 }
 
 // buildResponsesTextConfig creates the text configuration for the Responses API with JSON schema output.
-func buildResponsesTextConfig(schema *jsonschema.Schema) *schemas.ResponsesTextConfig {
+func buildResponsesTextConfig(schema *jsonschema.Schema) (*schemas.ResponsesTextConfig, error) {
 	schemaMap, err := jsonSchemaToMap(schema)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	responseSchema, err := buildResponsesJSONSchema(schemaMap)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	return &schemas.ResponsesTextConfig{
 		Format: &schemas.ResponsesTextConfigFormat{
@@ -939,7 +1130,7 @@ func buildResponsesTextConfig(schema *jsonschema.Schema) *schemas.ResponsesTextC
 			Strict:     Ptr(true),
 			JSONSchema: responseSchema,
 		},
-	}
+	}, nil
 }
 
 // isValidImageType checks if the MIME type is supported.
@@ -1206,7 +1397,7 @@ func (b *LLM) buildResponsesReasoning(cfg llm.LanguageModelConfig) *schemas.Resp
 }
 
 // convertToBifrostResponsesRequest converts our CompletionRequest to Bifrost's Responses API format.
-func (b *LLM) convertToBifrostResponsesRequest(request llm.CompletionRequest, cfg llm.LanguageModelConfig) *schemas.BifrostResponsesRequest {
+func (b *LLM) convertToBifrostResponsesRequest(request llm.CompletionRequest, cfg llm.LanguageModelConfig) (*schemas.BifrostResponsesRequest, error) {
 	messages := b.convertToResponsesMessages(request.Posts)
 	tools := b.convertToResponsesTools(request, cfg)
 
@@ -1228,11 +1419,15 @@ func (b *LLM) convertToBifrostResponsesRequest(request llm.CompletionRequest, cf
 	params.Reasoning = b.buildResponsesReasoning(cfg)
 	// Apply structured output (JSON schema) configuration
 	if cfg.JSONOutputFormat != nil {
-		params.Text = buildResponsesTextConfig(cfg.JSONOutputFormat)
+		textConfig, err := buildResponsesTextConfig(cfg.JSONOutputFormat)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build responses text config: %w", err)
+		}
+		params.Text = textConfig
 	}
 	req.Params = params
 
-	return req
+	return req, nil
 }
 
 // streamResponses handles the streaming Responses API completion.
@@ -1241,7 +1436,14 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 	defer cancel()
 
 	// Convert to Bifrost Responses API request
-	bifrostReq := b.convertToBifrostResponsesRequest(request, cfg)
+	bifrostReq, err := b.convertToBifrostResponsesRequest(request, cfg)
+	if err != nil {
+		output <- llm.TextStreamEvent{
+			Type:  llm.EventTypeError,
+			Value: err,
+		}
+		return
+	}
 
 	// Make streaming request
 	streamChan, bifrostErr := b.client.ResponsesStreamRequest(bifrostCtx, bifrostReq)

--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -235,6 +235,20 @@ func (b *LLM) createConfig(opts []llm.LanguageModelOption) llm.LanguageModelConf
 	return cfg
 }
 
+func buildResponsesJSONSchema(schemaMap map[string]interface{}) (*schemas.ResponsesTextConfigFormatJSONSchema, error) {
+	data, err := json.Marshal(schemaMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal responses JSON schema: %w", err)
+	}
+
+	var responseSchema schemas.ResponsesTextConfigFormatJSONSchema
+	if err := json.Unmarshal(data, &responseSchema); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal responses JSON schema: %w", err)
+	}
+
+	return &responseSchema, nil
+}
+
 // ChatCompletion performs a streaming chat completion request.
 func (b *LLM) ChatCompletion(request llm.CompletionRequest, opts ...llm.LanguageModelOption) (*llm.TextStreamResult, error) {
 	cfg := b.createConfig(opts)
@@ -913,15 +927,17 @@ func buildResponsesTextConfig(schema *jsonschema.Schema) *schemas.ResponsesTextC
 	if err != nil {
 		return nil
 	}
-	var schemaAny any = schemaMap
+
+	responseSchema, err := buildResponsesJSONSchema(schemaMap)
+	if err != nil {
+		return nil
+	}
 	return &schemas.ResponsesTextConfig{
 		Format: &schemas.ResponsesTextConfigFormat{
-			Type:   "json_schema",
-			Name:   Ptr("response"),
-			Strict: Ptr(true),
-			JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
-				Schema: &schemaAny,
-			},
+			Type:       "json_schema",
+			Name:       Ptr("response"),
+			Strict:     Ptr(true),
+			JSONSchema: responseSchema,
 		},
 	}
 }

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -676,7 +676,12 @@ func TestConvertToBifrostResponsesRequestStructuredOutput(t *testing.T) {
 				assert.Equal(t, "response", *req.Params.Text.Format.Name)
 				assert.Equal(t, true, *req.Params.Text.Format.Strict)
 				require.NotNil(t, req.Params.Text.Format.JSONSchema)
-				require.NotNil(t, req.Params.Text.Format.JSONSchema.Schema)
+				assert.Nil(t, req.Params.Text.Format.JSONSchema.Schema)
+				require.NotNil(t, req.Params.Text.Format.JSONSchema.Type)
+				assert.Equal(t, "object", *req.Params.Text.Format.JSONSchema.Type)
+				require.NotNil(t, req.Params.Text.Format.JSONSchema.Properties)
+				assert.Len(t, *req.Params.Text.Format.JSONSchema.Properties, 2)
+				assert.ElementsMatch(t, []string{"name", "score"}, req.Params.Text.Format.JSONSchema.Required)
 			} else {
 				assert.Nil(t, req.Params.Text)
 			}

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -667,7 +668,8 @@ func TestConvertToBifrostResponsesRequestStructuredOutput(t *testing.T) {
 				cfg.JSONOutputFormat = llm.NewJSONSchemaFromStruct[testStructuredOutput]()
 			}
 
-			req := b.convertToBifrostResponsesRequest(llm.CompletionRequest{}, cfg)
+			req, err := b.convertToBifrostResponsesRequest(llm.CompletionRequest{}, cfg)
+			require.NoError(t, err)
 
 			if tt.expectFormat {
 				require.NotNil(t, req.Params.Text)
@@ -682,11 +684,132 @@ func TestConvertToBifrostResponsesRequestStructuredOutput(t *testing.T) {
 				require.NotNil(t, req.Params.Text.Format.JSONSchema.Properties)
 				assert.Len(t, *req.Params.Text.Format.JSONSchema.Properties, 2)
 				assert.ElementsMatch(t, []string{"name", "score"}, req.Params.Text.Format.JSONSchema.Required)
+				require.NotNil(t, req.Params.Text.Format.JSONSchema.AdditionalProperties)
+				require.NotNil(t, req.Params.Text.Format.JSONSchema.AdditionalProperties.AdditionalPropertiesBool)
+				assert.False(t, *req.Params.Text.Format.JSONSchema.AdditionalProperties.AdditionalPropertiesBool)
 			} else {
 				assert.Nil(t, req.Params.Text)
 			}
 		})
 	}
+}
+
+func TestConvertToBifrostResponsesRequestStructuredOutputStringEnum(t *testing.T) {
+	b := &LLM{
+		provider:        schemas.OpenAI,
+		defaultModel:    "gpt-4",
+		useResponsesAPI: true,
+	}
+
+	cfg := llm.LanguageModelConfig{
+		Model:              "gpt-4",
+		MaxGeneratedTokens: 1000,
+		JSONOutputFormat: &jsonschema.Schema{
+			Type: "string",
+			Enum: []any{"open", "closed"},
+		},
+	}
+
+	req, err := b.convertToBifrostResponsesRequest(llm.CompletionRequest{}, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, req.Params.Text)
+	require.NotNil(t, req.Params.Text.Format)
+	require.NotNil(t, req.Params.Text.Format.JSONSchema)
+	assert.Equal(t, []string{"open", "closed"}, req.Params.Text.Format.JSONSchema.Enum)
+}
+
+func TestConvertToBifrostResponsesRequestStructuredOutputRejectsNonStringEnum(t *testing.T) {
+	b := &LLM{
+		provider:        schemas.OpenAI,
+		defaultModel:    "gpt-4",
+		useResponsesAPI: true,
+	}
+
+	cfg := llm.LanguageModelConfig{
+		Model:              "gpt-4",
+		MaxGeneratedTokens: 1000,
+		JSONOutputFormat: &jsonschema.Schema{
+			Type: "integer",
+			Enum: []any{1, 2},
+		},
+	}
+
+	_, err := b.convertToBifrostResponsesRequest(llm.CompletionRequest{}, cfg)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "enum[0] must be a string")
+}
+
+func TestConvertToBifrostResponsesRequestStructuredOutputMultiTypeArray(t *testing.T) {
+	b := &LLM{
+		provider:        schemas.OpenAI,
+		defaultModel:    "gpt-4",
+		useResponsesAPI: true,
+	}
+
+	cfg := llm.LanguageModelConfig{
+		Model:              "gpt-4",
+		MaxGeneratedTokens: 1000,
+		JSONOutputFormat: &jsonschema.Schema{
+			Types: []string{"string", "null"},
+		},
+	}
+
+	req, err := b.convertToBifrostResponsesRequest(llm.CompletionRequest{}, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, req.Params.Text.Format.JSONSchema)
+	js := req.Params.Text.Format.JSONSchema
+	assert.Nil(t, js.Type)
+	require.Len(t, js.AnyOf, 2)
+	assert.Equal(t, map[string]any{"type": "string"}, js.AnyOf[0])
+	assert.Equal(t, map[string]any{"type": "null"}, js.AnyOf[1])
+}
+
+func TestConvertToBifrostResponsesRequestStructuredOutputTopLevelAnyOf(t *testing.T) {
+	b := &LLM{
+		provider:        schemas.OpenAI,
+		defaultModel:    "gpt-4",
+		useResponsesAPI: true,
+	}
+
+	cfg := llm.LanguageModelConfig{
+		Model:              "gpt-4",
+		MaxGeneratedTokens: 1000,
+		JSONOutputFormat: &jsonschema.Schema{
+			AnyOf: []*jsonschema.Schema{
+				{Type: "string"},
+				{Type: "number"},
+			},
+		},
+	}
+
+	req, err := b.convertToBifrostResponsesRequest(llm.CompletionRequest{}, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, req.Params.Text.Format.JSONSchema)
+	js := req.Params.Text.Format.JSONSchema
+	require.Len(t, js.AnyOf, 2)
+	assert.Equal(t, map[string]any{"type": "string"}, js.AnyOf[0])
+	assert.Equal(t, map[string]any{"type": "number"}, js.AnyOf[1])
+}
+
+func TestChatCompletionNoStreamReturnsErrorForUnsupportedResponsesSchema(t *testing.T) {
+	b := &LLM{
+		provider:        schemas.OpenAI,
+		defaultModel:    "gpt-4",
+		useResponsesAPI: true,
+	}
+
+	_, err := b.ChatCompletionNoStream(
+		llm.CompletionRequest{},
+		func(cfg *llm.LanguageModelConfig) {
+			cfg.Model = "gpt-4"
+			cfg.JSONOutputFormat = &jsonschema.Schema{
+				Type: "integer",
+				Enum: []any{1, 2},
+			}
+		},
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "enum[0] must be a string")
 }
 
 func TestEnvProxyRouting(t *testing.T) {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -9115,6 +9115,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -9115,7 +9115,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",


### PR DESCRIPTION
#### Summary
- flatten Bifrost Responses API structured output schemas into typed `ResponsesTextConfigFormatJSONSchema` fields so recaps send a concrete schema through the AI bridge
- update the structured output regression test to assert the Responses schema is serialized through typed fields instead of nested under `schema`
- include the requested `webapp/package-lock.json` change in this branch
- validation: `go build ./bifrost ./api` and `go test -count=1 ./bifrost -run TestConvertToBifrostResponsesRequestStructuredOutput`

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
Fixed Bifrost Responses API structured output schema serialization so recaps can send concrete JSON schemas through the AI bridge.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced typed JSON Schema handling for response configurations and stricter validation of schema shapes.
  * Streaming will now halt and surface an explicit error when a response schema cannot be converted.

* **Bug Fixes**
  * Improved error messages and validation for enum and multi-type schemas to prevent invalid configurations.

* **Tests**
  * Added and updated tests covering enum validation, multi-type schemas, anyOf propagation and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->