### PR TITLE
MM-68440: Allow enabling disconnected MCP servers in New Agent modal + live refresh after connect

### DIFF
--- a/api/api_agents.go
+++ b/api/api_agents.go
@@ -26,6 +26,13 @@ var validUsernameRe = regexp.MustCompile(`^[a-z][a-z0-9._-]*$`)
 // WebsocketEventBotsInvalidate is the event name for PublishWebSocketEvent (webapp: custom_mattermost-ai_<name>).
 const WebsocketEventBotsInvalidate = "bots_invalidate"
 
+// WebsocketEventMCPConnectionUpdated is published to a single user when their
+// MCP OAuth connection state changes (e.g. after completing the auth flow from
+// the system console or the New Agent modal). The webapp listens for it to
+// refresh its cached list of user-visible MCP servers/tools without requiring
+// a page reload.
+const WebsocketEventMCPConnectionUpdated = "mcp_connection_updated"
+
 // MaxAgentRequestBodyBytes caps the JSON body size for agent create/update requests
 // to protect against oversized payloads in the various ID slices and MCP tool lists.
 const MaxAgentRequestBodyBytes = 512 << 10 // 512 KiB

--- a/api/api_agents.go
+++ b/api/api_agents.go
@@ -26,11 +26,7 @@ var validUsernameRe = regexp.MustCompile(`^[a-z][a-z0-9._-]*$`)
 // WebsocketEventBotsInvalidate is the event name for PublishWebSocketEvent (webapp: custom_mattermost-ai_<name>).
 const WebsocketEventBotsInvalidate = "bots_invalidate"
 
-// WebsocketEventMCPConnectionUpdated is published to a single user when their
-// MCP OAuth connection state changes (e.g. after completing the auth flow from
-// the system console or the New Agent modal). The webapp listens for it to
-// refresh its cached list of user-visible MCP servers/tools without requiring
-// a page reload.
+// WebsocketEventMCPConnectionUpdated is the event name for user-scoped MCP OAuth connection updates (webapp: custom_mattermost-ai_<name>).
 const WebsocketEventMCPConnectionUpdated = "mcp_connection_updated"
 
 // MaxAgentRequestBodyBytes caps the JSON body size for agent create/update requests

--- a/api/api_mcp.go
+++ b/api/api_mcp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/mcp"
+	"github.com/mattermost/mattermost/server/public/model"
 )
 
 // UserMCPToolsResponse is the top-level response for GET /mcp/tools.
@@ -240,7 +241,27 @@ func (a *API) handleDeleteUserMCPOAuth(c *gin.Context) {
 		return
 	}
 
+	a.publishMCPDisconnected(userID, serverName)
 	c.Status(http.StatusOK)
+}
+
+// publishMCPDisconnected broadcasts an MCP disconnection event so the webapp
+// can refresh its user-visible MCP server state after a manual disconnect.
+func (a *API) publishMCPDisconnected(userID, serverName string) {
+	if a.mmClient == nil || userID == "" {
+		return
+	}
+
+	payload := map[string]interface{}{
+		"status":     "disconnected",
+		"serverName": serverName,
+	}
+
+	a.mmClient.PublishWebSocketEvent(
+		WebsocketEventMCPConnectionUpdated,
+		payload,
+		&model.WebsocketBroadcast{UserId: userID},
+	)
 }
 
 // handleGetVettedToolSeed returns authoritative vetted default tool_configs for a base URL (admin).

