### PR TITLE
fix mixed tool approval rendering

### DIFF
--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -25,7 +25,6 @@ import {
     extractReasoningFromTurn,
     extractAnnotationsFromTurn,
     deriveApprovalStageForPost,
-    hasAutoApprovedToolsForPost,
 } from './turn_content_utils';
 import {ReasoningDisplay, LoadingSpinner, MinimalReasoningContainer} from './reasoning_display';
 import {ControlsBarComponent} from './controls_bar';
@@ -79,7 +78,6 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     const [generating, setGenerating] = useState(false);
     const [toolCalls, setToolCalls] = useState<ToolCall[]>([]);
     const [toolApprovalStage, setToolApprovalStage] = useState<ToolApprovalStage>('call');
-    const [isAutoApproved, setIsAutoApproved] = useState(false);
     const [annotations, setAnnotations] = useState<Annotation[]>([]);
     const [precontent, setPrecontent] = useState(props.post.message === '');
     const [error, setError] = useState('');
@@ -110,7 +108,6 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
             const derived = extractToolCallsForPost(conversation, props.post.id);
             setToolCalls(derived);
             setToolApprovalStage(deriveApprovalStageForPost(conversation, props.post.id));
-            setIsAutoApproved(hasAutoApprovedToolsForPost(conversation, props.post.id));
         }
 
         // Reasoning
@@ -367,7 +364,6 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                     canExpand={requesterIsCurrentUser}
                     showArguments={showToolArguments}
                     showResults={showToolResults}
-                    isAutoApproved={isAutoApproved}
                 />
             )}
             <PostText

--- a/webapp/src/components/tool_approval_set.test.tsx
+++ b/webapp/src/components/tool_approval_set.test.tsx
@@ -1,0 +1,90 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {render} from '@testing-library/react';
+import {IntlProvider} from 'react-intl';
+
+import ToolApprovalSet from './tool_approval_set';
+import {ToolCall, ToolCallStatus} from './tool_types';
+
+type MockToolCardProps = {
+    tool: ToolCall;
+    onApprove?: () => void;
+    onReject?: () => void;
+    isAutoApproved?: boolean;
+};
+
+const mockToolCard = jest.fn(() => null);
+
+jest.mock('./tool_card', () => ({
+    __esModule: true,
+    default: (props: MockToolCardProps) => {
+        mockToolCard(props);
+        return null;
+    },
+}));
+
+function makeTool(overrides: Partial<ToolCall>): ToolCall {
+    return {
+        id: 'tool_1',
+        name: 'test_tool',
+        description: '',
+        status: ToolCallStatus.Pending,
+        ...overrides,
+    };
+}
+
+function renderComponent(toolCalls: ToolCall[]) {
+    return render(
+        <IntlProvider locale='en'>
+            <ToolApprovalSet
+                postID='post_1'
+                conversationID='conv_1'
+                toolCalls={toolCalls}
+                approvalStage='call'
+                canApprove={true}
+                canExpand={true}
+                showArguments={true}
+                showResults={true}
+            />
+        </IntlProvider>,
+    );
+}
+
+function getToolCardProps(toolID: string): MockToolCardProps {
+    const match = mockToolCard.mock.calls.find(([props]) => props.tool.id === toolID);
+    expect(match).toBeDefined();
+    return match![0] as MockToolCardProps;
+}
+
+beforeEach(() => {
+    mockToolCard.mockClear();
+});
+
+describe('ToolApprovalSet', () => {
+    test('keeps call-stage decisions available for pending tools in mixed auto-approved responses', () => {
+        renderComponent([
+            makeTool({id: 'tool_auto', status: ToolCallStatus.AutoApproved}),
+            makeTool({id: 'tool_pending', status: ToolCallStatus.Pending}),
+        ]);
+
+        const pendingTool = getToolCardProps('tool_pending');
+        expect(pendingTool.onApprove).toEqual(expect.any(Function));
+        expect(pendingTool.onReject).toEqual(expect.any(Function));
+
+        const autoApprovedTool = getToolCardProps('tool_auto');
+        expect(autoApprovedTool.onApprove).toBeUndefined();
+        expect(autoApprovedTool.onReject).toBeUndefined();
+    });
+
+    test('marks only auto-approved tools with the auto-approved badge prop', () => {
+        renderComponent([
+            makeTool({id: 'tool_auto', status: ToolCallStatus.AutoApproved}),
+            makeTool({id: 'tool_pending', status: ToolCallStatus.Pending}),
+        ]);
+
+        expect(getToolCardProps('tool_auto').isAutoApproved).toBe(true);
+        expect(getToolCardProps('tool_pending').isAutoApproved).toBe(false);
+    });
+});

