### PR TITLE
Fix non-admin channel search in Create Agent modal

### DIFF
--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -1,9 +1,18 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+const mockSearchAllChannels = jest.fn();
+
+jest.mock('@mattermost/client', () => ({
+    Client4: jest.fn().mockImplementation(() => ({
+        searchAllChannels: mockSearchAllChannels,
+    })),
+    ClientError: class extends Error {},
+}));
+
 import type {ConversationResponse, Turn} from '@/types/conversation';
 
-import {normalizeConversationResponse} from './client';
+import {normalizeConversationResponse, searchAllChannels} from './client';
 
 function makeTurn(overrides: Partial<Turn> = {}): Turn {
     return {
@@ -33,6 +42,10 @@ function makeConv(overrides: Partial<ConversationResponse> = {}): ConversationRe
 }
 
 describe('normalizeConversationResponse', () => {
+    beforeEach(() => {
+        mockSearchAllChannels.mockReset();
+    });
+
     test('replaces null turn content with an empty array', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const raw = makeConv({turns: [makeTurn({content: null as any})]});
@@ -68,5 +81,25 @@ describe('normalizeConversationResponse', () => {
         expect(normalized.turns[0].content).toHaveLength(1);
         expect(normalized.turns[1].content).toEqual([]);
         expect(normalized.turns[2].content).toEqual([]);
+    });
+});
+
+describe('searchAllChannels', () => {
+    beforeEach(() => {
+        mockSearchAllChannels.mockReset();
+    });
+
+    test('uses the non-admin search path for channel scoping', async () => {
+        const channels = [{id: 'channel-id'}];
+        mockSearchAllChannels.mockResolvedValue(channels);
+
+        await expect(searchAllChannels('town')).resolves.toEqual(channels);
+        expect(mockSearchAllChannels).toHaveBeenCalledWith('town', {
+            nonAdminSearch: true,
+            public: true,
+            private: true,
+            include_deleted: false,
+            deleted: false,
+        });
     });
 });

--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -4,23 +4,32 @@
 import type {ChannelSearchOpts, ChannelWithTeamData} from '@mattermost/types/channels';
 import type {OptsSignalExt} from '@mattermost/types/client4';
 
-type SearchAllChannelsOpts = Omit<ChannelSearchOpts, 'page' | 'per_page'> & OptsSignalExt;
-
-const mockSearchAllChannels = jest.fn<
-    Promise<ChannelWithTeamData[]>,
-    [string, SearchAllChannelsOpts | undefined]
->();
-
-jest.mock('@mattermost/client', () => ({
-    Client4: jest.fn().mockImplementation(() => ({
-        searchAllChannels: mockSearchAllChannels,
-    })),
-    ClientError: class extends Error {},
-}));
-
 import type {ConversationResponse, Turn} from '@/types/conversation';
 
 import {normalizeConversationResponse, searchAllChannels} from './client';
+
+type SearchAllChannelsOpts = Omit<ChannelSearchOpts, 'page' | 'per_page'> & OptsSignalExt;
+
+jest.mock('@mattermost/client', () => {
+    const mockSearchAllChannels = jest.fn<
+        Promise<ChannelWithTeamData[]>,
+        [string, SearchAllChannelsOpts | undefined]
+    >();
+
+    return {
+        Client4: jest.fn().mockImplementation(() => ({
+            searchAllChannels: mockSearchAllChannels,
+        })),
+        ClientError: class extends Error {},
+        mockSearchAllChannels,
+    };
+});
+
+const {mockSearchAllChannels} = jest.requireMock('@mattermost/client') as {
+    mockSearchAllChannels: jest.MockedFunction<
+        (term: string, opts?: SearchAllChannelsOpts) => Promise<ChannelWithTeamData[]>
+    >;
+};
 
 function makeTurn(overrides: Partial<Turn> = {}): Turn {
     return {

--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -17,9 +17,11 @@ jest.mock('@mattermost/client', () => {
     >();
 
     return {
-        Client4: jest.fn().mockImplementation(() => ({
-            searchAllChannels: mockSearchAllChannels,
-        })),
+
+        // client.tsx constructs `new Client4()`; the mocked class exposes instance methods.
+        Client4: class Client4 {
+            searchAllChannels = mockSearchAllChannels;
+        },
         ClientError: class extends Error {},
         mockSearchAllChannels,
     };

--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -1,7 +1,11 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-const mockSearchAllChannels = jest.fn();
+import type Client4 from '@mattermost/client';
+
+type Client4SearchAllChannels = Client4['searchAllChannels'];
+
+const mockSearchAllChannels = jest.fn() as jest.MockedFunction<Client4SearchAllChannels>;
 
 jest.mock('@mattermost/client', () => ({
     Client4: jest.fn().mockImplementation(() => ({

--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -1,11 +1,15 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type Client4 from '@mattermost/client';
+import type {ChannelSearchOpts, ChannelWithTeamData} from '@mattermost/types/channels';
+import type {OptsSignalExt} from '@mattermost/types/client4';
 
-type Client4SearchAllChannels = Client4['searchAllChannels'];
+type SearchAllChannelsOpts = Omit<ChannelSearchOpts, 'page' | 'per_page'> & OptsSignalExt;
 
-const mockSearchAllChannels = jest.fn() as jest.MockedFunction<Client4SearchAllChannels>;
+const mockSearchAllChannels = jest.fn<
+    Promise<ChannelWithTeamData[]>,
+    [string, SearchAllChannelsOpts | undefined]
+>();
 
 jest.mock('@mattermost/client', () => ({
     Client4: jest.fn().mockImplementation(() => ({
@@ -94,7 +98,7 @@ describe('searchAllChannels', () => {
     });
 
     test('uses the non-admin search path for channel scoping', async () => {
-        const channels = [{id: 'channel-id'}];
+        const channels = [{id: 'channel-id'} as ChannelWithTeamData];
         mockSearchAllChannels.mockResolvedValue(channels);
 
         await expect(searchAllChannels('town')).resolves.toEqual(channels);

--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -372,7 +372,9 @@ export async function getProfilesByIds(userIds: string[]) {
 
 export async function searchAllChannels(term: string): Promise<ChannelWithTeamData[]> {
     return Client4.searchAllChannels(term, {
-        nonAdminSearch: false,
+        // Use the non-admin search path so regular users can search visible channels
+        // without requiring system console permissions.
+        nonAdminSearch: true,
         public: true,
         private: true,
         include_deleted: false,

--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -372,6 +372,7 @@ export async function getProfilesByIds(userIds: string[]) {
 
 export async function searchAllChannels(term: string): Promise<ChannelWithTeamData[]> {
     return Client4.searchAllChannels(term, {
+
         // Use the non-admin search path so regular users can search visible channels
         // without requiring system console permissions.
         nonAdminSearch: true,


### PR DESCRIPTION
#### Summary
- Switched the agent channel selector to use the non-admin channel search path so non-admin users can search visible channels without hitting a 403.
- Added a unit test covering the channel search wrapper options.
- QA: As a non-admin user, open the Create Agent modal, choose selected channels, search for a visible channel, and verify results appear instead of `No options`.
- Local Jest/ESLint/TypeScript validation could not be run in this worktree because `webapp/node_modules` is missing.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-68446

#### Screenshots
N/A

#### Release Note
```release-note
Fixed an issue where non-admin users could not search for channels when scoping an agent to selected channels.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Channel search updated so regular users can discover all visible channels without requiring system administrator permissions, improving visibility and access for non-admins.

* **Tests**
  * Test suite expanded to mock and verify channel search behaviour with non-admin scoping, and tests now reset mocks between groups to improve isolation and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->