--- a/api/api_mcp.go
+++ b/api/api_mcp.go
@@ -245,8 +245,7 @@ func (a *API) handleDeleteUserMCPOAuth(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-// publishMCPDisconnected broadcasts an MCP disconnection event so the webapp
-// can refresh its user-visible MCP server state after a manual disconnect.
+// publishMCPDisconnected notifies the webapp that the user disconnected an MCP server.
 func (a *API) publishMCPDisconnected(userID, serverName string) {
 	if a.mmClient == nil || userID == "" {
 		return
@@ -255,6 +254,9 @@ func (a *API) publishMCPDisconnected(userID, serverName string) {
 	payload := map[string]interface{}{
 		"status":     "disconnected",
 		"serverName": serverName,
+	}
+	if sc, ok := a.getMCPServerConfig(serverName); ok && sc.BaseURL != "" {
+		payload["serverOrigin"] = sc.BaseURL
 	}
 
 	a.mmClient.PublishWebSocketEvent(

--- a/api/api_mcp_test.go
+++ b/api/api_mcp_test.go
@@ -300,6 +300,13 @@ func TestHandleDeleteUserMCPOAuth(t *testing.T) {
 	mcpMock := &mockMCPClientManager{}
 	e.api.mcpClientManager = mcpMock
 
+	const testServerOrigin = "https://mcp.test/"
+	e.config.mcpConfig = mcp.Config{
+		Servers: []mcp.ServerConfig{
+			{Name: "TestServer", BaseURL: testServerOrigin, Enabled: true},
+		},
+	}
+
 	mmClient := mmapimocks.NewMockClient(t)
 	var gotEvent string
 	var gotPayload map[string]interface{}
@@ -323,6 +330,7 @@ func TestHandleDeleteUserMCPOAuth(t *testing.T) {
 	require.Equal(t, WebsocketEventMCPConnectionUpdated, gotEvent)
 	require.Equal(t, "disconnected", gotPayload["status"])
 	require.Equal(t, "TestServer", gotPayload["serverName"])
+	require.Equal(t, testServerOrigin, gotPayload["serverOrigin"])
 	require.NotNil(t, gotBroadcast)
 	require.Equal(t, testUserID, gotBroadcast.UserId)
 }
@@ -508,7 +516,6 @@ func TestPublishMCPConnectionUpdatedNoOpWhenMMClientMissing(t *testing.T) {
 	e := SetupTestEnvironment(t)
 	defer e.Cleanup(t)
 
-	// mmClient is nil — the helper should simply return without panicking.
 	e.api.publishMCPConnectionUpdated(testUserID, nil)
 }
 

--- a/api/api_mcp_test.go
+++ b/api/api_mcp_test.go
@@ -516,7 +516,13 @@ func TestPublishMCPConnectionUpdatedNoOpWhenMMClientMissing(t *testing.T) {
 	e := SetupTestEnvironment(t)
 	defer e.Cleanup(t)
 
-	e.api.publishMCPConnectionUpdated(testUserID, nil)
+	e.api.mmClient = nil
+	session := &mcp.OAuthSession{
+		UserID:    testUserID,
+		ServerID:  "TestServer",
+		ServerURL: "https://test.example.com",
+	}
+	e.api.publishMCPConnectionUpdated(testUserID, session)
 }
 
 func TestHandleOAuthStartAcceptsResourceMetadataMatchingOrigin(t *testing.T) {

--- a/api/api_mcp_test.go
+++ b/api/api_mcp_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/mcp"
 	mmapimocks "github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/mock"
@@ -299,6 +300,18 @@ func TestHandleDeleteUserMCPOAuth(t *testing.T) {
 	mcpMock := &mockMCPClientManager{}
 	e.api.mcpClientManager = mcpMock
 
+	mmClient := mmapimocks.NewMockClient(t)
+	var gotEvent string
+	var gotPayload map[string]interface{}
+	var gotBroadcast *model.WebsocketBroadcast
+	mmClient.On("PublishWebSocketEvent", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]interface {}"), mock.AnythingOfType("*model.WebsocketBroadcast")).
+		Run(func(args mock.Arguments) {
+			gotEvent = args.String(0)
+			gotPayload, _ = args.Get(1).(map[string]interface{})
+			gotBroadcast, _ = args.Get(2).(*model.WebsocketBroadcast)
+		}).Return()
+	e.api.mmClient = mmClient
+
 	request := httptest.NewRequest(http.MethodDelete, "/mcp/oauth/TestServer", nil)
 	request.Header.Add("Mattermost-User-Id", testUserID)
 
@@ -307,6 +320,11 @@ func TestHandleDeleteUserMCPOAuth(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
 	require.Equal(t, []mcpDisconnectCall{{userID: testUserID, serverName: "TestServer"}}, mcpMock.disconnectCalls)
+	require.Equal(t, WebsocketEventMCPConnectionUpdated, gotEvent)
+	require.Equal(t, "disconnected", gotPayload["status"])
+	require.Equal(t, "TestServer", gotPayload["serverName"])
+	require.NotNil(t, gotBroadcast)
+	require.Equal(t, testUserID, gotBroadcast.UserId)
 }
 
 func TestHandleDeleteUserMCPOAuthMissingServerName(t *testing.T) {
@@ -453,6 +471,45 @@ func TestHandleOAuthStartRejectsResourceMetadataWrongOrigin(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, recorder.Result().StatusCode)
 	require.Empty(t, recorder.Result().Header.Get("Location"))
+}
+
+func TestPublishMCPConnectionUpdatedEmitsUserScopedEvent(t *testing.T) {
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	mmClient := mmapimocks.NewMockClient(t)
+	var gotEvent string
+	var gotPayload map[string]interface{}
+	var gotBroadcast *model.WebsocketBroadcast
+	mmClient.On("PublishWebSocketEvent", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]interface {}"), mock.AnythingOfType("*model.WebsocketBroadcast")).
+		Run(func(args mock.Arguments) {
+			gotEvent = args.String(0)
+			gotPayload, _ = args.Get(1).(map[string]interface{})
+			gotBroadcast, _ = args.Get(2).(*model.WebsocketBroadcast)
+		}).Return()
+	e.api.mmClient = mmClient
+
+	session := &mcp.OAuthSession{
+		UserID:    testUserID,
+		ServerID:  "AtlassianMCP",
+		ServerURL: "https://mcp.atlassian.com/v1/sse",
+	}
+	e.api.publishMCPConnectionUpdated(testUserID, session)
+
+	require.Equal(t, WebsocketEventMCPConnectionUpdated, gotEvent)
+	require.Equal(t, "connected", gotPayload["status"])
+	require.Equal(t, "AtlassianMCP", gotPayload["serverName"])
+	require.Equal(t, "https://mcp.atlassian.com/v1/sse", gotPayload["serverOrigin"])
+	require.NotNil(t, gotBroadcast)
+	require.Equal(t, testUserID, gotBroadcast.UserId)
+}
+
+func TestPublishMCPConnectionUpdatedNoOpWhenMMClientMissing(t *testing.T) {
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	// mmClient is nil — the helper should simply return without panicking.
+	e.api.publishMCPConnectionUpdated(testUserID, nil)
 }
 
 func TestHandleOAuthStartAcceptsResourceMetadataMatchingOrigin(t *testing.T) {

--- a/api/api_oauth.go
+++ b/api/api_oauth.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mattermost/mattermost-plugin-agents/mcp"
+	"github.com/mattermost/mattermost/server/public/model"
 )
 
 func (a *API) handleOAuthStart(c *gin.Context) {
@@ -79,14 +80,41 @@ func (a *API) handleOAuthCallback(c *gin.Context) {
 		return
 	}
 
-	_, err := a.mcpClientManager.ProcessOAuthCallback(c.Request.Context(), userID, state, code)
+	session, err := a.mcpClientManager.ProcessOAuthCallback(c.Request.Context(), userID, state, code)
 	if err != nil {
 		a.pluginAPI.Log.Error("Failed to process OAuth callback", "error", err)
 		a.renderOAuthWindowClosePage(c, http.StatusInternalServerError, "Authorization Failed")
 		return
 	}
 
+	a.publishMCPConnectionUpdated(userID, session)
 	a.renderOAuthWindowClosePage(c, http.StatusOK, "Authorization Successful")
+}
+
+// publishMCPConnectionUpdated broadcasts an MCP connection change to the user so
+// open webapp tabs can refresh their tool list without a manual reload.
+func (a *API) publishMCPConnectionUpdated(userID string, session *mcp.OAuthSession) {
+	if a.mmClient == nil || userID == "" {
+		return
+	}
+
+	payload := map[string]interface{}{
+		"status": "connected",
+	}
+	if session != nil {
+		if session.ServerID != "" {
+			payload["serverName"] = session.ServerID
+		}
+		if session.ServerURL != "" {
+			payload["serverOrigin"] = session.ServerURL
+		}
+	}
+
+	a.mmClient.PublishWebSocketEvent(
+		WebsocketEventMCPConnectionUpdated,
+		payload,
+		&model.WebsocketBroadcast{UserId: userID},
+	)
 }
 
 func (a *API) getMCPServerConfig(serverName string) (mcp.ServerConfig, bool) {

--- a/api/api_oauth.go
+++ b/api/api_oauth.go
@@ -91,8 +91,7 @@ func (a *API) handleOAuthCallback(c *gin.Context) {
 	a.renderOAuthWindowClosePage(c, http.StatusOK, "Authorization Successful")
 }
 
-// publishMCPConnectionUpdated broadcasts an MCP connection change to the user so
-// open webapp tabs can refresh their tool list without a manual reload.
+// publishMCPConnectionUpdated notifies the webapp that the user connected an MCP server (OAuth callback).
 func (a *API) publishMCPConnectionUpdated(userID string, session *mcp.OAuthSession) {
 	if a.mmClient == nil || userID == "" {
 		return

--- a/llm/tools.go
+++ b/llm/tools.go
@@ -403,19 +403,12 @@ func (s *ToolStore) RemoveToolsByServerOrigin(disabledOrigins []string) {
 	}
 }
 
-// MCPServerToolWildcard is a sentinel value for EnabledMCPTool.ToolName that
-// matches every tool exposed by the given ServerOrigin. Agents set this entry
-// when the admin enables a whole MCP server without knowing its tool list
-// ahead of time (e.g. because they are not personally authenticated to it).
+// MCPServerToolWildcard in EnabledMCPTool.ToolName means every tool from that ServerOrigin is allowed.
 const MCPServerToolWildcard = "*"
 
 // RetainOnlyMCPTools filters the tool store to only retain MCP tools whose
 // (ServerOrigin, Name) pair appears in the allowlist. Built-in tools (those
 // with empty ServerOrigin) are never removed by this method.
-//
-// An entry with ToolName == MCPServerToolWildcard matches every tool from its
-// ServerOrigin, used when the agent owner enables a whole MCP server without
-// enumerating its tools.
 //
 // An empty or nil allowlist removes all MCP tools. Callers that want to keep
 // every MCP tool (e.g. agents with AutoEnableNewMCPTools=true) should skip

--- a/llm/tools.go
+++ b/llm/tools.go
@@ -403,9 +403,19 @@ func (s *ToolStore) RemoveToolsByServerOrigin(disabledOrigins []string) {
 	}
 }
 
+// MCPServerToolWildcard is a sentinel value for EnabledMCPTool.ToolName that
+// matches every tool exposed by the given ServerOrigin. Agents set this entry
+// when the admin enables a whole MCP server without knowing its tool list
+// ahead of time (e.g. because they are not personally authenticated to it).
+const MCPServerToolWildcard = "*"
+
 // RetainOnlyMCPTools filters the tool store to only retain MCP tools whose
 // (ServerOrigin, Name) pair appears in the allowlist. Built-in tools (those
 // with empty ServerOrigin) are never removed by this method.
+//
+// An entry with ToolName == MCPServerToolWildcard matches every tool from its
+// ServerOrigin, used when the agent owner enables a whole MCP server without
+// enumerating its tools.
 //
 // An empty or nil allowlist removes all MCP tools. Callers that want to keep
 // every MCP tool (e.g. agents with AutoEnableNewMCPTools=true) should skip
@@ -417,13 +427,21 @@ func (s *ToolStore) RetainOnlyMCPTools(allowlist []EnabledMCPTool) {
 
 	// Build a set for O(1) lookup. Key: "serverOrigin\x00toolName"
 	allowed := make(map[string]bool, len(allowlist))
+	wildcardOrigins := make(map[string]bool, len(allowlist))
 	for _, t := range allowlist {
+		if t.ToolName == MCPServerToolWildcard {
+			wildcardOrigins[t.ServerOrigin] = true
+			continue
+		}
 		allowed[t.ServerOrigin+"\x00"+t.ToolName] = true
 	}
 
 	for name, tool := range s.tools {
 		// Never filter built-in tools (empty ServerOrigin)
 		if tool.ServerOrigin == "" {
+			continue
+		}
+		if wildcardOrigins[tool.ServerOrigin] {
 			continue
 		}
 		// Remove MCP tools not in the allowlist

--- a/llm/tools_test.go
+++ b/llm/tools_test.go
@@ -436,6 +436,33 @@ func TestRetainOnlyMCPTools(t *testing.T) {
 			wantToolNames: []string{},
 		},
 		{
+			name: "server wildcard entry retains every tool from that origin",
+			tools: []Tool{
+				{Name: "builtin_search", ServerOrigin: ""},
+				{Name: "jira_get", ServerOrigin: "https://mcp.atlassian.com"},
+				{Name: "jira_create", ServerOrigin: "https://mcp.atlassian.com"},
+				{Name: "slack_post", ServerOrigin: "https://mcp.slack.com"},
+			},
+			allowlist: []EnabledMCPTool{
+				{ServerOrigin: "https://mcp.atlassian.com", ToolName: MCPServerToolWildcard},
+			},
+			wantToolNames: []string{"builtin_search", "jira_get", "jira_create"},
+		},
+		{
+			name: "server wildcard combines with explicit tool entries from other origins",
+			tools: []Tool{
+				{Name: "jira_get", ServerOrigin: "https://mcp.atlassian.com"},
+				{Name: "jira_create", ServerOrigin: "https://mcp.atlassian.com"},
+				{Name: "slack_post", ServerOrigin: "https://mcp.slack.com"},
+				{Name: "slack_edit", ServerOrigin: "https://mcp.slack.com"},
+			},
+			allowlist: []EnabledMCPTool{
+				{ServerOrigin: "https://mcp.atlassian.com", ToolName: MCPServerToolWildcard},
+				{ServerOrigin: "https://mcp.slack.com", ToolName: "slack_post"},
+			},
+			wantToolNames: []string{"jira_get", "jira_create", "slack_post"},
+		},
+		{
 			name:  "nil ToolStore is safe",
 			tools: nil, // will test on nil *ToolStore
 			allowlist: []EnabledMCPTool{

--- a/llmcontext/llm_context_test.go
+++ b/llmcontext/llm_context_test.go
@@ -37,6 +37,15 @@ func (p *countingMCPToolProvider) GetToolsForUser(string) ([]llm.Tool, *mcp.Erro
 	}, nil
 }
 
+type staticMCPToolProvider struct {
+	tools  []llm.Tool
+	errors *mcp.Errors
+}
+
+func (p *staticMCPToolProvider) GetToolsForUser(string) ([]llm.Tool, *mcp.Errors) {
+	return p.tools, p.errors
+}
+
 type contextTestConfigProvider struct{}
 
 func (p *contextTestConfigProvider) GetEnableLLMTrace() bool {
@@ -48,8 +57,12 @@ func (p *contextTestConfigProvider) GetServiceByID(string) (llm.ServiceConfig, b
 }
 
 func newTestBot() *bots.Bot {
+	return newTestBotWithConfig(llm.BotConfig{ID: "bot-id", Name: "matty", DisplayName: "Matty"})
+}
+
+func newTestBotWithConfig(cfg llm.BotConfig) *bots.Bot {
 	return bots.NewBot(
-		llm.BotConfig{ID: "bot-id", Name: "matty", DisplayName: "Matty"},
+		cfg,
 		llm.ServiceConfig{DefaultModel: "test-model", Type: llm.ServiceTypeOpenAI},
 		&model.Bot{UserId: "bot-id", Username: "matty", DisplayName: "Matty"},
 		nil,
@@ -110,6 +123,56 @@ func TestWithLLMContextNoToolsSkipsMCPProvider(t *testing.T) {
 
 	require.Equal(t, 0, mcpProvider.calls)
 	require.Empty(t, context.Tools.GetTools())
+}
+
+func TestWithLLMContextDefaultToolsRetainsAuthErrorsForWildcardAllowlist(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	siteName := "Mattermost"
+	siteURL := "https://example.com"
+	mockAPI.On("GetConfig").Return(&model.Config{
+		TeamSettings:    model.TeamSettings{SiteName: &siteName},
+		ServiceSettings: model.ServiceSettings{SiteURL: &siteURL},
+	}).Maybe()
+	mockAPI.On("GetLicense").Return(&model.License{}).Maybe()
+
+	client := pluginapi.NewClient(mockAPI, nil)
+	mcpProvider := &staticMCPToolProvider{
+		errors: &mcp.Errors{
+			ToolAuthErrors: []llm.ToolAuthError{
+				{
+					ServerName:   "Atlassian",
+					ServerOrigin: "https://mcp.atlassian.com",
+					AuthURL:      "https://auth.example.com",
+				},
+			},
+		},
+	}
+	builder := NewLLMContextBuilder(client, &emptyToolProvider{}, mcpProvider, &contextTestConfigProvider{})
+	bot := newTestBotWithConfig(llm.BotConfig{
+		ID:                    "bot-id",
+		Name:                  "matty",
+		DisplayName:           "Matty",
+		AutoEnableNewMCPTools: false,
+		EnabledMCPTools: []llm.EnabledMCPTool{
+			{ServerOrigin: "https://mcp.atlassian.com/", ToolName: llm.MCPServerToolWildcard},
+		},
+	})
+
+	user := &model.User{Id: "user-id", Username: "test-user", Locale: "en"}
+	channel := &model.Channel{Id: "channel-id", Type: model.ChannelTypeDirect}
+
+	context := builder.BuildLLMContextUserRequest(
+		bot,
+		user,
+		channel,
+		builder.WithLLMContextDefaultTools(bot),
+	)
+
+	require.Empty(t, context.Tools.GetTools())
+	authErrors := context.Tools.GetAuthErrors()
+	require.Len(t, authErrors, 1)
+	assert.Equal(t, "https://mcp.atlassian.com", authErrors[0].ServerOrigin)
+	assert.Equal(t, "https://auth.example.com", authErrors[0].AuthURL)
 }
 
 func TestSanitizeUserProfileField(t *testing.T) {

--- a/webapp/src/components/agents/tabs/mcps_tab.tsx
+++ b/webapp/src/components/agents/tabs/mcps_tab.tsx
@@ -56,6 +56,10 @@ const McpsTab = (props: Props) => {
     // Fetch available MCP tools on mount and whenever an MCP OAuth connection
     // change websocket event fires (e.g. after the user completes the Connect
     // flow in a popup).
+    //
+    // Only the initial load surfaces errors into the modal body — a transient
+    // failure from a websocket-triggered background refresh must not clobber
+    // the user's in-progress edits by swapping the list for an error panel.
     const loadServers = useCallback(async (opts: {showLoading?: boolean} = {}) => {
         try {
             if (opts.showLoading) {
@@ -64,8 +68,17 @@ const McpsTab = (props: Props) => {
             const response = await getUserMCPTools();
             setServers(response.servers || []);
             setError(null);
-        } catch {
-            setError(intl.formatMessage({defaultMessage: 'Failed to load MCP tools.'}));
+        } catch (err) {
+            if (opts.showLoading) {
+                setError(intl.formatMessage({defaultMessage: 'Failed to load MCP tools.'}));
+            } else {
+                // Background refresh — keep prior servers + clear any stale
+                // error state so the UI does not get stuck on a failure from
+                // a previous attempt. Log so the failure is visible in
+                // diagnostic output rather than silently dropped.
+                // eslint-disable-next-line no-console
+                console.error('Background refresh of MCP tools failed:', err);
+            }
         } finally {
             if (opts.showLoading) {
                 setLoading(false);

--- a/webapp/src/components/agents/tabs/mcps_tab.tsx
+++ b/webapp/src/components/agents/tabs/mcps_tab.tsx
@@ -60,6 +60,8 @@ const McpsTab = (props: Props) => {
             setError(null);
         } catch (err) {
             if (opts.showLoading) {
+                // eslint-disable-next-line no-console
+                console.error('Failed to load MCP tools:', err);
                 setError(intl.formatMessage({defaultMessage: 'Failed to load MCP tools.'}));
             } else {
                 // eslint-disable-next-line no-console
@@ -329,9 +331,7 @@ const McpsTab = (props: Props) => {
                                     <ConnectButton
                                         type='button'
                                         onClick={() => {
-                                            if (server.authURL) {
-                                                window.open(server.authURL, '_blank', 'noopener,noreferrer');
-                                            }
+                                            window.open(server.authURL!, '_blank', 'noopener,noreferrer');
                                         }}
                                     >
                                         <FormattedMessage defaultMessage='Connect'/>

--- a/webapp/src/components/agents/tabs/mcps_tab.tsx
+++ b/webapp/src/components/agents/tabs/mcps_tab.tsx
@@ -605,20 +605,24 @@ const EmptyToolsNotice = styled.div`
 `;
 
 const ConnectButton = styled.button`
-    flex-shrink: 0;
-    height: 28px;
-    padding: 0 12px;
+    padding: 4px 10px;
     border-radius: 4px;
-    border: 1px solid var(--button-bg);
-    background: transparent;
-    color: var(--button-bg);
+    border: none;
     font-size: 12px;
     font-weight: 600;
+    white-space: nowrap;
     cursor: pointer;
-    transition: background 0.15s ease, color 0.15s ease;
+    flex-shrink: 0;
+    background: var(--button-bg);
+    color: var(--button-color);
 
-    &:hover {
-        background: rgba(var(--button-bg-rgb), 0.08);
+    &:hover:not(:disabled) {
+        background: rgba(var(--button-bg-rgb), 0.88);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
     }
 
     &:focus-visible {

--- a/webapp/src/components/agents/tabs/mcps_tab.tsx
+++ b/webapp/src/components/agents/tabs/mcps_tab.tsx
@@ -10,10 +10,7 @@ import {getUserMCPTools} from '@/client';
 import {EnabledTool} from '@/types/agents';
 import {useMCPConnectionEvents} from '@/hooks/use_mcp_connection_events';
 
-// MCPServerToolWildcard matches llm.MCPServerToolWildcard in Go: an EnabledTool
-// entry whose tool_name equals this sentinel grants the agent every tool from
-// that server, even tools the configuring admin cannot currently enumerate
-// (e.g. because they are not authenticated to the server yet).
+// Same sentinel as llm.MCPServerToolWildcard ('*' = all tools from that origin).
 const MCPServerToolWildcard = '*';
 
 // Types matching the getUserMCPTools() response shape (from api/api_mcp.go)
@@ -53,13 +50,6 @@ const McpsTab = (props: Props) => {
     const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set());
     const [searchQuery, setSearchQuery] = useState('');
 
-    // Fetch available MCP tools on mount and whenever an MCP OAuth connection
-    // change websocket event fires (e.g. after the user completes the Connect
-    // flow in a popup).
-    //
-    // Only the initial load surfaces errors into the modal body — a transient
-    // failure from a websocket-triggered background refresh must not clobber
-    // the user's in-progress edits by swapping the list for an error panel.
     const loadServers = useCallback(async (opts: {showLoading?: boolean} = {}) => {
         try {
             if (opts.showLoading) {
@@ -72,10 +62,6 @@ const McpsTab = (props: Props) => {
             if (opts.showLoading) {
                 setError(intl.formatMessage({defaultMessage: 'Failed to load MCP tools.'}));
             } else {
-                // Background refresh — keep prior servers + clear any stale
-                // error state so the UI does not get stuck on a failure from
-                // a previous attempt. Log so the failure is visible in
-                // diagnostic output rather than silently dropped.
                 // eslint-disable-next-line no-console
                 console.error('Background refresh of MCP tools failed:', err);
             }
@@ -94,10 +80,6 @@ const McpsTab = (props: Props) => {
         loadServers();
     }, [loadServers]));
 
-    // Does the allowlist contain a wildcard entry for this server? The
-    // wildcard entry (tool_name = '*') means the agent owner enabled the whole
-    // server without knowing its tool list, typically because the owner is not
-    // authenticated to the server themselves.
     const hasServerWildcard = useCallback((serverOrigin: string) => {
         return enabledTools.some(
             (t) => t.server_origin === serverOrigin && t.tool_name === MCPServerToolWildcard,
@@ -141,9 +123,6 @@ const McpsTab = (props: Props) => {
         });
     }, []);
 
-    // Toggling the per-server switch either enables all known tools, adds a
-    // wildcard marker (for servers with no enumerable tools yet), or clears
-    // every entry for that server origin.
     const toggleAllServerTools = useCallback((server: UserMCPServerInfo) => {
         const serverTools = server.tools.filter((t) => t.enabled);
         const hasWildcard = hasServerWildcard(server.serverOrigin);
@@ -173,9 +152,6 @@ const McpsTab = (props: Props) => {
         onChange({enabledTools: [...existing, ...newTools]});
     }, [enabledTools, hasServerWildcard, onChange]);
 
-    // Detect orphaned tools (enabled but no longer available). Wildcard
-    // entries are kept as long as the server is still configured, even if it
-    // is temporarily disconnected and advertising zero tools.
     const isEntryAvailable = useCallback((et: EnabledTool) => {
         return servers.some((s) => {
             if (s.serverOrigin !== et.server_origin) {
@@ -287,10 +263,6 @@ const McpsTab = (props: Props) => {
 
                     const toolsPanelId = serverToolsPanelId(server.serverOrigin);
 
-                    // Reflect the auto-enable checkbox on every per-server toggle so
-                    // the UI matches the semantic "every tool is on" when the box is
-                    // checked. Wildcard entries also display as on for disconnected
-                    // servers that have no enumerable tools yet.
                     const allKnownOn = totalCount > 0 && enabledCount === totalCount;
                     const allOn = autoEnableNewMCPTools || wildcardOn || allKnownOn;
                     const serverToggleLabel = allOn ? intl.formatMessage(

--- a/webapp/src/components/agents/tabs/mcps_tab.tsx
+++ b/webapp/src/components/agents/tabs/mcps_tab.tsx
@@ -8,6 +8,13 @@ import {ChevronDownIcon, ChevronRightIcon} from '@mattermost/compass-icons/compo
 
 import {getUserMCPTools} from '@/client';
 import {EnabledTool} from '@/types/agents';
+import {useMCPConnectionEvents} from '@/hooks/use_mcp_connection_events';
+
+// MCPServerToolWildcard matches llm.MCPServerToolWildcard in Go: an EnabledTool
+// entry whose tool_name equals this sentinel grants the agent every tool from
+// that server, even tools the configuring admin cannot currently enumerate
+// (e.g. because they are not authenticated to the server yet).
+const MCPServerToolWildcard = '*';
 
 // Types matching the getUserMCPTools() response shape (from api/api_mcp.go)
 type UserMCPToolInfo = {
@@ -21,7 +28,9 @@ type UserMCPServerInfo = {
     name: string;
     serverOrigin: string;
     authenticated: boolean;
+    needsOAuth: boolean;
     authEmail: string;
+    authURL?: string;
     tools: UserMCPToolInfo[];
 }
 
@@ -44,30 +53,55 @@ const McpsTab = (props: Props) => {
     const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set());
     const [searchQuery, setSearchQuery] = useState('');
 
-    // Fetch available MCP tools on mount
-    useEffect(() => {
-        const load = async () => {
-            try {
+    // Fetch available MCP tools on mount and whenever an MCP OAuth connection
+    // change websocket event fires (e.g. after the user completes the Connect
+    // flow in a popup).
+    const loadServers = useCallback(async (opts: {showLoading?: boolean} = {}) => {
+        try {
+            if (opts.showLoading) {
                 setLoading(true);
-                const response = await getUserMCPTools();
-                setServers(response.servers || []);
-            } catch {
-                setError(intl.formatMessage({defaultMessage: 'Failed to load MCP tools.'}));
-            } finally {
+            }
+            const response = await getUserMCPTools();
+            setServers(response.servers || []);
+            setError(null);
+        } catch {
+            setError(intl.formatMessage({defaultMessage: 'Failed to load MCP tools.'}));
+        } finally {
+            if (opts.showLoading) {
                 setLoading(false);
             }
-        };
-        load();
+        }
     }, [intl]);
+
+    useEffect(() => {
+        loadServers({showLoading: true});
+    }, [loadServers]);
+
+    useMCPConnectionEvents(useCallback(() => {
+        loadServers();
+    }, [loadServers]));
+
+    // Does the allowlist contain a wildcard entry for this server? The
+    // wildcard entry (tool_name = '*') means the agent owner enabled the whole
+    // server without knowing its tool list, typically because the owner is not
+    // authenticated to the server themselves.
+    const hasServerWildcard = useCallback((serverOrigin: string) => {
+        return enabledTools.some(
+            (t) => t.server_origin === serverOrigin && t.tool_name === MCPServerToolWildcard,
+        );
+    }, [enabledTools]);
 
     const isToolEnabled = useCallback((serverOrigin: string, toolName: string) => {
         if (autoEnableNewMCPTools) {
             return true;
         }
+        if (hasServerWildcard(serverOrigin)) {
+            return true;
+        }
         return enabledTools.some(
             (t) => t.server_origin === serverOrigin && t.tool_name === toolName,
         );
-    }, [autoEnableNewMCPTools, enabledTools]);
+    }, [autoEnableNewMCPTools, enabledTools, hasServerWildcard]);
 
     const toggleTool = useCallback((serverOrigin: string, toolName: string) => {
         const exists = enabledTools.some(
@@ -94,48 +128,63 @@ const McpsTab = (props: Props) => {
         });
     }, []);
 
+    // Toggling the per-server switch either enables all known tools, adds a
+    // wildcard marker (for servers with no enumerable tools yet), or clears
+    // every entry for that server origin.
     const toggleAllServerTools = useCallback((server: UserMCPServerInfo) => {
         const serverTools = server.tools.filter((t) => t.enabled);
-        const allEnabled = serverTools.every((t) =>
-            enabledTools.some(
-                (e) => e.server_origin === server.serverOrigin && e.tool_name === t.name,
-            ),
+        const hasWildcard = hasServerWildcard(server.serverOrigin);
+        const allEnabled = hasWildcard || (
+            serverTools.length > 0 &&
+            serverTools.every((t) =>
+                enabledTools.some(
+                    (e) => e.server_origin === server.serverOrigin && e.tool_name === t.name,
+                ),
+            )
         );
 
         if (allEnabled) {
             onChange({enabledTools: enabledTools.filter((t) => t.server_origin !== server.serverOrigin)});
-        } else {
-            const existing = enabledTools.filter((t) => t.server_origin !== server.serverOrigin);
-            const newTools = serverTools.map((t) => ({
-                server_origin: server.serverOrigin,
-                tool_name: t.name,
-            }));
-            onChange({enabledTools: [...existing, ...newTools]});
+            return;
         }
-    }, [enabledTools, onChange]);
 
-    // Detect orphaned tools (enabled but no longer available)
+        const existing = enabledTools.filter((t) => t.server_origin !== server.serverOrigin);
+        if (serverTools.length === 0) {
+            onChange({enabledTools: [...existing, {server_origin: server.serverOrigin, tool_name: MCPServerToolWildcard}]});
+            return;
+        }
+        const newTools = serverTools.map((t) => ({
+            server_origin: server.serverOrigin,
+            tool_name: t.name,
+        }));
+        onChange({enabledTools: [...existing, ...newTools]});
+    }, [enabledTools, hasServerWildcard, onChange]);
+
+    // Detect orphaned tools (enabled but no longer available). Wildcard
+    // entries are kept as long as the server is still configured, even if it
+    // is temporarily disconnected and advertising zero tools.
+    const isEntryAvailable = useCallback((et: EnabledTool) => {
+        return servers.some((s) => {
+            if (s.serverOrigin !== et.server_origin) {
+                return false;
+            }
+            if (et.tool_name === MCPServerToolWildcard) {
+                return true;
+            }
+            return s.tools.some((t) => t.name === et.tool_name);
+        });
+    }, [servers]);
+
     const orphanedTools = useMemo(() => {
         if (autoEnableNewMCPTools || servers.length === 0) {
             return [];
         }
-        return enabledTools.filter((et) =>
-            !servers.some((s) =>
-                s.serverOrigin === et.server_origin &&
-                s.tools.some((t) => t.name === et.tool_name),
-            ),
-        );
-    }, [autoEnableNewMCPTools, enabledTools, servers]);
+        return enabledTools.filter((et) => !isEntryAvailable(et));
+    }, [autoEnableNewMCPTools, enabledTools, servers, isEntryAvailable]);
 
-    // Auto-remove orphaned tools from enabledTools so they're cleaned on save
     useEffect(() => {
         if (!autoEnableNewMCPTools && orphanedTools.length > 0 && servers.length > 0) {
-            const cleaned = enabledTools.filter((et) =>
-                servers.some((s) =>
-                    s.serverOrigin === et.server_origin &&
-                    s.tools.some((t) => t.name === et.tool_name),
-                ),
-            );
+            const cleaned = enabledTools.filter((et) => isEntryAvailable(et));
             onChange({enabledTools: cleaned});
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -216,22 +265,47 @@ const McpsTab = (props: Props) => {
             <ServerList>
                 {filteredServers.map((server) => {
                     const isExpanded = expandedServers.has(server.serverOrigin);
-                    const enabledCount = server.tools.filter(
-                        (t) => t.enabled && isToolEnabled(server.serverOrigin, t.name),
+                    const wildcardOn = hasServerWildcard(server.serverOrigin);
+                    const adminEnabledTools = server.tools.filter((t) => t.enabled);
+                    const enabledCount = adminEnabledTools.filter(
+                        (t) => isToolEnabled(server.serverOrigin, t.name),
                     ).length;
-                    const totalCount = server.tools.filter((t) => t.enabled).length;
+                    const totalCount = adminEnabledTools.length;
 
                     const toolsPanelId = serverToolsPanelId(server.serverOrigin);
-                    const allOn = enabledCount === totalCount && totalCount > 0;
-                    const serverToggleLabel = allOn ?
-                        intl.formatMessage(
-                            {defaultMessage: 'Disable all tools for {serverName}'},
-                            {serverName: server.name},
-                        ) :
-                        intl.formatMessage(
-                            {defaultMessage: 'Enable all tools for {serverName}'},
-                            {serverName: server.name},
+
+                    // Reflect the auto-enable checkbox on every per-server toggle so
+                    // the UI matches the semantic "every tool is on" when the box is
+                    // checked. Wildcard entries also display as on for disconnected
+                    // servers that have no enumerable tools yet.
+                    const allKnownOn = totalCount > 0 && enabledCount === totalCount;
+                    const allOn = autoEnableNewMCPTools || wildcardOn || allKnownOn;
+                    const serverToggleLabel = allOn ? intl.formatMessage(
+                        {defaultMessage: 'Disable all tools for {serverName}'},
+                        {serverName: server.name},
+                    ) : intl.formatMessage(
+                        {defaultMessage: 'Enable all tools for {serverName}'},
+                        {serverName: server.name},
+                    );
+                    const canConnect = !server.authenticated && Boolean(server.authURL);
+                    const metaDetail = (() => {
+                        if (wildcardOn && totalCount === 0) {
+                            return intl.formatMessage({defaultMessage: 'All tools enabled'});
+                        }
+                        if (totalCount === 0) {
+                            return intl.formatMessage({defaultMessage: '0 tools available'});
+                        }
+                        if (enabledCount > 0) {
+                            return intl.formatMessage(
+                                {defaultMessage: '{enabled} of {total} tools enabled'},
+                                {enabled: enabledCount, total: totalCount},
+                            );
+                        }
+                        return intl.formatMessage(
+                            {defaultMessage: '{total} tools available'},
+                            {total: totalCount},
                         );
+                    })();
 
                     return (
                         <ServerBlock key={server.serverOrigin}>
@@ -242,18 +316,7 @@ const McpsTab = (props: Props) => {
                                     aria-controls={toolsPanelId}
                                     aria-label={intl.formatMessage(
                                         {defaultMessage: '{serverName}, {detail}. Press to expand or collapse tools.'},
-                                        {
-                                            serverName: server.name,
-                                            detail: enabledCount > 0 ?
-                                                intl.formatMessage(
-                                                    {defaultMessage: '{enabled} of {total} tools enabled'},
-                                                    {enabled: enabledCount, total: totalCount},
-                                                ) :
-                                                intl.formatMessage(
-                                                    {defaultMessage: '{total} tools available'},
-                                                    {total: totalCount},
-                                                ),
-                                        },
+                                        {serverName: server.name, detail: metaDetail},
                                     )}
                                     onClick={() => toggleServer(server.serverOrigin)}
                                 >
@@ -263,16 +326,7 @@ const McpsTab = (props: Props) => {
                                     <ServerInfo>
                                         <ServerName>{server.name}</ServerName>
                                         <ServerMeta>
-                                            {enabledCount > 0 ?
-                                                intl.formatMessage(
-                                                    {defaultMessage: '{enabled} of {total} tools enabled'},
-                                                    {enabled: enabledCount, total: totalCount},
-                                                ) :
-                                                intl.formatMessage(
-                                                    {defaultMessage: '{total} tools available'},
-                                                    {total: totalCount},
-                                                )
-                                            }
+                                            {metaDetail}
                                             {server.authenticated && (
                                                 <AuthBadge>
                                                     <FormattedMessage defaultMessage='Connected'/>
@@ -286,9 +340,22 @@ const McpsTab = (props: Props) => {
                                         </ServerMeta>
                                     </ServerInfo>
                                 </ServerHeaderButton>
+                                {canConnect && (
+                                    <ConnectButton
+                                        type='button'
+                                        onClick={() => {
+                                            if (server.authURL) {
+                                                window.open(server.authURL, '_blank', 'noopener,noreferrer');
+                                            }
+                                        }}
+                                    >
+                                        <FormattedMessage defaultMessage='Connect'/>
+                                    </ConnectButton>
+                                )}
                                 <ServerToggle
                                     type='button'
                                     aria-label={serverToggleLabel}
+                                    aria-checked={allOn}
                                     onClick={() => !autoEnableNewMCPTools && toggleAllServerTools(server)}
                                     disabled={autoEnableNewMCPTools}
                                     $enabled={allOn}
@@ -303,8 +370,19 @@ const McpsTab = (props: Props) => {
                                     role='region'
                                     aria-label={server.name}
                                 >
-                                    {server.tools.filter((t) => t.enabled).map((tool) => {
+                                    {adminEnabledTools.length === 0 && wildcardOn && (
+                                        <EmptyToolsNotice>
+                                            <FormattedMessage defaultMessage='This server has no tools available right now. When a user of this agent authenticates, every tool this server exposes will be enabled.'/>
+                                        </EmptyToolsNotice>
+                                    )}
+                                    {adminEnabledTools.length === 0 && !wildcardOn && canConnect && (
+                                        <EmptyToolsNotice>
+                                            <FormattedMessage defaultMessage='Connect this server to see and pick individual tools, or toggle it on to give the agent access to every tool the server exposes once a user connects.'/>
+                                        </EmptyToolsNotice>
+                                    )}
+                                    {adminEnabledTools.map((tool) => {
                                         const toolOn = isToolEnabled(server.serverOrigin, tool.name);
+                                        const toolsDisabled = autoEnableNewMCPTools || wildcardOn;
                                         return (
                                             <ToolRow key={tool.name}>
                                                 <ToolInfo>
@@ -315,17 +393,15 @@ const McpsTab = (props: Props) => {
                                                 </ToolInfo>
                                                 <ToolToggle
                                                     type='button'
-                                                    aria-label={toolOn ?
-                                                        intl.formatMessage(
-                                                            {defaultMessage: 'Disable tool {toolName} on {serverName}'},
-                                                            {toolName: tool.name, serverName: server.name},
-                                                        ) :
-                                                        intl.formatMessage(
-                                                            {defaultMessage: 'Enable tool {toolName} on {serverName}'},
-                                                            {toolName: tool.name, serverName: server.name},
-                                                        )}
-                                                    onClick={() => !autoEnableNewMCPTools && toggleTool(server.serverOrigin, tool.name)}
-                                                    disabled={autoEnableNewMCPTools}
+                                                    aria-label={toolOn ? intl.formatMessage(
+                                                        {defaultMessage: 'Disable tool {toolName} on {serverName}'},
+                                                        {toolName: tool.name, serverName: server.name},
+                                                    ) : intl.formatMessage(
+                                                        {defaultMessage: 'Enable tool {toolName} on {serverName}'},
+                                                        {toolName: tool.name, serverName: server.name},
+                                                    )}
+                                                    onClick={() => !toolsDisabled && toggleTool(server.serverOrigin, tool.name)}
+                                                    disabled={toolsDisabled}
                                                     $enabled={toolOn}
                                                 >
                                                     <ToggleKnob $enabled={toolOn}/>
@@ -535,6 +611,35 @@ const ToggleKnob = styled.div<{$enabled: boolean}>`
 
 const ToolList = styled.div`
     border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+`;
+
+const EmptyToolsNotice = styled.div`
+    padding: 12px 16px;
+    font-size: 12px;
+    color: rgba(var(--center-channel-color-rgb), 0.64);
+`;
+
+const ConnectButton = styled.button`
+    flex-shrink: 0;
+    height: 28px;
+    padding: 0 12px;
+    border-radius: 4px;
+    border: 1px solid var(--button-bg);
+    background: transparent;
+    color: var(--button-bg);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+
+    &:hover {
+        background: rgba(var(--button-bg-rgb), 0.08);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--button-bg);
+        outline-offset: 2px;
+    }
 `;
 
 const ToolRow = styled.div`

--- a/webapp/src/components/rhs/tool_provider_popover.tsx
+++ b/webapp/src/components/rhs/tool_provider_popover.tsx
@@ -8,6 +8,7 @@ import {ChevronDownIcon} from '@mattermost/compass-icons/components';
 
 import {disconnectMCPOAuth, getUserMCPTools, updateUserToolPreferences} from '@/client';
 import {EnabledMCPTool} from '@/bots';
+import {useMCPConnectionEvents} from '@/hooks/use_mcp_connection_events';
 
 import DotMenu, {DotMenuButton, DropdownMenu} from '../dot_menu';
 import {ToggleSwitch} from '../toggle_switch';
@@ -61,16 +62,28 @@ const ToolProviderPopover = ({disabledServers, onDisabledServersChange, preloade
 
     const servers = filterServersByEnabledTools(allServers, enabledMCPTools, autoEnableNewMCPTools);
 
-    const fetchServers = useCallback(async () => {
-        setLoading(true);
+    const fetchServers = useCallback(async (opts: {showLoading?: boolean} = {showLoading: true}) => {
+        if (opts.showLoading) {
+            setLoading(true);
+        }
         try {
             const response = await getUserMCPTools();
             setAllServers(response.servers);
         } catch {
             // Silently fail - servers stay empty
         }
-        setLoading(false);
+        if (opts.showLoading) {
+            setLoading(false);
+        }
     }, []);
+
+    // Refresh the cached server list whenever the user's MCP OAuth connection
+    // state changes (popup-driven Connect flow, cluster-forwarded disconnect,
+    // etc.) so the popover reflects the new state without manual refresh —
+    // both while the popover is open and next time it opens.
+    useMCPConnectionEvents(useCallback(() => {
+        fetchServers({showLoading: false});
+    }, [fetchServers]));
 
     const handleToggle = useCallback(async (serverOrigin: string, enabled: boolean) => {
         let updatedDisabled: string[];

--- a/webapp/src/components/rhs/tool_provider_popover.tsx
+++ b/webapp/src/components/rhs/tool_provider_popover.tsx
@@ -69,11 +69,16 @@ const ToolProviderPopover = ({disabledServers, onDisabledServersChange, preloade
         try {
             const response = await getUserMCPTools();
             setAllServers(response.servers);
-        } catch {
-            // Silently fail - servers stay empty
-        }
-        if (opts.showLoading) {
-            setLoading(false);
+        } catch (error) {
+            // Popover has no dedicated error surface; keep the prior server
+            // list and log so the failure is visible in diagnostic output
+            // rather than silently dropped.
+            // eslint-disable-next-line no-console
+            console.error('Failed to fetch MCP tools for RHS popover:', error);
+        } finally {
+            if (opts.showLoading) {
+                setLoading(false);
+            }
         }
     }, []);
 

--- a/webapp/src/components/rhs/tool_provider_popover.tsx
+++ b/webapp/src/components/rhs/tool_provider_popover.tsx
@@ -70,9 +70,6 @@ const ToolProviderPopover = ({disabledServers, onDisabledServersChange, preloade
             const response = await getUserMCPTools();
             setAllServers(response.servers);
         } catch (error) {
-            // Popover has no dedicated error surface; keep the prior server
-            // list and log so the failure is visible in diagnostic output
-            // rather than silently dropped.
             // eslint-disable-next-line no-console
             console.error('Failed to fetch MCP tools for RHS popover:', error);
         } finally {
@@ -82,10 +79,6 @@ const ToolProviderPopover = ({disabledServers, onDisabledServersChange, preloade
         }
     }, []);
 
-    // Refresh the cached server list whenever the user's MCP OAuth connection
-    // state changes (popup-driven Connect flow, cluster-forwarded disconnect,
-    // etc.) so the popover reflects the new state without manual refresh —
-    // both while the popover is open and next time it opens.
     useMCPConnectionEvents(useCallback(() => {
         fetchServers({showLoading: false});
     }, [fetchServers]));

--- a/webapp/src/components/rhs/tool_provider_popover.tsx
+++ b/webapp/src/components/rhs/tool_provider_popover.tsx
@@ -108,8 +108,9 @@ const ToolProviderPopover = ({disabledServers, onDisabledServersChange, preloade
         try {
             await disconnectMCPOAuth(serverName);
             await fetchServers();
-        } catch {
-            // Silently fail
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error(`Failed to disconnect MCP OAuth for ${serverName}:`, error);
         }
     }, [fetchServers]);
 

--- a/webapp/src/components/system_console/mcp_tools_viewer.tsx
+++ b/webapp/src/components/system_console/mcp_tools_viewer.tsx
@@ -49,20 +49,27 @@ const MCPToolsViewer = ({mcpConfig, onConfigChange, initialToolsData}: MCPToolsV
     const [clearSuccess, setClearSuccess] = useState<string | null>(null);
     const seededRef = useRef(false);
 
-    // Fetch tools data from the API
-    const fetchTools = async () => {
-        setLoading(true);
-        setError(null);
-
+    const fetchTools = useCallback(async (opts: {showLoading?: boolean} = {}) => {
         try {
+            if (opts.showLoading) {
+                setLoading(true);
+            }
             const response = await getMCPTools();
             setToolsData(response);
+            setError(null);
         } catch (err) {
-            setError(err instanceof Error ? err.message : 'Failed to fetch MCP tools');
+            if (opts.showLoading) {
+                setError(err instanceof Error ? err.message : 'Failed to fetch MCP tools');
+            } else {
+                // eslint-disable-next-line no-console
+                console.error('Background refresh of MCP tools failed:', err);
+            }
         } finally {
-            setLoading(false);
+            if (opts.showLoading) {
+                setLoading(false);
+            }
         }
-    };
+    }, []);
 
     // Clear the MCP tools cache
     const handleClearCache = async () => {
@@ -75,7 +82,7 @@ const MCPToolsViewer = ({mcpConfig, onConfigChange, initialToolsData}: MCPToolsV
             setClearSuccess(response.message);
 
             // Automatically refresh tools after clearing cache
-            await fetchTools();
+            await fetchTools({showLoading: true});
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to clear cache');
         } finally {
@@ -83,22 +90,17 @@ const MCPToolsViewer = ({mcpConfig, onConfigChange, initialToolsData}: MCPToolsV
         }
     };
 
-    // Fetch tools on component mount (skip if pre-loaded data is available)
     useEffect(() => {
         if (!initialToolsData) {
-            fetchTools();
+            fetchTools({showLoading: true});
         }
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [initialToolsData, fetchTools]);
 
-    // Refresh after the user finishes an MCP connect/disconnect flow in a
-    // popup window so the Tools tab reflects the new state without a manual
-    // refresh.
-    useMCPConnectionEvents(useCallback(() => {
-        fetchTools();
-
-    // fetchTools closes over setters only; it's stable for our purposes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []));
+    useMCPConnectionEvents(
+        useCallback(() => {
+            fetchTools();
+        }, [fetchTools]),
+    );
 
     // Retroactively seed vetted tool configs for existing servers.
     // This runs once after tools are first fetched, to fix servers configured before
@@ -253,7 +255,7 @@ const MCPToolsViewer = ({mcpConfig, onConfigChange, initialToolsData}: MCPToolsV
                         <FormattedMessage defaultMessage='Clear Cache'/>
                     </SecondaryButton>
                     <RefreshButton
-                        onClick={fetchTools}
+                        onClick={() => fetchTools({showLoading: true})}
                         disabled={loading || clearing}
                     >
                         <RefreshIcon

--- a/webapp/src/components/system_console/mcp_tools_viewer.tsx
+++ b/webapp/src/components/system_console/mcp_tools_viewer.tsx
@@ -1,13 +1,14 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import styled from 'styled-components';
 import {RefreshIcon, ExclamationThickIcon} from '@mattermost/compass-icons/components';
 import {FormattedMessage} from 'react-intl';
 
 import {TertiaryButton, SecondaryButton} from '../assets/buttons';
 import {getMCPTools, clearMCPToolsCache, getVettedToolSeed} from '../../client';
+import {useMCPConnectionEvents} from '../../hooks/use_mcp_connection_events';
 
 import {MCPConfig, MCPServerConfig, MCPToolConfig} from './mcp_servers';
 import MCPServerToolRow from './mcp_server_tool_row';
@@ -88,6 +89,16 @@ const MCPToolsViewer = ({mcpConfig, onConfigChange, initialToolsData}: MCPToolsV
             fetchTools();
         }
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Refresh after the user finishes an MCP connect/disconnect flow in a
+    // popup window so the Tools tab reflects the new state without a manual
+    // refresh.
+    useMCPConnectionEvents(useCallback(() => {
+        fetchTools();
+
+    // fetchTools closes over setters only; it's stable for our purposes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []));
 
     // Retroactively seed vetted tool configs for existing servers.
     // This runs once after tools are first fetched, to fix servers configured before

--- a/webapp/src/hooks/use_mcp_connection_events.ts
+++ b/webapp/src/hooks/use_mcp_connection_events.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useEffect} from 'react';
+
+// MCPConnectionEvent mirrors the payload of the backend websocket event
+// `custom_mattermost-ai_mcp_connection_updated` (see api.WebsocketEventMCPConnectionUpdated).
+export type MCPConnectionEvent = {
+    status: 'connected' | 'disconnected';
+    serverName?: string;
+    serverOrigin?: string;
+}
+
+// Module-level subscriber list. The websocket registration itself lives in
+// index.tsx; all it does is call notifyMCPConnectionUpdated() so UI components
+// can refresh their cached view of the user's MCP connection state without
+// requiring a page reload.
+const subscribers = new Set<(event: MCPConnectionEvent) => void>();
+
+export function notifyMCPConnectionUpdated(event: MCPConnectionEvent) {
+    subscribers.forEach((cb) => {
+        try {
+            cb(event);
+        } catch {
+            // Swallow listener errors so one misbehaving subscriber does not
+            // prevent the others from seeing the event.
+        }
+    });
+}
+
+export function useMCPConnectionEvents(listener: (event: MCPConnectionEvent) => void) {
+    useEffect(() => {
+        subscribers.add(listener);
+        return () => {
+            subscribers.delete(listener);
+        };
+    }, [listener]);
+}

--- a/webapp/src/hooks/use_mcp_connection_events.ts
+++ b/webapp/src/hooks/use_mcp_connection_events.ts
@@ -3,18 +3,13 @@
 
 import {useEffect} from 'react';
 
-// MCPConnectionEvent mirrors the payload of the backend websocket event
-// `custom_mattermost-ai_mcp_connection_updated` (see api.WebsocketEventMCPConnectionUpdated).
+// Payload for custom_mattermost-ai_mcp_connection_updated websocket events.
 export type MCPConnectionEvent = {
     status: 'connected' | 'disconnected';
     serverName?: string;
     serverOrigin?: string;
 }
 
-// Module-level subscriber list. The websocket registration itself lives in
-// index.tsx; all it does is call notifyMCPConnectionUpdated() so UI components
-// can refresh their cached view of the user's MCP connection state without
-// requiring a page reload.
 const subscribers = new Set<(event: MCPConnectionEvent) => void>();
 
 export function notifyMCPConnectionUpdated(event: MCPConnectionEvent) {
@@ -22,8 +17,7 @@ export function notifyMCPConnectionUpdated(event: MCPConnectionEvent) {
         try {
             cb(event);
         } catch {
-            // Swallow listener errors so one misbehaving subscriber does not
-            // prevent the others from seeing the event.
+            // Subscriber errors must not block other listeners.
         }
     });
 }

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -190,9 +190,7 @@ export default class Plugin {
             },
         );
 
-        // Fan out MCP connection updates so the New Agent modal and System
-        // Console tools viewer can refresh their cached tool lists after the
-        // user finishes an OAuth connect/disconnect flow in a popup window.
+        // MCP OAuth connect/disconnect: refresh cached tool lists in open UI.
         registry.registerWebSocketEventHandler(
             'custom_mattermost-ai_mcp_connection_updated',
             (msg: WebSocketMessage<MCPConnectionEvent>) => {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -35,6 +35,7 @@ import SearchButton from './components/search_button';
 import AskChannelButton from './components/ask_channel_button';
 import {doSelectPost} from './hooks';
 import {invalidateConversation} from './hooks/use_conversation';
+import {notifyMCPConnectionUpdated, MCPConnectionEvent} from './hooks/use_mcp_connection_events';
 import {handleAskChannelCommand, handleSummarizeChannelCommand} from './commands';
 import SearchHints from './components/search_hints';
 import {useBotlist} from './bots';
@@ -186,6 +187,16 @@ export default class Plugin {
             'custom_mattermost-ai_conversation_updated',
             (msg: WebSocketMessage<{conversation_id: string}>) => {
                 invalidateConversation(msg.data.conversation_id);
+            },
+        );
+
+        // Fan out MCP connection updates so the New Agent modal and System
+        // Console tools viewer can refresh their cached tool lists after the
+        // user finishes an OAuth connect/disconnect flow in a popup window.
+        registry.registerWebSocketEventHandler(
+            'custom_mattermost-ai_mcp_connection_updated',
+            (msg: WebSocketMessage<MCPConnectionEvent>) => {
+                notifyMCPConnectionUpdated(msg.data);
             },
         );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Addresses three usability gaps on the **MCPs** tab of the **New Agent** modal, surfaced in [MM-68440](https://mattermost.atlassian.net/browse/MM-68440):

1. **Connect button** now appears on the MCPs tab for servers the admin has not authenticated to, mirroring the System Console *Tools* tab.
2. **Disconnected servers can be enabled** for the agent via the per-server toggle. The agent records a new wildcard `EnabledMCPTool` entry (`tool_name = "*"`) meaning "every tool this server exposes". When a user of the agent later authenticates, all the server's tools are granted. The per-server toggles also mirror the top-level "Automatically enable all MCP tools" checkbox — checking the box flips every toggle on.
3. **No more manual refresh after connecting.** The backend now publishes a `mcp_connection_updated` websocket event (scoped to the connecting user) on successful OAuth callback and on manual disconnect. The webapp listens for it and automatically refreshes the New Agent modal, the System Console Tools tab, and the RHS **Tool Providers** popover (same Connect affordance surfaces there for end-users).

##### Backend
- `llm/tools.go` — `RetainOnlyMCPTools` honors the new wildcard entry (`ToolName == "*"` keeps every tool from that `ServerOrigin`). Unit tests added.
- `api/api_oauth.go` — emits `mcp_connection_updated` (`status: connected`) to the user after a successful OAuth callback.
- `api/api_mcp.go` — emits `mcp_connection_updated` (`status: disconnected`) to the user after `DELETE /mcp/oauth/:serverName`.
- `api/api_agents.go` — new `WebsocketEventMCPConnectionUpdated` constant.

##### Webapp
- `webapp/src/hooks/use_mcp_connection_events.ts` — tiny subscriber bus fed from the plugin's websocket handler in `index.tsx`.
- `webapp/src/components/agents/tabs/mcps_tab.tsx` — Connect button, wildcard semantics, auto-enable mirror, websocket-driven refresh.
- `webapp/src/components/system_console/mcp_tools_viewer.tsx` — websocket-driven refresh.
- `webapp/src/components/rhs/tool_provider_popover.tsx` — websocket-driven refresh so the Tools popover picks up a new/removed connection without the user having to close and re-open it.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-68440

#### Screenshots

| Initial state (every toggle ON because "Automatically enable all MCP tools" is checked) | After unchecking — every toggle OFF, Connect buttons visible on disconnected servers |
| --- | --- |
| ![MCP tab initial state](https://cursor.com/artifacts/c/art-814d64a5-0e40-4dd2-9cac-d56fe9d9f277) | ![MCP tab unchecked](https://cursor.com/artifacts/c/art-3f49aed7-44e6-4804-b24d-e99e38680e25) |

| GitHub row enabled despite being disconnected; wildcard hint shown in the expanded tool list | System Console Tools tab reference (existing Connect Account flow being mirrored) |
| --- | --- |
| ![MCP tab wildcard enabled](https://cursor.com/artifacts/c/art-22623134-3ee6-4e10-9e92-709546bf65e3) | ![System Console Connect reference](https://cursor.com/artifacts/c/art-1b70f227-077a-42e6-8efa-3f932d58aa57) |

Demo walkthrough:

<a href="https://cursor.com/agents/bc-5cfec8ff-ba1a-4479-b9bc-1022586e44c5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_new_agent_modal_demo.mp4"><img src="https://cursor.com/artifacts/c/art-e9fc8d6f-5845-4cf5-9ae7-20b6b940f51c" alt="mcp_new_agent_modal_demo.mp4" /></a>

#### Release Note
```release-note
Agents plugin: the New Agent modal's MCPs tab now exposes a Connect button for disconnected MCP servers, allows enabling whole servers even while not authenticated, and — along with the System Console Tools tab and the RHS Tool Providers popover — automatically refreshes after connect/disconnect via a new `mcp_connection_updated` websocket event.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cfec8ff-ba1a-4479-b9bc-1022586e44c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cfec8ff-ba1a-4479-b9bc-1022586e44c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time MCP connect/disconnect notifications trigger UI refreshes without a page reload.
  * Wildcard server-level tool enablement to activate all tools from a server at once.
  * Conditional "Connect" action appears when OAuth is available; UI shows distinct empty states and accessibility attributes for server toggles.

* **Improvements**
  * Background, non-disruptive refreshes across popovers, RHS and System Console via event-driven updates and refined loading/error handling.

* **Tests**
  * Added tests for MCP connection notifications and wildcard allowlist behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->