--- a/webapp/src/components/tool_approval_set.test.tsx
+++ b/webapp/src/components/tool_approval_set.test.tsx
@@ -15,7 +15,7 @@ type MockToolCardProps = {
     isAutoApproved?: boolean;
 };
 
-const mockToolCard = jest.fn((props: MockToolCardProps) => null);
+const mockToolCard = jest.fn<null, [MockToolCardProps]>(() => null);
 
 jest.mock('./tool_card', () => ({
     __esModule: true,

--- a/webapp/src/components/tool_approval_set.test.tsx
+++ b/webapp/src/components/tool_approval_set.test.tsx
@@ -15,13 +15,12 @@ type MockToolCardProps = {
     isAutoApproved?: boolean;
 };
 
-const mockToolCard = jest.fn(() => null);
+const mockToolCard = jest.fn((props: MockToolCardProps) => null);
 
 jest.mock('./tool_card', () => ({
     __esModule: true,
     default: (props: MockToolCardProps) => {
-        mockToolCard(props);
-        return null;
+        return mockToolCard(props);
     },
 }));
 

--- a/webapp/src/components/tool_approval_set.tsx
+++ b/webapp/src/components/tool_approval_set.tsx
@@ -66,7 +66,6 @@ interface ToolApprovalSetProps {
     canExpand: boolean;
     showArguments: boolean;
     showResults: boolean;
-    isAutoApproved?: boolean;
 }
 
 // Define a type for tool decisions
@@ -90,8 +89,9 @@ const ToolApprovalSet: React.FC<ToolApprovalSetProps> = (props) => {
     const isCallStage = props.approvalStage === 'call';
     const isResultStage = props.approvalStage === 'result';
 
-    // When auto-approved during call stage, suppress approval buttons
-    const effectiveCanApprove = props.isAutoApproved && isCallStage ? false : props.canApprove;
+    // Approval is per pending tool. Earlier auto-approved tools in the same
+    // response should not suppress controls for later manual ones.
+    const effectiveCanApprove = props.canApprove;
 
     const decisionToolCalls = useMemo(() => {
         if (!effectiveCanApprove) {
@@ -269,7 +269,7 @@ const ToolApprovalSet: React.FC<ToolApprovalSetProps> = (props) => {
                         showArguments={props.showArguments}
                         showResults={props.showResults}
                         approvalStage={props.approvalStage}
-                        isAutoApproved={props.isAutoApproved || tool.status === ToolCallStatus.AutoApproved}
+                        isAutoApproved={tool.status === ToolCallStatus.AutoApproved}
                     />
                 );
             })}


### PR DESCRIPTION
#### Summary
- keep pending tool approvals visible when earlier tools in the same response were auto-approved
- scope the auto-approved badge to the tool that actually auto-ran
- add a regression test for mixed auto-approved and pending tool cards

#### Ticket Link
- NONE

#### Screenshots
- N/A

#### Test plan
- `cd webapp && npm test -- --runInBand src/components/tool_approval_set.test.tsx src/components/llmbot_post/turn_content_utils.test.ts`
- `cd webapp && npx eslint src/components/tool_approval_set.tsx src/components/tool_approval_set.test.tsx src/components/llmbot_post/llmbot_post.tsx`

#### Release Note
```release-note
Fixed a regression where pending tool approvals could disappear when earlier tools in the same agent response were auto-approved.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying tool-approval UI: pending tools receive approve/reject handlers and only auto-approved tools show the auto-approved badge.

* **Refactoring**
  * Simplified auto-approval logic so approval is decided per tool (removed global auto-approval flag), and controls reflect each tool's status.

* **UI**
  * Removed the global auto-approval input from bot posts so per-tool decision controls are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->