### PR TITLE
Stabilize New Agent modal size across tabs and AI service changes

### DIFF
--- a/webapp/src/components/agents/agent_config_modal.tsx
+++ b/webapp/src/components/agents/agent_config_modal.tsx
@@ -379,11 +379,14 @@ const ModalOverlay = styled.div`
     z-index: 2000;
 `;
 
+// Fixed-height modal keeps the top edge anchored so it doesn't jump around when
+// the active tab or AI Service selection changes how tall the body content is.
+// The body scrolls internally (see ModalBody) when content exceeds the frame.
 const ModalContainer = styled.div`
     background-color: var(--center-channel-bg);
     border-radius: 12px;
     width: 700px;
-    max-height: 85vh;
+    height: min(720px, 85vh);
     min-height: 0;
     display: flex;
     flex-direction: column;

--- a/webapp/src/components/select.tsx
+++ b/webapp/src/components/select.tsx
@@ -12,14 +12,7 @@ import {ChannelType, ChannelWithTeamData} from '@mattermost/types/channels';
 
 import {getAutocompleteAllUsers, getChannelById, getProfilePictureUrl, getProfilesByIds, getTeamIconUrl, getTeamsByIds, searchAllChannels, searchTeams} from '../client';
 
-function selectMenuPortalTarget(): HTMLElement | null {
-    if (typeof document === 'undefined') {
-        return null;
-    }
-
-    // Prefer #root so portaled menus inherit Mattermost theme CSS variables (same as the main app).
-    return document.getElementById('root') ?? document.body;
-}
+import {getPortalTarget} from '../utils/dom';
 
 type Option = {
     value: string;
@@ -187,7 +180,7 @@ function SelectComponent<T extends Option>(props: SelectProps<T>) {
             loadOptions={loadOptions}
             formatOptionLabel={props.formatOptionLabel}
             placeholder={props.placeholder}
-            menuPortalTarget={selectMenuPortalTarget()}
+            menuPortalTarget={getPortalTarget()}
             menuPosition='fixed'
             styles={selectStyles}
             defaultOptions={true}

--- a/webapp/src/components/system_console/item.tsx
+++ b/webapp/src/components/system_console/item.tsx
@@ -7,6 +7,16 @@ import {FormattedMessage} from 'react-intl';
 import CreatableSelect from 'react-select/creatable';
 import {StylesConfig, SingleValue} from 'react-select';
 
+// Portal Combobox menus so they are not clipped by ancestor scroll containers
+// (e.g. the Agent config modal body). Prefer #root so menu CSS variables match
+// the rest of the app.
+function comboboxMenuPortalTarget(): HTMLElement | null {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+    return document.getElementById('root') ?? document.body;
+}
+
 export const ItemList = styled.div`
 	display: grid;
 	grid-template-columns: minmax(auto, 275px) 1fr;
@@ -190,6 +200,10 @@ export const ComboboxItem = (props: ComboboxItemProps) => {
             backgroundColor: 'var(--center-channel-bg)',
             border: '1px solid rgba(var(--center-channel-color-rgb), 0.16)',
         }),
