### PR TITLE
MM-68447: Fix MCP tab short-query false positives in agent modal search

### DIFF
--- a/e2e/helpers/api-health-check.ts
+++ b/e2e/helpers/api-health-check.ts
@@ -23,89 +23,145 @@ interface HealthCheckResult {
 // when multiple test suites use the same provider in a single process.
 const healthCheckCache = new Map<string, Promise<HealthCheckResult>>();
 
+function isTransientHealthCheckError(message: string): boolean {
+    const m = message.toLowerCase();
+    return m.includes('timeout') || m.includes('aborted') || m.includes('econnreset') ||
+        m.includes('fetch failed') || m.includes('network') || m.includes('socket');
+}
+
+async function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function checkAnthropicHealth(service: LLMService): Promise<HealthCheckResult> {
-    const start = Date.now();
-    try {
-        const response = await fetch(`${service.apiURL}/v1/messages`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'x-api-key': service.apiKey,
-                'anthropic-version': '2023-06-01',
-            },
-            body: JSON.stringify({
+    const maxAttempts = 3;
+    let lastError = '';
+    const overallStart = Date.now();
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const start = Date.now();
+        try {
+            const response = await fetch(`${service.apiURL}/v1/messages`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-api-key': service.apiKey,
+                    'anthropic-version': '2023-06-01',
+                },
+                body: JSON.stringify({
+                    model: service.defaultModel,
+                    max_tokens: 20,
+                    messages: [{ role: 'user', content: 'hi' }],
+                }),
+                signal: AbortSignal.timeout(30000),
+            });
+
+            const latencyMs = Date.now() - start;
+
+            if (response.ok) {
+                return { provider: 'Anthropic', model: service.defaultModel, healthy: true, latencyMs: Date.now() - overallStart };
+            }
+
+            const body = await response.text().catch(() => '');
+            lastError = `HTTP ${response.status}: ${body.substring(0, 200)}`;
+            return {
+                provider: 'Anthropic',
                 model: service.defaultModel,
-                max_tokens: 20,
-                messages: [{ role: 'user', content: 'hi' }],
-            }),
-            signal: AbortSignal.timeout(30000),
-        });
-
-        const latencyMs = Date.now() - start;
-
-        if (response.ok) {
-            return { provider: 'Anthropic', model: service.defaultModel, healthy: true, latencyMs };
+                healthy: false,
+                error: lastError,
+                latencyMs: Date.now() - overallStart,
+            };
+        } catch (err) {
+            lastError = `Connection failed: ${(err as Error).message}`;
+            if (attempt < maxAttempts && isTransientHealthCheckError(lastError)) {
+                console.warn(
+                    `API Health Check: Anthropic (${service.defaultModel}) attempt ${attempt}/${maxAttempts} failed (${lastError}); retrying…`,
+                );
+                await sleep(2000 * attempt);
+                continue;
+            }
+            return {
+                provider: 'Anthropic',
+                model: service.defaultModel,
+                healthy: false,
+                error: lastError,
+                latencyMs: Date.now() - overallStart,
+            };
         }
-
-        const body = await response.text().catch(() => '');
-        return {
-            provider: 'Anthropic',
-            model: service.defaultModel,
-            healthy: false,
-            error: `HTTP ${response.status}: ${body.substring(0, 200)}`,
-            latencyMs,
-        };
-    } catch (err) {
-        return {
-            provider: 'Anthropic',
-            model: service.defaultModel,
-            healthy: false,
-            error: `Connection failed: ${(err as Error).message}`,
-            latencyMs: Date.now() - start,
-        };
     }
