### PR TITLE
MM-68452: Add unsaved changes warning to agent config modal

### DIFF
--- a/e2e/helpers/agent-page.ts
+++ b/e2e/helpers/agent-page.ts
@@ -181,6 +181,18 @@ export class AgentPageHelper {
         return this.getDeleteDialog().getByRole('button', { name: 'Delete' });
     }
 
+    getDiscardChangesDialog(): Locator {
+        return this.page.getByRole('dialog', { name: 'Discard changes?' });
+    }
+
+    getDiscardChangesButton(): Locator {
+        return this.getDiscardChangesDialog().getByRole('button', { name: 'Discard changes' });
+    }
+
+    getKeepEditingButton(): Locator {
+        return this.getDiscardChangesDialog().getByRole('button', { name: 'Keep editing' });
+    }
+
     // --- MCPs Tab ---
 
     getMCPSearchInput(): Locator {
@@ -221,5 +233,17 @@ export class AgentPageHelper {
     async waitForModalClosed(): Promise<void> {
         // Wait for the display name input to disappear (reliable signal)
         await this.getDisplayNameInput().waitFor({ state: 'hidden', timeout: 10000 });
+    }
+
+    async clickModalBackdrop(): Promise<void> {
+        const modal = this.getModal();
+        const box = await modal.boundingBox();
+        if (!box) {
+            throw new Error('Agent config modal is not visible');
+        }
+
+        const clickX = Math.max(5, box.x - 20);
+        const clickY = Math.max(5, box.y - 20);
+        await this.page.mouse.click(clickX, clickY);
     }
 }

--- a/e2e/helpers/agent-page.ts
+++ b/e2e/helpers/agent-page.ts
@@ -189,8 +189,16 @@ export class AgentPageHelper {
         return this.getDiscardChangesDialog().getByRole('button', { name: 'Discard changes' });
     }
 
+    getDiscardChangesConfirmButton(): Locator {
+        return this.getDiscardChangesButton();
+    }
+
     getKeepEditingButton(): Locator {
         return this.getDiscardChangesDialog().getByRole('button', { name: 'Keep editing' });
+    }
+
+    getDiscardChangesCancelButton(): Locator {
+        return this.getKeepEditingButton();
     }
 
     // --- MCPs Tab ---

--- a/e2e/tests/agents/crud.spec.ts
+++ b/e2e/tests/agents/crud.spec.ts
@@ -256,4 +256,35 @@ test.describe('Agent CRUD', () => {
         const mcpsTab = page.getByRole('button', { name: 'MCPs' });
         await expect(mcpsTab).toBeDisabled();
     });
+
+    test('warns before discarding unsaved agent modal changes', async ({ page }) => {
+        test.setTimeout(60000);
+        const mmPage = new MattermostPage(page);
+        const agentPage = new AgentPageHelper(page);
+
+        await mmPage.login(mattermost.url(), agentAdminUsername, agentAdminPassword);
+        await agentPage.navigateToAgents(mattermost.url());
+
+        await agentPage.getCreateButton().click();
+        await agentPage.waitForModal();
+
+        await agentPage.fillConfigTab({
+            displayName: 'Unsaved Agent',
+            username: 'unsavedagent',
+            serviceLabel: 'Mock Service',
+        });
+
+        await agentPage.clickModalBackdrop();
+        await expect(agentPage.getDiscardChangesDialog()).toBeVisible({timeout: 10000});
+
+        await agentPage.getDiscardChangesCancelButton().click();
+        await expect(agentPage.getDiscardChangesDialog()).not.toBeVisible({timeout: 10000});
+        await expect(agentPage.getDisplayNameInput()).toHaveValue('Unsaved Agent');
+
+        await agentPage.clickModalBackdrop();
+        await expect(agentPage.getDiscardChangesDialog()).toBeVisible({timeout: 10000});
+
+        await agentPage.getDiscardChangesConfirmButton().click();
+        await agentPage.waitForModalClosed();
+    });
 });

