### PR TITLE
Fix Agents product icon color in global header

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -71,7 +71,8 @@ const IconAIContainer = styled.img`
     height: 24px;
 `;
 
-// Product switcher: primary blue like Channels; fixed slot width for label alignment, smaller glyph (~18px) to match core product icons (24px SVG looked oversized).
+// Product switcher: in the global header, inherit the same muted header text color as the Channels glyph
+// (see Mattermost ProductBranding). In the dropdown, match string product icons (ProductMenuItem uses --button-bg).
 const ProductSwitcherIconWrapper = styled.span`
     display: inline-flex;
     align-items: center;
@@ -80,7 +81,11 @@ const ProductSwitcherIconWrapper = styled.span`
     min-width: 24px;
     height: 24px;
     flex-shrink: 0;
-    color: var(--button-bg);
+    color: inherit;
+
+    .product-switcher-menu & {
+        color: var(--button-bg);
+    }
 
     svg {
         width: 18px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

The Agents sparkle icon registered for `registerProduct` was wrapped with `color: var(--button-bg)`, so it stayed primary blue in the **global header** while Channels uses the header’s inherited text color (`rgba(var(--sidebar-text-rgb), 0.64)` per Mattermost `GlobalHeader` / `ProductBranding`). The product **dropdown** already forces blue for string icons via `ProductMenuItem`; custom React nodes did not get that, so we relied on the wrapper for blue there.

This change sets the wrapper to **`color: inherit`** in the header and **`color: var(--button-bg)`** only when the icon appears inside Mattermost’s `.product-switcher-menu` dropdown, so the header matches Channels and the menu stays on-brand blue.

#### Ticket Link

N/A

#### Screenshots

Before:
<img width="209" height="124" alt="image" src="https://github.com/user-attachments/assets/044e53b3-c135-4201-8a77-15dd13fc7167" />
After:
<img width="495" height="112" alt="image" src="https://github.com/user-attachments/assets/7650b433-d9b6-4f1d-a46a-f7bf980d6556" />


#### Release Note

```release-note
Fixed Agents product icon using primary button blue in the global header instead of the same muted header color as other products.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d65860c2-988b-44ff-ba28-31e2a2583e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d65860c2-988b-44ff-ba28-31e2a2583e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated product switcher icon colour styling to inherit the global header text colour by default, with specific colour adjustments applied to the dropdown menu variant, improving visual consistency with other product menu icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->