+        menuPortal: (base) => ({
+            ...base,
+            zIndex: 10000,
+        }),
         option: (base, state) => {
             let backgroundColor = 'transparent';
             if (state.isSelected) {
@@ -217,6 +231,8 @@ export const ComboboxItem = (props: ComboboxItemProps) => {
                     styles={selectStyles}
                     isClearable={props.isClearable ?? true}
                     formatCreateLabel={(inputValue: string) => `Use custom model: ${inputValue}`}
+                    menuPortalTarget={comboboxMenuPortalTarget()}
+                    menuPosition='fixed'
                 />
                 {props.helptext &&
                 <HelpText>{props.helptext}</HelpText>

--- a/webapp/src/components/system_console/item.tsx
+++ b/webapp/src/components/system_console/item.tsx
@@ -20,9 +20,13 @@ function comboboxMenuPortalTarget(): HTMLElement | null {
 // Portaled Combobox menus need to stack above the agent config modal overlay
 // (z-index 2000). Targets react-select's classNamePrefix='SystemConsoleCombobox'
 // so the z-index lives in styled-components rather than inline style props.
+// react-select v5 emits its default menuPortalCSS (z-index: 1) via an
+// @emotion/react generated className, so whether that or our global rule wins
+// depends on CSS declaration order at runtime. Use !important to make the
+// override deterministic regardless of which stylesheet is parsed last.
 const ComboboxPortalStyles = createGlobalStyle`
     .SystemConsoleCombobox__menu-portal {
-        z-index: 10000;
+        z-index: 10000 !important;
     }
 `;
 

--- a/webapp/src/components/system_console/item.tsx
+++ b/webapp/src/components/system_console/item.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import styled from 'styled-components';
+import styled, {createGlobalStyle} from 'styled-components';
 import {FormattedMessage} from 'react-intl';
 import CreatableSelect from 'react-select/creatable';
 import {StylesConfig, SingleValue} from 'react-select';
@@ -16,6 +16,15 @@ function comboboxMenuPortalTarget(): HTMLElement | null {
     }
     return document.getElementById('root') ?? document.body;
 }
+
+// Portaled Combobox menus need to stack above the agent config modal overlay
+// (z-index 2000). Targets react-select's classNamePrefix='SystemConsoleCombobox'
+// so the z-index lives in styled-components rather than inline style props.
+const ComboboxPortalStyles = createGlobalStyle`
+    .SystemConsoleCombobox__menu-portal {
+        z-index: 10000;
+    }
+`;
 
 export const ItemList = styled.div`
 	display: grid;
@@ -200,10 +209,6 @@ export const ComboboxItem = (props: ComboboxItemProps) => {
             backgroundColor: 'var(--center-channel-bg)',
             border: '1px solid rgba(var(--center-channel-color-rgb), 0.16)',
         }),
-        menuPortal: (base) => ({
-            ...base,
-            zIndex: 10000,
-        }),
         option: (base, state) => {
             let backgroundColor = 'transparent';
             if (state.isSelected) {
@@ -221,9 +226,11 @@ export const ComboboxItem = (props: ComboboxItemProps) => {
 
     return (
         <>
+            <ComboboxPortalStyles/>
             <ItemLabel>{props.label}</ItemLabel>
             <TextFieldContainer>
                 <CreatableSelect<SelectOption, false>
+                    classNamePrefix='SystemConsoleCombobox'
                     value={currentValue}
                     onChange={handleChange}
                     options={selectOptions}

--- a/webapp/src/components/system_console/item.tsx
+++ b/webapp/src/components/system_console/item.tsx
@@ -7,15 +7,7 @@ import {FormattedMessage} from 'react-intl';
 import CreatableSelect from 'react-select/creatable';
 import {StylesConfig, SingleValue} from 'react-select';
 
-// Portal Combobox menus so they are not clipped by ancestor scroll containers
-// (e.g. the Agent config modal body). Prefer #root so menu CSS variables match
-// the rest of the app.
-function comboboxMenuPortalTarget(): HTMLElement | null {
-    if (typeof document === 'undefined') {
-        return null;
-    }
-    return document.getElementById('root') ?? document.body;
-}
+import {getPortalTarget} from '../../utils/dom';
 
 // Portaled Combobox menus need to stack above the agent config modal overlay
 // (z-index 2000). Targets react-select's classNamePrefix='SystemConsoleCombobox'
@@ -242,7 +234,7 @@ export const ComboboxItem = (props: ComboboxItemProps) => {
                     styles={selectStyles}
                     isClearable={props.isClearable ?? true}
                     formatCreateLabel={(inputValue: string) => `Use custom model: ${inputValue}`}
-                    menuPortalTarget={comboboxMenuPortalTarget()}
+                    menuPortalTarget={getPortalTarget()}
                     menuPosition='fixed'
                 />
                 {props.helptext &&

--- a/webapp/src/utils/dom.ts
+++ b/webapp/src/utils/dom.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Returns the element to portal floating UI (e.g. react-select menus,
+ * dropdown popovers) into.
+ *
+ * Prefer `#root` so portaled content inherits the Mattermost theme CSS
+ * variables scoped there, same as the main webapp. Falls back to
+ * `document.body` if `#root` is not present (should only happen in
+ * unusual test setups). Returns `null` in non-browser environments (SSR).
+ */
+export function getPortalTarget(): HTMLElement | null {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+    return document.getElementById('root') ?? document.body;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

The `AgentConfigModal` (New Agent / Edit Agent in the Self Service Agents view) previously let its container grow or shrink with whatever the active tab rendered. Switching between **Configuration**, **Access**, and **MCPs**, or picking an AI service that reveals provider-specific fields (Anthropic / OpenAI), changed the overall modal height. Because the overlay centers the modal vertically, the top edge visibly jumped on each change, which is disorienting mid-edit. Tall content could also push past the viewport since the container had only `max-height: 85vh` and no fixed target.

This PR:
- Gives the modal container a stable size: `height: min(720px, 85vh)`. The header (title + tabs) and footer (Cancel / Save) stay anchored; only the body scrolls.
- `ModalBody` already had `overflow-y: auto`, so internal scrolling now kicks in when content is taller than the frame (e.g. Configuration tab with Anthropic selected, a long custom instructions textarea, or a long MCP tool list).
- Portals the `ComboboxItem` menu (the Model dropdown) to `#root` with `position: fixed`, matching what `SelectUser` / `SelectChannel` (Access tab) and `AvatarItem` (Configuration tab) already do, so the menu is not clipped by the newly-scrolling modal body. The AI Service selector is a native `<select>` whose popup is not clipped, so it keeps working as-is.

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-68441

#### Screenshots

##### Walkthrough

Before — unstable size (modal top jumps as content grows / shrinks):

<a href="https://cursor.com/agents/bc-60f47b12-3be9-4574-8f06-e09b442eda22/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnew_agent_modal_unstable_size_before.mp4"><img src="https://cursor.com/artifacts/c/art-5aeaaacb-4b61-4080-82a2-e33bd8570954" alt="new_agent_modal_unstable_size_before.mp4" /></a>

After — stable frame, scrolling happens inside the body:

<a href="https://cursor.com/agents/bc-60f47b12-3be9-4574-8f06-e09b442eda22/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnew_agent_modal_stable_size_after.mp4"><img src="https://cursor.com/artifacts/c/art-2e97fa0b-a2e9-48e0-bfa8-0fbce40b4438" alt="new_agent_modal_stable_size_after.mp4" /></a>

| before | after |
| --- | --- |
| Modal height changes with each tab / AI service change; because the overlay centers it vertically the top edge visibly jumps. | Modal frame stays anchored (`height: min(720px, 85vh)`); only the body scrolls when content exceeds the frame. |

#### Release Note

```release-note
Stabilized the New Agent / Edit Agent modal size so it no longer jumps when switching between Configuration, Access, and MCPs tabs, or when changing the AI service. The modal now has a fixed frame with internal scrolling.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60f47b12-3be9-4574-8f06-e09b442eda22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60f47b12-3be9-4574-8f06-e09b442eda22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized modal height to prevent layout shifting when switching tabs or services.
  * Preserved internal scrolling so modal content scrolls without moving the modal frame.
  * Ensured dropdown menus render in a fixed, top stacking context so they consistently appear above overlays and remain visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->