+
+    return {
+        provider: 'Anthropic',
+        model: service.defaultModel,
+        healthy: false,
+        error: lastError,
+        latencyMs: Date.now() - overallStart,
+    };
 }
 
 async function checkOpenAIHealth(service: LLMService): Promise<HealthCheckResult> {
-    const start = Date.now();
-    try {
-        const response = await fetch(`${service.apiURL}/chat/completions`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${service.apiKey}`,
-            },
-            body: JSON.stringify({
+    const maxAttempts = 3;
+    let lastError = '';
+    const overallStart = Date.now();
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const start = Date.now();
+        try {
+            const response = await fetch(`${service.apiURL}/chat/completions`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${service.apiKey}`,
+                },
+                body: JSON.stringify({
+                    model: service.defaultModel,
+                    max_completion_tokens: 20,
+                    messages: [{ role: 'user', content: 'hi' }],
+                }),
+                signal: AbortSignal.timeout(30000),
+            });
+
+            const latencyMs = Date.now() - start;
+
+            if (response.ok) {
+                return { provider: 'OpenAI', model: service.defaultModel, healthy: true, latencyMs: Date.now() - overallStart };
+            }
+
+            const body = await response.text().catch(() => '');
+            lastError = `HTTP ${response.status}: ${body.substring(0, 200)}`;
+            return {
+                provider: 'OpenAI',
                 model: service.defaultModel,
-                max_completion_tokens: 20,
-                messages: [{ role: 'user', content: 'hi' }],
-            }),
-            signal: AbortSignal.timeout(30000),
-        });
-
-        const latencyMs = Date.now() - start;
-
-        if (response.ok) {
-            return { provider: 'OpenAI', model: service.defaultModel, healthy: true, latencyMs };
+                healthy: false,
+                error: lastError,
+                latencyMs: Date.now() - overallStart,
+            };
+        } catch (err) {
+            lastError = `Connection failed: ${(err as Error).message}`;
+            if (attempt < maxAttempts && isTransientHealthCheckError(lastError)) {
+                console.warn(
+                    `API Health Check: OpenAI (${service.defaultModel}) attempt ${attempt}/${maxAttempts} failed (${lastError}); retrying…`,
+                );
+                await sleep(2000 * attempt);
+                continue;
+            }
+            return {
+                provider: 'OpenAI',
+                model: service.defaultModel,
+                healthy: false,
+                error: lastError,
+                latencyMs: Date.now() - overallStart,
+            };
         }
-
-        const body = await response.text().catch(() => '');
-        return {
-            provider: 'OpenAI',
-            model: service.defaultModel,
-            healthy: false,
-            error: `HTTP ${response.status}: ${body.substring(0, 200)}`,
-            latencyMs,
-        };
-    } catch (err) {
-        return {
-            provider: 'OpenAI',
-            model: service.defaultModel,
-            healthy: false,
-            error: `Connection failed: ${(err as Error).message}`,
-            latencyMs: Date.now() - start,
-        };
     }
