### PR TITLE
Fix MCP tool toggle alignment

### DIFF
--- a/webapp/src/components/agents/tabs/mcps_tab.tsx
+++ b/webapp/src/components/agents/tabs/mcps_tab.tsx
@@ -328,7 +328,7 @@ const McpsTab = (props: Props) => {
                                                     disabled={autoEnableNewMCPTools}
                                                     $enabled={toolOn}
                                                 >
-                                                    <ToggleKnob $enabled={toolOn}/>
+                                                    <ToolToggleKnob $enabled={toolOn}/>
                                                 </ToolToggle>
                                             </ToolRow>
                                         );
@@ -578,6 +578,11 @@ const ToolToggle = styled(ServerToggle)`
     width: 36px;
     height: 20px;
     border-radius: 10px;
+`;
+
+const ToolToggleKnob = styled(ToggleKnob)<{$enabled: boolean}>`
+    top: 1px;
+    left: ${(p) => (p.$enabled ? '17px' : '1px')};
 `;
 
 const OrphanedToolsWarning = styled.div`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Adjusted the nested MCP tool toggle thumb offsets so the smaller per-tool switches align cleanly within their tracks and match the server-level toggle appearance.

#### Ticket Link
NONE

#### Screenshots
Before:
<img width="1304" height="876" alt="image" src="https://github.com/user-attachments/assets/a15b58f7-ced8-437f-bf21-a0f6154d33d5" />

After:
<img width="658" height="719" alt="image" src="https://github.com/user-attachments/assets/8ba42ac2-bf49-4433-af40-1f115e4d5fb2" />


#### Release Note
```release-note
Fixed the self-serve agent MCP tab so expanded tool toggles align correctly with the server toggle styling.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9a467fe-2aff-48af-9280-0a36803afb8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9a467fe-2aff-48af-9280-0a36803afb8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tool toggle switch styling to improve visual alignment and consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->