### PR TITLE
Add legacy bot migration unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fergusstrange/embedded-postgres v1.34.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
@@ -193,6 +194,7 @@ require (
 	github.com/wiggin77/merror v1.0.5 // indirect
 	github.com/wiggin77/srslog v1.0.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	gitlab.com/golang-commonmark/html v0.0.0-20191124015941-a22733972181 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fergusstrange/embedded-postgres v1.34.0 h1:c6RKhPKFsLVU+Tdxsx8q0UxCHsvZZ/iShAnljRBXs6s=
+github.com/fergusstrange/embedded-postgres v1.34.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
@@ -593,6 +595,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/server/legacy_bot_migration_test.go
+++ b/server/legacy_bot_migration_test.go
@@ -5,10 +5,11 @@ package main
 
 import (
 	"fmt"
-	"net"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,75 +27,104 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var legacyMigrationTestConnStr string
+var (
+	legacyMigrationTestConnStr string
+	legacyMigrationTestBaseDir string
+	legacyMigrationTestDB      *embeddedpostgres.EmbeddedPostgres
+	legacyMigrationSetupOnce   sync.Once
+	legacyMigrationSetupErr    error
+)
 
 func TestMain(m *testing.M) {
 	os.Exit(runLegacyBotMigrationTestMain(m))
 }
 
 func runLegacyBotMigrationTestMain(m *testing.M) int {
-	baseDir, err := os.MkdirTemp("", "legacy-bot-migration-testdb-*")
-	if err != nil {
-		fmt.Printf("Failed to create temp dir: %v\n", err)
-		return 1
-	}
-	defer os.RemoveAll(baseDir)
-
-	port, err := getFreePort()
-	if err != nil {
-		fmt.Printf("Failed to allocate postgres port: %v\n", err)
-		return 1
-	}
-
-	dbConfig := embeddedpostgres.DefaultConfig().
-		Port(port).
-		Database("testdb").
-		Username("testuser").
-		Password("testpass").
-		StartTimeout(2 * time.Minute).
-		RuntimePath(filepath.Join(baseDir, "runtime")).
-		DataPath(filepath.Join(baseDir, "data")).
-		BinariesPath(filepath.Join(baseDir, "binaries")).
-		CachePath(filepath.Join(baseDir, "cache"))
-
-	postgres := embeddedpostgres.NewDatabase(dbConfig)
-	if err := postgres.Start(); err != nil {
-		fmt.Printf("Failed to start embedded postgres: %v\n", err)
-		return 1
-	}
-
-	legacyMigrationTestConnStr = dbConfig.GetConnectionURL()
 	code := m.Run()
 
-	if err := postgres.Stop(); err != nil {
-		fmt.Printf("Failed to stop embedded postgres: %v\n", err)
-		return 1
+	if legacyMigrationTestDB != nil {
+		if err := legacyMigrationTestDB.Stop(); err != nil {
+			fmt.Printf("Failed to stop embedded postgres: %v\n", err)
+			return 1
+		}
+	}
+
+	if legacyMigrationTestBaseDir != "" {
+		if err := os.RemoveAll(legacyMigrationTestBaseDir); err != nil {
+			fmt.Printf("Failed to remove temp dir: %v\n", err)
+			return 1
+		}
 	}
 
 	return code
 }
 
-func getFreePort() (uint32, error) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+func ensureLegacyMigrationPostgres(t *testing.T) {
+	t.Helper()
+
+	legacyMigrationSetupOnce.Do(func() {
+		legacyMigrationSetupErr = startLegacyMigrationPostgres()
+	})
+
+	require.NoError(t, legacyMigrationSetupErr)
+	require.NotEmpty(t, legacyMigrationTestConnStr)
+}
+
+func startLegacyMigrationPostgres() error {
+	baseDir, err := os.MkdirTemp("", "legacy-bot-migration-testdb-*")
 	if err != nil {
-		return 0, err
+		return fmt.Errorf("failed to create temp dir: %w", err)
 	}
-	defer listener.Close()
+	legacyMigrationTestBaseDir = baseDir
 
-	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
-	if !ok {
-		return 0, fmt.Errorf("unexpected listener address type %T", listener.Addr())
+	for attempt := 0; attempt < 10; attempt++ {
+		port := legacyMigrationPortForAttempt(attempt)
+
+		dbConfig := embeddedpostgres.DefaultConfig().
+			Port(port).
+			Database("testdb").
+			Username("testuser").
+			Password("testpass").
+			StartTimeout(2 * time.Minute).
+			RuntimePath(filepath.Join(baseDir, "runtime")).
+			DataPath(filepath.Join(baseDir, "data")).
+			BinariesPath(filepath.Join(baseDir, "binaries")).
+			CachePath(filepath.Join(baseDir, "cache"))
+
+		postgres := embeddedpostgres.NewDatabase(dbConfig)
+		if err := postgres.Start(); err != nil {
+			_ = postgres.Stop()
+			if isPortInUseError(err) {
+				continue
+			}
+			return fmt.Errorf("failed to start embedded postgres: %w", err)
+		}
+
+		legacyMigrationTestDB = postgres
+		legacyMigrationTestConnStr = dbConfig.GetConnectionURL()
+		return nil
 	}
 
-	if tcpAddr.Port < 0 || tcpAddr.Port > 65535 {
-		return 0, fmt.Errorf("unexpected TCP port %d", tcpAddr.Port)
+	return fmt.Errorf("failed to start embedded postgres after multiple port attempts")
+}
+
+func legacyMigrationPortForAttempt(attempt int) uint32 {
+	offset := (time.Now().UnixNano() + int64(attempt*7919)) % 30000
+	if offset < 0 {
+		offset = -offset
 	}
 
-	return uint32(tcpAddr.Port), nil
+	return uint32(20000 + offset)
+}
+
+func isPortInUseError(err error) bool {
+	return strings.Contains(err.Error(), "already listening on port") ||
+		strings.Contains(err.Error(), "address already in use")
 }
 
 func setupLegacyMigrationStore(t *testing.T) *store.Store {
 	t.Helper()
+	ensureLegacyMigrationPostgres(t)
 
 	setupDB, err := sqlx.Connect("postgres", legacyMigrationTestConnStr)
 	require.NoError(t, err)

--- a/server/legacy_bot_migration_test.go
+++ b/server/legacy_bot_migration_test.go
@@ -1,0 +1,389 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+	"github.com/mattermost/mattermost-plugin-agents/config"
+	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/mattermost/mattermost-plugin-agents/store"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var legacyMigrationTestConnStr string
+
+func TestMain(m *testing.M) {
+	baseDir, err := os.MkdirTemp("", "legacy-bot-migration-testdb-*")
+	if err != nil {
+		fmt.Printf("Failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(baseDir)
+
+	port, err := getFreePort()
+	if err != nil {
+		fmt.Printf("Failed to allocate postgres port: %v\n", err)
+		os.Exit(1)
+	}
+
+	dbConfig := embeddedpostgres.DefaultConfig().
+		Port(port).
+		Database("testdb").
+		Username("testuser").
+		Password("testpass").
+		StartTimeout(2 * time.Minute).
+		RuntimePath(filepath.Join(baseDir, "runtime")).
+		DataPath(filepath.Join(baseDir, "data")).
+		BinariesPath(filepath.Join(baseDir, "binaries")).
+		CachePath(filepath.Join(baseDir, "cache"))
+
+	postgres := embeddedpostgres.NewDatabase(dbConfig)
+	if err := postgres.Start(); err != nil {
+		fmt.Printf("Failed to start embedded postgres: %v\n", err)
+		os.Exit(1)
+	}
+
+	legacyMigrationTestConnStr = dbConfig.GetConnectionURL()
+	code := m.Run()
+
+	if err := postgres.Stop(); err != nil {
+		fmt.Printf("Failed to stop embedded postgres: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}
+
+func getFreePort() (uint32, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("unexpected listener address type %T", listener.Addr())
+	}
+
+	return uint32(tcpAddr.Port), nil
+}
+
+func setupLegacyMigrationStore(t *testing.T) *store.Store {
+	t.Helper()
+
+	setupDB, err := sqlx.Connect("postgres", legacyMigrationTestConnStr)
+	require.NoError(t, err)
+
+	schemaName := fmt.Sprintf("test_%d", time.Now().UnixNano())
+	_, err = setupDB.Exec(fmt.Sprintf("CREATE SCHEMA %s", schemaName))
+	require.NoError(t, err)
+	setupDB.Close()
+
+	connStr := withSearchPath(t, legacyMigrationTestConnStr, schemaName)
+	db, err := sqlx.Connect("postgres", connStr)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.Exec(fmt.Sprintf("DROP SCHEMA %s CASCADE", schemaName))
+		db.Close()
+	})
+
+	st := store.New(db)
+	require.NoError(t, st.RunMigrations())
+
+	return st
+}
+
+func withSearchPath(t *testing.T, connStr, schemaName string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(connStr)
+	require.NoError(t, err)
+
+	query := parsed.Query()
+	query.Set("search_path", schemaName)
+	parsed.RawQuery = query.Encode()
+
+	return parsed.String()
+}
+
+func newLegacyBotConfig(username string) llm.BotConfig {
+	return llm.BotConfig{
+		ID:                      "legacy-" + username,
+		Name:                    username,
+		DisplayName:             "Legacy " + username,
+		CustomInstructions:      "Help as " + username,
+		ServiceID:               "svc-1",
+		Model:                   "gpt-4o",
+		EnableVision:            true,
+		DisableTools:            false,
+		ChannelAccessLevel:      llm.ChannelAccessLevelAllow,
+		ChannelIDs:              []string{"channel-1"},
+		UserAccessLevel:         llm.UserAccessLevelAll,
+		TeamIDs:                 []string{"team-1"},
+		EnabledNativeTools:      []string{"web_search"},
+		EnabledMCPTools:         []llm.EnabledMCPTool{{ServerOrigin: "https://mcp.example.com", ToolName: "search_posts"}},
+		AutoEnableNewMCPTools:   false,
+		ReasoningEnabled:        true,
+		ReasoningEffort:         "medium",
+		ThinkingBudget:          2048,
+		StructuredOutputEnabled: true,
+		BotUserID:               "config-user-" + username,
+		CreatorID:               "legacy-creator",
+		AdminUserIDs:            []string{"legacy-admin"},
+		CreateAt:                111,
+		UpdateAt:                222,
+		DeleteAt:                333,
+	}
+}
+
+func newLegacyConfig(bots ...llm.BotConfig) config.Config {
+	return config.Config{
+		Bots:           bots,
+		DefaultBotName: "legacy-default",
+	}
+}
+
+func newPluginAPIForMigration(t *testing.T, mmBots []*model.Bot) (*plugintest.API, *pluginapi.Client) {
+	t.Helper()
+
+	api := &plugintest.API{}
+	api.On("KVSetWithOptions", mock.AnythingOfType("string"), mock.AnythingOfType("[]uint8"), mock.AnythingOfType("model.PluginKVSetOptions")).Return(true, nil).Maybe()
+	api.On("KVDelete", mock.AnythingOfType("string")).Return(nil).Maybe()
+	api.On("GetBots", mock.AnythingOfType("*model.BotGetOptions")).Return(mmBots, nil).Maybe()
+	api.On("LogWarn", mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+	api.On("LogInfo", mock.Anything).Return().Maybe()
+
+	return api, pluginapi.NewClient(api, nil)
+}
+
+func saveConfigAndLoadContainer(t *testing.T, st *store.Store, cfgValue config.Config) *config.Container {
+	t.Helper()
+
+	require.NoError(t, st.SaveConfig(cfgValue))
+
+	cfg := &config.Container{}
+	cfg.Update(&cfgValue)
+
+	return cfg
+}
+
+func agentByName(t *testing.T, st *store.Store) map[string]*llm.BotConfig {
+	t.Helper()
+
+	agents, err := st.ListAgents()
+	require.NoError(t, err)
+
+	byName := make(map[string]*llm.BotConfig, len(agents))
+	for _, agent := range agents {
+		byName[agent.Name] = agent
+	}
+
+	return byName
+}
+
+func TestMigrateLegacyConfigBotsToUserAgentsAlreadyMigrated(t *testing.T) {
+	st := setupLegacyMigrationStore(t)
+	cfgValue := newLegacyConfig(newLegacyBotConfig("alpha"))
+	cfg := saveConfigAndLoadContainer(t, st, cfgValue)
+	require.NoError(t, st.SetSystemValue(legacyConfigBotsMigratedKey, "true"))
+
+	mockAPI, pluginClient := newPluginAPIForMigration(t, nil)
+
+	migrated, err := migrateLegacyConfigBotsToUserAgents(mockAPI, pluginClient, st, cfg)
+	require.NoError(t, err)
+	assert.False(t, migrated)
+
+	agents, err := st.ListAgents()
+	require.NoError(t, err)
+	assert.Empty(t, agents)
+
+	reloaded, err := st.GetConfig()
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	require.Len(t, reloaded.Bots, 1)
+	assert.Equal(t, "alpha", reloaded.Bots[0].Name)
+
+	flag, err := st.GetSystemValue(legacyConfigBotsMigratedKey)
+	require.NoError(t, err)
+	assert.Equal(t, "true", flag)
+}
+
+func TestMigrateLegacyConfigBotsToUserAgentsNoConfigBots(t *testing.T) {
+	st := setupLegacyMigrationStore(t)
+	cfgValue := newLegacyConfig()
+	cfg := saveConfigAndLoadContainer(t, st, cfgValue)
+
+	mockAPI, pluginClient := newPluginAPIForMigration(t, nil)
+
+	migrated, err := migrateLegacyConfigBotsToUserAgents(mockAPI, pluginClient, st, cfg)
+	require.NoError(t, err)
+	assert.False(t, migrated)
+
+	agents, err := st.ListAgents()
+	require.NoError(t, err)
+	assert.Empty(t, agents)
+
+	reloaded, err := st.GetConfig()
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	assert.Empty(t, reloaded.Bots)
+
+	flag, err := st.GetSystemValue(legacyConfigBotsMigratedKey)
+	require.NoError(t, err)
+	assert.Empty(t, flag)
+}
+
+func TestMigrateLegacyConfigBotsToUserAgentsDefersWhenMMBotMissing(t *testing.T) {
+	st := setupLegacyMigrationStore(t)
+	cfgValue := newLegacyConfig(newLegacyBotConfig("alpha"))
+	cfg := saveConfigAndLoadContainer(t, st, cfgValue)
+
+	mockAPI, pluginClient := newPluginAPIForMigration(t, []*model.Bot{})
+
+	migrated, err := migrateLegacyConfigBotsToUserAgents(mockAPI, pluginClient, st, cfg)
+	require.NoError(t, err)
+	assert.False(t, migrated)
+
+	agents, err := st.ListAgents()
+	require.NoError(t, err)
+	assert.Empty(t, agents)
+
+	reloaded, err := st.GetConfig()
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	require.Len(t, reloaded.Bots, 1)
+	assert.Equal(t, "alpha", reloaded.Bots[0].Name)
+	require.NotNil(t, cfg.Config())
+	require.Len(t, cfg.Config().Bots, 1)
+
+	flag, err := st.GetSystemValue(legacyConfigBotsMigratedKey)
+	require.NoError(t, err)
+	assert.Empty(t, flag)
+}
+
+func TestMigrateLegacyConfigBotsToUserAgentsHappyPath(t *testing.T) {
+	st := setupLegacyMigrationStore(t)
+	cfgValue := newLegacyConfig(
+		newLegacyBotConfig("alpha"),
+		newLegacyBotConfig("beta"),
+	)
+	cfg := saveConfigAndLoadContainer(t, st, cfgValue)
+
+	mockAPI, pluginClient := newPluginAPIForMigration(t, []*model.Bot{
+		{Username: "alpha", UserId: "mm-user-alpha"},
+		{Username: "beta", UserId: "mm-user-beta"},
+	})
+
+	migrated, err := migrateLegacyConfigBotsToUserAgents(mockAPI, pluginClient, st, cfg)
+	require.NoError(t, err)
+	assert.True(t, migrated)
+
+	agents := agentByName(t, st)
+	require.Len(t, agents, 2)
+
+	alpha := agents["alpha"]
+	require.NotNil(t, alpha)
+	assert.Equal(t, "Legacy alpha", alpha.DisplayName)
+	assert.Equal(t, "Help as alpha", alpha.CustomInstructions)
+	assert.Equal(t, "svc-1", alpha.ServiceID)
+	assert.Equal(t, "mm-user-alpha", alpha.BotUserID)
+	assert.Empty(t, alpha.CreatorID)
+	assert.Nil(t, alpha.AdminUserIDs)
+	assert.True(t, alpha.AutoEnableNewMCPTools)
+	assert.Nil(t, alpha.EnabledMCPTools)
+	assert.NotEmpty(t, alpha.ID)
+	assert.NotZero(t, alpha.CreateAt)
+	assert.NotZero(t, alpha.UpdateAt)
+	assert.Zero(t, alpha.DeleteAt)
+
+	beta := agents["beta"]
+	require.NotNil(t, beta)
+	assert.Equal(t, "mm-user-beta", beta.BotUserID)
+	assert.True(t, beta.AutoEnableNewMCPTools)
+	assert.Nil(t, beta.EnabledMCPTools)
+
+	reloaded, err := st.GetConfig()
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	assert.Empty(t, reloaded.Bots)
+	require.NotNil(t, cfg.Config())
+	assert.Empty(t, cfg.Config().Bots)
+
+	flag, err := st.GetSystemValue(legacyConfigBotsMigratedKey)
+	require.NoError(t, err)
+	assert.Equal(t, "true", flag)
+}
+
+func TestMigrateLegacyConfigBotsToUserAgentsSkipsExistingUsername(t *testing.T) {
+	st := setupLegacyMigrationStore(t)
+	cfgValue := newLegacyConfig(
+		newLegacyBotConfig("alpha"),
+		newLegacyBotConfig("beta"),
+	)
+	cfg := saveConfigAndLoadContainer(t, st, cfgValue)
+
+	existing := newLegacyBotConfig("alpha")
+	existing.BotUserID = "existing-mm-user-alpha"
+	existing.CreatorID = "existing-creator"
+	existing.AdminUserIDs = []string{"existing-admin"}
+	existing.AutoEnableNewMCPTools = false
+	existing.EnabledMCPTools = []llm.EnabledMCPTool{{ServerOrigin: "https://mcp.example.com", ToolName: "existing_tool"}}
+	require.NoError(t, st.CreateAgent(&existing))
+	existingID := existing.ID
+	existingBotUserID := existing.BotUserID
+
+	mockAPI, pluginClient := newPluginAPIForMigration(t, []*model.Bot{
+		{Username: "alpha", UserId: "mm-user-alpha"},
+		{Username: "beta", UserId: "mm-user-beta"},
+	})
+
+	migrated, err := migrateLegacyConfigBotsToUserAgents(mockAPI, pluginClient, st, cfg)
+	require.NoError(t, err)
+	assert.True(t, migrated)
+
+	agents := agentByName(t, st)
+	require.Len(t, agents, 2)
+
+	alpha := agents["alpha"]
+	require.NotNil(t, alpha)
+	assert.Equal(t, existingID, alpha.ID)
+	assert.Equal(t, existingBotUserID, alpha.BotUserID)
+	assert.Equal(t, "existing-creator", alpha.CreatorID)
+	assert.False(t, alpha.AutoEnableNewMCPTools)
+	require.Len(t, alpha.EnabledMCPTools, 1)
+	assert.Equal(t, "existing_tool", alpha.EnabledMCPTools[0].ToolName)
+
+	beta := agents["beta"]
+	require.NotNil(t, beta)
+	assert.Equal(t, "mm-user-beta", beta.BotUserID)
+	assert.Empty(t, beta.CreatorID)
+	assert.True(t, beta.AutoEnableNewMCPTools)
+	assert.Nil(t, beta.EnabledMCPTools)
+
+	reloaded, err := st.GetConfig()
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	assert.Empty(t, reloaded.Bots)
+
+	flag, err := st.GetSystemValue(legacyConfigBotsMigratedKey)
+	require.NoError(t, err)
+	assert.Equal(t, "true", flag)
+}

--- a/server/legacy_bot_migration_test.go
+++ b/server/legacy_bot_migration_test.go
@@ -114,7 +114,12 @@ func legacyMigrationPortForAttempt(attempt int) uint32 {
 		offset = -offset
 	}
 
-	return uint32(20000 + offset)
+	port := int64(20000) + offset
+	if port < 0 || port > 65535 {
+		panic(fmt.Sprintf("legacy migration test picked invalid port %d", port))
+	}
+
+	return uint32(port)
 }
 
 func isPortInUseError(err error) bool {

--- a/server/legacy_bot_migration_test.go
+++ b/server/legacy_bot_migration_test.go
@@ -29,17 +29,21 @@ import (
 var legacyMigrationTestConnStr string
 
 func TestMain(m *testing.M) {
+	os.Exit(runLegacyBotMigrationTestMain(m))
+}
+
+func runLegacyBotMigrationTestMain(m *testing.M) int {
 	baseDir, err := os.MkdirTemp("", "legacy-bot-migration-testdb-*")
 	if err != nil {
 		fmt.Printf("Failed to create temp dir: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 	defer os.RemoveAll(baseDir)
 
 	port, err := getFreePort()
 	if err != nil {
 		fmt.Printf("Failed to allocate postgres port: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	dbConfig := embeddedpostgres.DefaultConfig().
@@ -56,7 +60,7 @@ func TestMain(m *testing.M) {
 	postgres := embeddedpostgres.NewDatabase(dbConfig)
 	if err := postgres.Start(); err != nil {
 		fmt.Printf("Failed to start embedded postgres: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	legacyMigrationTestConnStr = dbConfig.GetConnectionURL()
@@ -64,10 +68,10 @@ func TestMain(m *testing.M) {
 
 	if err := postgres.Stop(); err != nil {
 		fmt.Printf("Failed to stop embedded postgres: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
-	os.Exit(code)
+	return code
 }
 
 func getFreePort() (uint32, error) {
@@ -80,6 +84,10 @@ func getFreePort() (uint32, error) {
 	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
 	if !ok {
 		return 0, fmt.Errorf("unexpected listener address type %T", listener.Addr())
+	}
+
+	if tcpAddr.Port < 0 || tcpAddr.Port > 65535 {
+		return 0, fmt.Errorf("unexpected TCP port %d", tcpAddr.Port)
 	}
 
 	return uint32(tcpAddr.Port), nil


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Added focused coverage for `migrateLegacyConfigBotsToUserAgents` covering already-migrated idempotency, empty config no-op, deferred migration when Mattermost bot rows are missing, happy-path migration with config cleanup, and username de-dup skipping. The new `server/legacy_bot_migration_test.go` uses embedded Postgres plus mocked Mattermost bot listing so the migration path runs end-to-end in tests.

Follow-up review and CI fixes tightened the test bootstrap:
- embedded Postgres now starts lazily only when the migration tests call `setupLegacyMigrationStore`, so unrelated `./server` tests do not depend on database startup
- the bootstrap no longer uses a free-port probe; it retries startup with a fresh temp workspace/port on bind conflicts to avoid the TOCTOU race called out in review
- cleanup still runs through a helper return path instead of `os.Exit` bypassing defers
- retry port selection now uses an explicit checked conversion before `uint32` to satisfy `gosec` overflow checks

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-65671

#### Screenshots
None.

#### Release Note
```release-note
NONE
```

#### Testing
- `go test -v ./server -run '^TestMigrateLegacyConfigBotsToUserAgents' -count=1`
- `go test -v ./server -run '^TestInMemoryServerCreation$' -count=1`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3954561e-0353-4282-b5ce-dcefaa58ebf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3954561e-0353-4282-b5ce-dcefaa58ebf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