+
+    return {
+        provider: 'OpenAI',
+        model: service.defaultModel,
+        healthy: false,
+        error: lastError,
+        latencyMs: Date.now() - overallStart,
+    };
 }
 
 /**

--- a/webapp/src/components/agents/tabs/mcp_servers_filter.test.ts
+++ b/webapp/src/components/agents/tabs/mcp_servers_filter.test.ts
@@ -54,9 +54,6 @@ describe('filterMcpsServersBySearchQuery', () => {
     });
 
     test('2-char query matching only enabled tool description is ignored (no false positive)', () => {
-        // "za" appears in read_post description in our default servers mock?
-        // read_post: "Read a specific post and thread from Mattermost" - no za
-        // Add dedicated server: only match in description
         const withZap: McpsSearchServerRow[] = [
             {
                 name: 'Alpha',

--- a/webapp/src/components/agents/tabs/mcp_servers_filter.test.ts
+++ b/webapp/src/components/agents/tabs/mcp_servers_filter.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {filterMcpsServersBySearchQuery, McpsSearchServerRow} from './mcp_servers_filter';
+
+function tool(
+    name: string,
+    description: string,
+    enabled = true,
+): McpsSearchServerRow['tools'][number] {
+    return {name, description, enabled};
+}
+
+describe('filterMcpsServersBySearchQuery', () => {
+    const servers: McpsSearchServerRow[] = [
+        {
+            name: 'Mattermost',
+            tools: [
+                tool('read_post', 'Read a specific post and thread from Mattermost.', true),
+                tool('dm', 'Send a direct message.', true),
+            ],
+        },
+        {
+            name: 'OtherCorp',
+            tools: [
+                tool('other_tool', 'Contains unrelated substring zap for testing.', true),
+            ],
+        },
+    ];
+
+    test('empty query returns all servers', () => {
+        expect(filterMcpsServersBySearchQuery(servers, '')).toEqual(servers);
+    });
+
+    test('whitespace-only query returns all servers', () => {
+        expect(filterMcpsServersBySearchQuery(servers, '   \t')).toEqual(servers);
+    });
+
+    test('1-char query matching server name keeps server', () => {
+        const result = filterMcpsServersBySearchQuery(servers, 'M');
+        expect(result.map((s) => s.name)).toContain('Mattermost');
+    });
+
+    test('1-char query matching only disabled tool description does not surface server', () => {
+        const disabledOnly: McpsSearchServerRow[] = [
+            {
+                name: 'HiddenMatch',
+                tools: [
+                    tool('disabled_tool', 'The word za appears only here in a long description.', false),
+                ],
+            },
+        ];
+        expect(filterMcpsServersBySearchQuery(disabledOnly, 'z')).toEqual([]);
+    });
+
+    test('2-char query matching only enabled tool description is ignored (no false positive)', () => {
+        // "za" appears in read_post description in our default servers mock?
+        // read_post: "Read a specific post and thread from Mattermost" - no za
+        // Add dedicated server: only match in description
+        const withZap: McpsSearchServerRow[] = [
+            {
+                name: 'Alpha',
+                tools: [tool('x', 'only the letters za appear in this long description', true)],
+            },
+        ];
+        expect(filterMcpsServersBySearchQuery(withZap, 'za')).toEqual([]);
+    });
+
+    test('2-char query matching enabled tool name returns server', () => {
+        const s: McpsSearchServerRow[] = [
+            {name: 'S', tools: [tool('ab_foo', 'no', true)]},
+        ];
+        expect(filterMcpsServersBySearchQuery(s, 'ab')).toEqual(s);
+    });
+
+    test('3-char query matching only tool description returns server', () => {
+        const s: McpsSearchServerRow[] = [
+            {
+                name: 'X',
+                tools: [tool('t1', 'uniqueZapToken in the description', true)],
+            },
+        ];
+        expect(filterMcpsServersBySearchQuery(s, 'Zap')).toEqual(s);
+    });
+
+    test('3-char query with no match returns empty', () => {
+        expect(filterMcpsServersBySearchQuery(servers, 'qqq')).toEqual([]);
+    });
+
+    test('query match on disabled tool name does not show server', () => {
+        const s: McpsSearchServerRow[] = [
+            {
+                name: 'ServerA',
+                tools: [tool('secret_tool', 'y', false)],
+            },
+        ];
+        expect(filterMcpsServersBySearchQuery(s, 'secret')).toEqual([]);
+    });
+
+    test('query match on disabled tool description with 3+ chars does not show server', () => {
+        const s: McpsSearchServerRow[] = [
+            {
+                name: 'ServerB',
+                tools: [tool('off', 'contains uniqueBlobToken only here', false)],
+            },
+        ];
+        expect(filterMcpsServersBySearchQuery(s, 'Blob')).toEqual([]);
+    });
+
+    test('boundary: 2-char query uppercase trimmed still uses short-query rules', () => {
+        const s: McpsSearchServerRow[] = [
+            {
+                name: 'NoSub',
+                tools: [tool('ok', 'ZZ substring in description zz', true)],
+            },
+        ];
+        expect(filterMcpsServersBySearchQuery(s, ' ZZ ')).toEqual([]);
+    });
+
+    test('boundary: exactly 3 chars enables description search', () => {
+        const s: McpsSearchServerRow[] = [
+            {
+                name: 'NoSub',
+                tools: [tool('ok', 'abc-only-in-description-field', true)],
+            },
+        ];
+        expect(filterMcpsServersBySearchQuery(s, 'abc')).toEqual(s);
+    });
+});

--- a/webapp/src/components/agents/tabs/mcp_servers_filter.ts
+++ b/webapp/src/components/agents/tabs/mcp_servers_filter.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Tool row shape used by MCP server search (matches GET /mcp/tools user response).
+ */
+export type McpsSearchToolRow = {
+    name: string;
+    description: string;
+    enabled: boolean;
+};
+
+/**
+ * Server row shape used by MCP server search.
+ */
+export type McpsSearchServerRow = {
+    name: string;
+    tools: McpsSearchToolRow[];
+};
+
+/**
+ * Returns servers visible for the given search query.
+ *
+ * - Empty or whitespace-only query: all servers (unchanged ordering).
+ * - Queries shorter than 3 characters (after trim): match server name and **enabled**
+ *   tool names only (not descriptions), so short substrings in long prose do not surface
+ *   unrelated servers.
+ * - Queries of 3+ characters: also match against **enabled** tool descriptions.
+ *
+ * Disabled admin-level tools never participate in search matching.
+ */
+export function filterMcpsServersBySearchQuery<T extends McpsSearchServerRow>(
+    servers: T[],
+    searchQuery: string,
+): T[] {
+    const trimmed = searchQuery.trim();
+    if (!trimmed) {
+        return servers;
+    }
+    const q = trimmed.toLowerCase();
+    const useDescriptions = q.length >= 3;
+    return servers.filter((server) => {
+        const searchableTools = server.tools.filter((t) => t.enabled);
+        const nameMatches = server.name.toLowerCase().includes(q);
+        const toolNameMatches = searchableTools.some((t) => t.name.toLowerCase().includes(q));
+        if (!useDescriptions) {
+            return nameMatches || toolNameMatches;
+        }
+        return nameMatches ||
+            toolNameMatches ||
+            searchableTools.some((t) => t.description.toLowerCase().includes(q));
+    });
+}

