### PR TITLE
Fix AI bot listing panic for filtered agents

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -419,7 +419,7 @@ func (a *API) getAIBotsForUser(userID string) ([]AIBotInfo, error) {
 	// Put the default bot first.
 	bots := make([]AIBotInfo, 0, len(allBots))
 	defaultBotName := a.config.GetDefaultBotName()
-	for i, bot := range allBots {
+	for _, bot := range allBots {
 		// Don't return bots the user is excluded from using.
 		if a.bots.CheckUsageRestrictionsForUser(bot, userID) != nil {
 			continue
@@ -448,7 +448,8 @@ func (a *API) getAIBotsForUser(userID string) ([]AIBotInfo, error) {
 			AutoEnableNewMCPTools: bot.GetConfig().AutoEnableNewMCPTools,
 		})
 		if bot.GetMMBot().Username == defaultBotName {
-			bots[0], bots[i] = bots[i], bots[0]
+			last := len(bots) - 1
+			bots[0], bots[last] = bots[last], bots[0]
 		}
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -740,6 +740,54 @@ func TestHandleGetAIBots(t *testing.T) {
 	}
 }
 
+func TestHandleGetAIBotsDefaultBotAfterFilteredBot(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	filteredBot := bots.NewBot(
+		llm.BotConfig{
+			Name:            "hidden",
+			DisplayName:     "Hidden Agent",
+			UserAccessLevel: llm.UserAccessLevelBlock,
+			UserIDs:         []string{"userid"},
+		},
+		llm.ServiceConfig{},
+		&model.Bot{UserId: "hiddenbotuserid1234567890", Username: "hidden", DisplayName: "Hidden Agent"},
+		nil,
+	)
+	defaultBot := bots.NewBot(
+		llm.BotConfig{
+			Name:        "ai",
+			DisplayName: "Default Agent",
+		},
+		llm.ServiceConfig{},
+		&model.Bot{UserId: "defaultbotuserid1234567890", Username: "ai", DisplayName: "Default Agent"},
+		nil,
+	)
+	e.bots.SetBotsForTesting([]*bots.Bot{filteredBot, defaultBot})
+
+	e.mockAPI.On("GetChannelByName", "", mock.AnythingOfType("string"), false).Return(nil, &model.AppError{})
+	e.mockAPI.On("LogError", mock.Anything).Maybe()
+
+	request := httptest.NewRequest(http.MethodGet, "/ai_bots", nil)
+	request.Header.Add("Mattermost-User-ID", "userid")
+
+	recorder := httptest.NewRecorder()
+	e.api.ServeHTTP(&plugin.Context{}, recorder, request)
+
+	resp := recorder.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var response AIBotsResponse
+	err := json.NewDecoder(resp.Body).Decode(&response)
+	require.NoError(t, err)
+	require.Len(t, response.Bots, 1)
+	require.Equal(t, "ai", response.Bots[0].Username)
+}
+
 func TestToolCallDMAllowedWhenChannelToolCallingDisabled(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DefaultWriter = io.Discard


### PR DESCRIPTION
#### Summary
Fixed the `/ai_bots` default-bot reordering logic so filtered agents can no longer trigger an out-of-range panic.
Added a regression test covering a hidden agent ahead of the visible default agent.

QA:
- `go test ./api -run '^(TestHandleGetAIBots|TestHandleGetAIBotsDefaultBotAfterFilteredBot)$'`

#### Ticket Link
NONE

#### Screenshots
NONE

#### Release Note
```release-note
Fixed a panic when listing AI bots if a filtered agent appeared before the default bot.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the ordering of the default AI bot in results when other bots are filtered or excluded.

* **Tests**
  * Added test validation to ensure the default bot appears correctly after bot filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->