### PR TITLE
Remove the unused min chunk size option from embedding search config

### DIFF
--- a/e2e/helpers/plugincontainer.ts
+++ b/e2e/helpers/plugincontainer.ts
@@ -86,7 +86,6 @@ const RunContainer = async (): Promise<MattermostContainer> => {
 			  "chunkingOptions": {
 				  "chunkSize": 500,
 				  "chunkOverlap": 100,
-				  "minChunkSize": 0.75,
 				  "chunkingStrategy": "sentences"
 			  }
 		  }

--- a/webapp/src/components/system_console/config.tsx
+++ b/webapp/src/components/system_console/config.tsx
@@ -123,7 +123,6 @@ const defaultConfig: Config = {
         chunkingOptions: {
             chunkSize: 1000,
             chunkOverlap: 200,
-            minChunkSize: 0.75,
             chunkingStrategy: 'sentences',
         },
     },

--- a/webapp/src/components/system_console/embedding_search/chunking_options.tsx
+++ b/webapp/src/components/system_console/embedding_search/chunking_options.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {useIntl} from 'react-intl';
 
 import {SelectionItem, SelectionItemOption} from '../item';
-import {IntItem, FloatItem} from '../number_items';
+import {IntItem} from '../number_items';
 
 import {ChunkingOptions, EmbeddingSearchConfig} from './types';
 
@@ -21,7 +21,6 @@ export const ChunkingOptionsConfig = ({value, onChange}: ChunkingOptionsProps) =
     const defaultChunkingOptions = {
         chunkSize: 1000,
         chunkOverlap: 200,
-        minChunkSize: 0.75,
         chunkingStrategy: 'sentences',
     };
 
@@ -76,24 +75,6 @@ export const ChunkingOptionsConfig = ({value, onChange}: ChunkingOptionsProps) =
                 }}
                 min={0}
                 helptext={intl.formatMessage({defaultMessage: 'Number of characters to overlap between chunks.'})}
-            />
-
-            <FloatItem
-                label={intl.formatMessage({defaultMessage: 'Minimum Chunk Size Ratio'})}
-                placeholder={defaultChunkingOptions.minChunkSize.toString()}
-                value={value.chunkingOptions?.minChunkSize || defaultChunkingOptions.minChunkSize}
-                onChange={(minChunkSize) => {
-                    onChange({
-                        ...value,
-                        chunkingOptions: {
-                            ...(value.chunkingOptions || defaultChunkingOptions),
-                            minChunkSize,
-                        } as ChunkingOptions,
-                    });
-                }}
-                min={0}
-                max={1}
-                helptext={intl.formatMessage({defaultMessage: 'Minimum chunk size as a fraction of the maximum size (0.0-1.0). Used for sentence and paragraph chunking.'})}
             />
         </>
     );

--- a/webapp/src/components/system_console/embedding_search/embedding_search_panel.tsx
+++ b/webapp/src/components/system_console/embedding_search/embedding_search_panel.tsx
@@ -122,7 +122,6 @@ const EmbeddingSearchPanel = ({value, onChange}: Props) => {
                                 chunkingOptions: {
                                     chunkSize: 1000,
                                     chunkOverlap: 200,
-                                    minChunkSize: 0.75,
                                     chunkingStrategy: 'sentences',
                                 },
                             });
@@ -136,7 +135,6 @@ const EmbeddingSearchPanel = ({value, onChange}: Props) => {
                                 chunkingOptions: {
                                     chunkSize: 1000,
                                     chunkOverlap: 200,
-                                    minChunkSize: 0.75,
                                     chunkingStrategy: 'sentences',
                                 },
                             });

--- a/webapp/src/components/system_console/embedding_search/types.tsx
+++ b/webapp/src/components/system_console/embedding_search/types.tsx
@@ -9,7 +9,6 @@ export interface UpstreamConfig {
 export interface ChunkingOptions {
     chunkSize: number;
     chunkOverlap: number;
-    minChunkSize: number;
     chunkingStrategy: string;
 }
 

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -51,7 +51,6 @@
   "4dZi3YBP": "API Key",
   "4f3EON2K": "Back to prompts",
   "4f8V1W0M": "Enable Embedding Search",
-  "4vkIJYq+": "Minimum Chunk Size Ratio",
   "4wQOb/5v": "Optional: Override the service's default model for this agent. Select from the list or type a custom model name.",
   "5+vsd4fd": "Use Responses API",
   "5EVl/vXb": "{serverName}, {detail}. Press to expand or collapse tools.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Removes the unused `minChunkSize` embedding-search setting from the system console config shape, defaults, i18n catalog, and e2e fixture so the UI/config no longer expose a backend-ignored option.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-64220

#### Screenshots
![Embedding search toggled on and scrolled](https://cursor.com/artifacts/c/art-f5308c74-c29e-41e5-8021-a0d5831be8ce)

#### Walkthrough
<a href="https://cursor.com/agents/bc-87715ba6-4ff9-405a-920d-a66cd3b6114b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fembedding_search_toggled_and_scrolled.webm"><img src="https://cursor.com/artifacts/c/art-2ce2c113-8945-4842-8027-fbd2aab7b46c" alt="embedding_search_toggled_and_scrolled.webm" /></a>

#### Release Note
```release-note
Removed the unused `minChunkSize` embedding search configuration option from the system console and related config fixtures.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87715ba6-4ff9-405a-920d-a66cd3b6114b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87715ba6-4ff9-405a-920d-a66cd3b6114b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the Minimum Chunk Size Ratio configuration option from the embedding search feature
  * This includes removal of the default configuration value, the system console UI control, the exported type definition, and the English localization entry for this setting
  * All configuration logic and related default handling throughout the system has been updated accordingly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->