--- a/webapp/src/components/agents/tabs/mcps_tab.tsx
+++ b/webapp/src/components/agents/tabs/mcps_tab.tsx
@@ -9,6 +9,8 @@ import {ChevronDownIcon, ChevronRightIcon} from '@mattermost/compass-icons/compo
 import {getUserMCPTools} from '@/client';
 import {EnabledTool} from '@/types/agents';
 
+import {filterMcpsServersBySearchQuery} from './mcp_servers_filter';
+
 // Types matching the getUserMCPTools() response shape (from api/api_mcp.go)
 type UserMCPToolInfo = {
     name: string;
@@ -141,27 +143,11 @@ const McpsTab = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [autoEnableNewMCPTools, enabledTools, servers]);
 
-    // Filter servers by search. Short queries only match server and tool names — not tool
-    // descriptions — because descriptions are long and common 1–2 letter substrings (e.g. "za")
-    // would otherwise keep unrelated servers (notably the embedded Mattermost server) visible.
-    const filteredServers = useMemo(() => {
-        const trimmed = searchQuery.trim();
-        if (!trimmed) {
-            return servers;
-        }
-        const q = trimmed.toLowerCase();
-        const useDescriptions = q.length >= 3;
-        return servers.filter((server) => {
-            const nameMatches = server.name.toLowerCase().includes(q);
-            const toolNameMatches = server.tools.some((t) => t.name.toLowerCase().includes(q));
-            if (!useDescriptions) {
-                return nameMatches || toolNameMatches;
-            }
-            return nameMatches ||
-                toolNameMatches ||
-                server.tools.some((t) => t.description.toLowerCase().includes(q));
-        });
-    }, [servers, searchQuery]);
+    // Search is implemented in mcp_servers_filter (see unit tests for query length rules).
+    const filteredServers = useMemo(
+        () => filterMcpsServersBySearchQuery(servers, searchQuery),
+        [servers, searchQuery],
+    );
 
     if (loading) {
         return (

--- a/webapp/src/components/agents/tabs/mcps_tab.tsx
+++ b/webapp/src/components/agents/tabs/mcps_tab.tsx
@@ -141,15 +141,27 @@ const McpsTab = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [autoEnableNewMCPTools, enabledTools, servers]);
 
-    // Filter servers/tools by search
-    const filteredServers = servers.filter((server) => {
-        if (!searchQuery) {
-            return true;
+    // Filter servers by search. Short queries only match server and tool names — not tool
+    // descriptions — because descriptions are long and common 1–2 letter substrings (e.g. "za")
+    // would otherwise keep unrelated servers (notably the embedded Mattermost server) visible.
+    const filteredServers = useMemo(() => {
+        const trimmed = searchQuery.trim();
+        if (!trimmed) {
+            return servers;
         }
-        const q = searchQuery.toLowerCase();
-        return server.name.toLowerCase().includes(q) ||
-            server.tools.some((t) => t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q));
-    });
+        const q = trimmed.toLowerCase();
+        const useDescriptions = q.length >= 3;
+        return servers.filter((server) => {
+            const nameMatches = server.name.toLowerCase().includes(q);
+            const toolNameMatches = server.tools.some((t) => t.name.toLowerCase().includes(q));
+            if (!useDescriptions) {
+                return nameMatches || toolNameMatches;
+            }
+            return nameMatches ||
+                toolNameMatches ||
+                server.tools.some((t) => t.description.toLowerCase().includes(q));
+        });
+    }, [servers, searchQuery]);
 
     if (loading) {
         return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Short search strings in the Create Agent modal MCPs tab could keep the embedded **Mattermost** server visible even when the query did not appear in the server name or any tool name. The filter matched **tool descriptions**, which are long prose strings and often contain unrelated two-letter substrings (for example `za`).

This change applies **full** matching (name + description) only when the trimmed query is **at least three characters**. For one- and two-character queries, matching is limited to the **server display name** and **tool names** only, which removes those false positives while preserving expected matches (for example a single `e` still matches **Matt**e**r**most).

Search matches only **admin-enabled** tools (`tool.enabled`): disabled tools are excluded from name and description matching so a server cannot appear solely because of a disabled tool row (see CodeRabbit feedback).

Pure filter logic lives in `webapp/src/components/agents/tabs/mcp_servers_filter.ts`; Jest regression tests are in `mcp_servers_filter.test.ts` (empty vs whitespace, short vs long queries, disabled-tool cases, 3-character boundary).

The `e2e-llmbot-real-apis-citations` CI job failed once with an **Anthropic API health check timeout** before any plugin tests ran (transient upstream/network). Real-API pre-flight checks in `e2e/helpers/api-health-check.ts` now **retry** (up to 3 attempts with backoff) on likely-transient connection errors for both Anthropic and OpenAI.

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-68447

#### Release Note

```release-note
Fixed the MCPs tab search in the agent builder so that very short queries no longer match unrelated text inside tool descriptions and incorrectly show the Mattermost server.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10246cd8-8318-4ef3-9910-a5cdd9c69766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10246cd8-8318-4ef3-9910-a5cdd9c69766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved MCP server search: queries are trimmed; 1–2 char queries match server and enabled tool names only, while 3+ char queries also match enabled tool descriptions; disabled tools are excluded.

* **Performance**
  * Search filtering optimized for snappier results.

* **Reliability**
  * Provider health checks now retry with backoff to improve stability and latency reporting.

* **Tests**
  * Added comprehensive tests covering search behaviour and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->