--- a/webapp/src/components/agents/agent_config_modal.test.tsx
+++ b/webapp/src/components/agents/agent_config_modal.test.tsx
@@ -1,0 +1,160 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {IntlProvider} from 'react-intl';
+
+import {ServiceInfo} from '@/types/agents';
+
+import AgentConfigModal, {AgentDraft} from './agent_config_modal';
+
+jest.mock('react-intl', () => {
+    const actual = jest.requireActual('react-intl');
+    return {
+        ...actual,
+        useIntl: () => ({
+            formatMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+        }),
+        FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
+});
+
+jest.mock('@/client', () => ({
+    createAgent: jest.fn(),
+    updateAgent: jest.fn(),
+    uploadAgentAvatar: jest.fn(),
+}));
+
+jest.mock('@/components/system_console/bot', () => ({
+    ChannelAccessLevel: {
+        All: 0,
+    },
+    UserAccessLevel: {
+        All: 0,
+    },
+}));
+
+jest.mock('./tabs/config_tab', () => ({
+    __esModule: true,
+    default: ({draft, onChange}: {draft: AgentDraft; onChange: (updates: Partial<AgentDraft>) => void}) => (
+        <input
+            aria-label='Display Name'
+            value={draft.displayName}
+            onChange={(e) => onChange({displayName: e.target.value})}
+        />
+    ),
+}));
+
+jest.mock('./tabs/access_tab', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('./tabs/mcps_tab', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+const services: ServiceInfo[] = [
+    {
+        id: 'svc_1',
+        name: 'Mock Service',
+        type: 'openai',
+        defaultModel: 'gpt-4.1',
+        outputTokenLimit: 4096,
+        useResponsesAPI: true,
+    },
+];
+
+function renderModal(onClose = jest.fn()) {
+    const result = render(
+        <IntlProvider locale='en'>
+            <AgentConfigModal
+                show={true}
+                mode='create'
+                services={services}
+                onClose={onClose}
+                onSaved={jest.fn()}
+            />
+        </IntlProvider>,
+    );
+
+    return {
+        ...result,
+        onClose,
+    };
+}
+
+describe('AgentConfigModal', () => {
+    test('confirms before dismissing unsaved changes from backdrop click', () => {
+        const {container, onClose} = renderModal();
+
+        fireEvent.change(screen.getByLabelText('Display Name'), {target: {value: 'Unsaved Agent'}});
+        fireEvent.click(container.firstChild as HTMLElement);
+
+        expect(screen.getByRole('dialog', {name: 'Discard changes?'})).not.toBeNull();
+        expect(onClose).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Keep editing'}));
+        expect(screen.queryByRole('dialog', {name: 'Discard changes?'})).toBeNull();
+        expect((screen.getByLabelText('Display Name') as HTMLInputElement).value).toBe('Unsaved Agent');
+
+        fireEvent.click(container.firstChild as HTMLElement);
+        fireEvent.click(screen.getByRole('button', {name: 'Discard changes'}));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('closes immediately when there are no unsaved changes', () => {
+        const {container, onClose} = renderModal();
+
+        fireEvent.click(container.firstChild as HTMLElement);
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('dialog', {name: 'Discard changes?'})).toBeNull();
+    });
+
+    test('loads edit mode without treating existing values as dirty', () => {
+        const onClose = jest.fn();
+
+        render(
+            <IntlProvider locale='en'>
+                <AgentConfigModal
+                    show={true}
+                    mode='edit'
+                    agent={{
+                        id: 'agent_1',
+                        name: 'existingagent',
+                        displayName: 'Existing Agent',
+                        customInstructions: '',
+                        serviceID: 'svc_1',
+                        model: '',
+                        enableVision: true,
+                        disableTools: false,
+                        channelAccessLevel: 0,
+                        channelIDs: [],
+                        userAccessLevel: 0,
+                        userIDs: [],
+                        teamIDs: [],
+                        enabledNativeTools: ['web_search'],
+                        enabledMCPTools: [],
+                        autoEnableNewMCPTools: true,
+                        reasoningEnabled: true,
+                        reasoningEffort: 'medium',
+                        thinkingBudget: 0,
+                        structuredOutputEnabled: false,
+                    }}
+                    services={services}
+                    onClose={onClose}
+                    onSaved={jest.fn()}
+                />
+            </IntlProvider>,
+        );
+
+        fireEvent.keyDown(document, {key: 'Escape'});
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('dialog', {name: 'Discard changes?'})).toBeNull();
+    });
+});

--- a/webapp/src/components/agents/agent_config_modal.tsx
+++ b/webapp/src/components/agents/agent_config_modal.tsx
@@ -10,6 +10,7 @@ import {createAgent, updateAgent, uploadAgentAvatar} from '@/client';
 import {UserAgent, CreateAgentRequest, UpdateAgentRequest, EnabledTool, ServiceInfo} from '@/types/agents';
 import {ChannelAccessLevel, UserAccessLevel} from '@/components/system_console/bot';
 import {PrimaryButton, TertiaryButton} from '@/components/assets/buttons';
+import ConfirmationDialog from '@/components/confirmation_dialog';
 
 import ConfigTab from './tabs/config_tab';
 import AccessTab from './tabs/access_tab';
@@ -65,6 +66,22 @@ const emptyDraft: AgentDraft = {
     thinkingBudget: 0,
     structuredOutputEnabled: false,
 };
+
+function cloneDraft(draft: AgentDraft): AgentDraft {
+    return {
+        ...draft,
+        channelIds: [...draft.channelIds],
+        userIds: [...draft.userIds],
+        teamIds: [...draft.teamIds],
+        adminUserIds: [...draft.adminUserIds],
+        enabledTools: [...draft.enabledTools],
+        enabledNativeTools: [...draft.enabledNativeTools],
+    };
+}
+
+function draftsEqual(a: AgentDraft, b: AgentDraft): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
+}
 
 /**
  * Full-document create payload from the form draft. The backend uses the UI as the sole
@@ -164,17 +181,22 @@ const AgentConfigModal = (props: Props) => {
 
     const [activeTab, setActiveTab] = useState<Tab>('config');
     const [draft, setDraft] = useState<AgentDraft>(emptyDraft);
+    const [initialDraft, setInitialDraft] = useState<AgentDraft>(emptyDraft);
     const [avatarFile, setAvatarFile] = useState<File | null>(null);
     const [saving, setSaving] = useState(false);
     const [errors, setErrors] = useState<Record<string, string>>({});
+    const [showDiscardChangesDialog, setShowDiscardChangesDialog] = useState(false);
 
     // Reset form when modal opens
     useEffect(() => {
         if (show) {
+            const nextDraft = cloneDraft(agent ? agentToDraft(agent) : emptyDraft);
             setActiveTab('config');
-            setDraft(agent ? agentToDraft(agent) : emptyDraft);
+            setDraft(nextDraft);
+            setInitialDraft(cloneDraft(nextDraft));
             setAvatarFile(null);
             setErrors({});
+            setShowDiscardChangesDialog(false);
         }
     }, [show, agent]);
 
@@ -185,6 +207,21 @@ const AgentConfigModal = (props: Props) => {
         }
     }, [draft.disableTools, activeTab]);
 
+    const hasUnsavedChanges = avatarFile !== null || !draftsEqual(draft, initialDraft);
+
+    const requestClose = useCallback(() => {
+        if (saving || showDiscardChangesDialog) {
+            return;
+        }
+
+        if (hasUnsavedChanges) {
+            setShowDiscardChangesDialog(true);
+            return;
+        }
+
+        onClose();
+    }, [saving, showDiscardChangesDialog, hasUnsavedChanges, onClose]);
+
     // Escape key to close
     useEffect(() => {
         if (!show) {
@@ -194,12 +231,12 @@ const AgentConfigModal = (props: Props) => {
         }
         const handler = (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
-                onClose();
+                requestClose();
             }
         };
         document.addEventListener('keydown', handler);
         return () => document.removeEventListener('keydown', handler);
-    }, [show, onClose]);
+    }, [show, requestClose]);
 
     const updateDraft = useCallback((updates: Partial<AgentDraft>) => {
         setDraft((prev) => ({...prev, ...updates}));
@@ -281,11 +318,11 @@ const AgentConfigModal = (props: Props) => {
         draft.displayName || intl.formatMessage({defaultMessage: 'Edit Agent'});
 
     return (
-        <ModalOverlay onClick={onClose}>
+        <ModalOverlay onClick={requestClose}>
             <ModalContainer onClick={(e) => e.stopPropagation()}>
                 <ModalHeader>
                     <ModalTitle>{title}</ModalTitle>
-                    <CloseButton onClick={onClose}>
+                    <CloseButton onClick={requestClose}>
                         <CloseIcon size={20}/>
                     </CloseButton>
                 </ModalHeader>
@@ -347,7 +384,7 @@ const AgentConfigModal = (props: Props) => {
                 </ModalBody>
 
                 <ModalFooter>
-                    <CancelButton onClick={onClose}>
+                    <CancelButton onClick={requestClose}>
                         <FormattedMessage defaultMessage='Cancel'/>
                     </CancelButton>
                     <SaveButton
@@ -361,6 +398,20 @@ const AgentConfigModal = (props: Props) => {
                     </SaveButton>
                 </ModalFooter>
             </ModalContainer>
+            {showDiscardChangesDialog && (
+                <ConfirmationDialog
+                    titleId='discard-agent-changes-dialog-title'
+                    title={<FormattedMessage defaultMessage='Discard changes?'/>}
+                    message={<FormattedMessage defaultMessage='You have unsaved changes. Do you want to keep editing or discard them?'/>}
+                    confirmButtonText={<FormattedMessage defaultMessage='Discard changes'/>}
+                    cancelButtonText={<FormattedMessage defaultMessage='Keep editing'/>}
+                    onConfirm={onClose}
+                    onCancel={() => setShowDiscardChangesDialog(false)}
+                    isDestructive={true}
+                    managedAccessibility={true}
+                    zIndex={2100}
+                />
+            )}
         </ModalOverlay>
     );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
- add a discard-changes confirmation when the agent create/edit modal is dismissed with unsaved edits
- preserve the current draft when the user chooses to keep editing
- cover the behavior with a focused webapp regression test and an agents CRUD Playwright regression

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-68452

#### Screenshots
Before:
![Before: unsaved agent modal closes without warning](https://cursor.com/artifacts/c/art-f2791c66-99cf-4e60-b48e-7c53aa42c875)

After:
![After: discard changes confirmation appears](https://cursor.com/artifacts/c/art-78ac6c4f-0353-4d66-9793-537386a78d1d)

#### Walkthrough
<a href="https://cursor.com/agents/bc-a05b324d-c2e8-4342-b8f7-a5c809b80a60/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmm68452_unsaved_changes_confirmation_demo.mp4"><img src="https://cursor.com/artifacts/c/art-21787bd0-3fe9-4f34-a270-bfba4b28846b" alt="mm68452_unsaved_changes_confirmation_demo.mp4" /></a>

#### QA
- `cd webapp && npm test -- --runInBand --watch=false`
- `cd webapp && npm run check-types`
- `cd webapp && npm run build`
- `cd webapp && npm run lint -- src/components/agents/agent_config_modal.tsx src/components/agents/agent_config_modal.test.tsx`
- `cd e2e && npx playwright test tests/agents/crud.spec.ts --list`
- `cd e2e && npx playwright test tests/agents/crud.spec.ts --project=chromium --reporter=list` *(initially blocked in this VM until Docker was brought up; screenshots/video were captured against a live local Mattermost instance after bringing the environment online)*

#### Release Note
```release-note
Fixed an issue where dismissing the agent configuration modal could discard unsaved edits without a confirmation prompt.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a05b324d-c2e8-4342-b8f7-a5c809b80a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a05b324d-c2e8-4342-b8f7-a5c809b80a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Discard changes?" confirmation dialog that appears when users attempt to close an agent configuration modal with unsaved changes, allowing users to either keep editing or confirm the discard.

* **Tests**
  * Added comprehensive test coverage for the confirmation dialog and modal closure behaviour under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->