### PR TITLE
MCP: use httpservice for local URL attachment fetches; standalone dev note

### DIFF
--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -497,7 +497,9 @@ For more information, see [Atlassian's documentation on MCP server settings](htt
 
 ## Mattermost MCP Server
 
-The Mattermost MCP Server enables AI agents and external applications to interact with your Mattermost instance through the Model Context Protocol (MCP). This is a standardized protocol that allows AI assistants to read messages, search content, create posts, and manage channels and teams programmatically. 
+The Mattermost MCP Server enables AI agents and external applications to interact with your Mattermost instance through the Model Context Protocol (MCP). This is a standardized protocol that allows AI assistants to read messages, search content, create posts, and manage channels and teams programmatically.
+
+**Standalone MCP server (separate process / stdio):** Running the standalone `mattermost-mcp-server` binary outside the Mattermost server is for **development and local use only** and is **not** intended for production. Production deployments should rely on the embedded Mattermost MCP server and the supported configuration in this plugin (System Console, HTTP endpoint for external clients, and agent MCP settings below).
 
 ### Overview
 

--- a/mcpserver/README.md
+++ b/mcpserver/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server that provides AI agents and automation tools with secure access to Mattermost channels, users, and content.
 
+**Standalone binary:** The `mattermost-mcp-server` process (for example, stdio transport for local clients) is intended for **development and local tooling only** and is **not** supported for production deployments. For production, use the Agents plugin’s embedded MCP and the in-server integration described in the [admin guide](../docs/admin_guide.md#mattermost-mcp-server).
+
 ## Features
 
 - **MCP Protocol Support**: Implements the Model Context Protocol for standardized AI agent communication

--- a/mcpserver/tools/file_utils.go
+++ b/mcpserver/tools/file_utils.go
@@ -12,9 +12,41 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/httpservice"
 )
+
+// staticMCPURLFetchConfig provides defaults that mirror a locked-down Mattermost server
+// (no TLS verification bypass, no allowlist of internal hostnames) for the standalone
+// MCP binary's untrusted URL fetches.
+var staticMCPURLFetchConfig = &model.Config{
+	ServiceSettings: model.ServiceSettings{
+		EnableInsecureOutgoingConnections:   model.NewPointer(false),
+		AllowedUntrustedInternalConnections: model.NewPointer(""),
+	},
+}
+
+// staticMCPConfigService implements the getConfig type expected by httpservice.MakeHTTPService.
+type staticMCPConfigService struct{}
+
+func (staticMCPConfigService) Config() *model.Config {
+	return staticMCPURLFetchConfig
+}
+
+// maxMCPURLFetchBytes matches the default model.FileSettings.MaxFileSize (100 MiB) for attachment reads.
+const maxMCPURLFetchBytes = 100 * 1024 * 1024
+
+var mcpLocalURLHTTPClientInstance *http.Client
+var mcpLocalURLHTTPClientOnce sync.Once
+
+func getMCPLocalURLHTTPClient() *http.Client {
+	mcpLocalURLHTTPClientOnce.Do(func() {
+		mcpLocalURLHTTPClientInstance = httpservice.MakeHTTPService(staticMCPConfigService{}).MakeClient(false)
+	})
+	return mcpLocalURLHTTPClientInstance
+}
 
 // GetDataDirectoryInternal is the internal function that can be overridden in tests
 var GetDataDirectoryInternal = getDataDirectory
@@ -49,7 +81,7 @@ func EnsureDataDirectory() error {
 }
 
 // fetchFileDataForLocal fetches file data from a file path or URL (local access only)
-func fetchFileDataForLocal(filespec string, accessMode AccessMode) ([]byte, error) {
+func fetchFileDataForLocal(ctx context.Context, filespec string, accessMode AccessMode) ([]byte, error) {
 	if filespec == "" {
 		return nil, fmt.Errorf("empty filespec provided")
 	}
@@ -61,7 +93,24 @@ func fetchFileDataForLocal(filespec string, accessMode AccessMode) ([]byte, erro
 
 	// Check if it's a URL
 	if isURL(filespec) {
-		resp, err := http.Get(filespec) // #nosec G107 - filespec is validated to be URL
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		parsed, err := url.Parse(filespec)
+		if err != nil {
+			return nil, fmt.Errorf("invalid URL: %w", err)
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return nil, fmt.Errorf("unsupported URL scheme: %q", parsed.Scheme)
+		}
+		if parsed.Host == "" {
+			return nil, fmt.Errorf("URL missing host")
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build request: %w", err)
+		}
+		resp, err := getMCPLocalURLHTTPClient().Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch file from URL: %w", err)
 		}
@@ -71,11 +120,14 @@ func fetchFileDataForLocal(filespec string, accessMode AccessMode) ([]byte, erro
 			return nil, fmt.Errorf("failed to fetch file: HTTP %d", resp.StatusCode)
 		}
 
-		data, err := io.ReadAll(resp.Body)
+		limited := io.LimitReader(resp.Body, maxMCPURLFetchBytes+1)
+		data, err := io.ReadAll(limited)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file data: %w", err)
 		}
-
+		if int64(len(data)) > maxMCPURLFetchBytes {
+			return nil, fmt.Errorf("response too large (max %d bytes)", maxMCPURLFetchBytes)
+		}
 		return data, nil
 	}
 
@@ -177,7 +229,7 @@ func uploadFilesForLocal(ctx context.Context, client *model.Client4, channelID s
 			continue
 		}
 
-		fileData, err := fetchFileDataForLocal(filespec, accessMode)
+		fileData, err := fetchFileDataForLocal(ctx, filespec, accessMode)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch file %s: %w", filespec, err)
 		}

--- a/mcpserver/tools/file_utils_test.go
+++ b/mcpserver/tools/file_utils_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/shared/httpservice"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchFileDataForLocal_LoopbackURLRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("x"))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := fetchFileDataForLocal(t.Context(), server.URL, AccessModeLocal)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), httpservice.ErrAddressForbidden.Error()),
+		"expected loopback URL to be rejected, got: %v", err)
+}
+
+func TestFetchFileDataForLocal_URLEmptyHostRejected(t *testing.T) {
+	_, err := fetchFileDataForLocal(t.Context(), "https:///path", AccessModeLocal)
+	require.Error(t, err)
+}

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -347,7 +347,7 @@ func (p *MattermostToolProvider) toolCreateTeam(mcpContext *MCPToolContext, args
 		if !isValidImageFile(fileName) {
 			teamIconMessage = " (team icon upload failed: unsupported file type, only .jpeg, .jpg, .png, .gif are supported)"
 		} else {
-			imageData, err := fetchFileDataForLocal(args.TeamIcon, mcpContext.AccessMode)
+			imageData, err := fetchFileDataForLocal(mcpContext.Ctx, args.TeamIcon, mcpContext.AccessMode)
 			if err != nil {
 				teamIconMessage = fmt.Sprintf(" (team icon upload failed: %v)", err)
 			} else {

--- a/mcpserver/tools/users.go
+++ b/mcpserver/tools/users.go
@@ -82,7 +82,7 @@ func (p *MattermostToolProvider) toolCreateUser(mcpContext *MCPToolContext, args
 		if !isValidImageFile(fileName) {
 			profileImageMessage = " (profile image upload failed: unsupported file type, only .jpeg, .jpg, .png, .gif are supported)"
 		} else {
-			imageData, err := fetchFileDataForLocal(args.ProfileImage, mcpContext.AccessMode)
+			imageData, err := fetchFileDataForLocal(mcpContext.Ctx, args.ProfileImage, mcpContext.AccessMode)
 			if err != nil {
 				profileImageMessage = fmt.Sprintf(" (profile image upload failed: %v)", err)
 			} else {

--- a/mcpserver/tools/util_test.go
+++ b/mcpserver/tools/util_test.go
@@ -91,7 +91,7 @@ func TestFetchFileData_FilePathValidation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, testErr := fetchFileDataForLocal(tc.filespec, AccessModeLocal)
+			_, testErr := fetchFileDataForLocal(t.Context(), tc.filespec, AccessModeLocal)
 
 			if tc.shouldFail {
 				if testErr == nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Use Mattermost `httpservice.MakeHTTPService` with a static `model.Config` and `MakeClient(false)` for local-mode attachment URL fetches in `mcpserver/tools/file_utils.go`, with a 100 MiB read cap and request context.
- Add a test that a loopback `httptest` URL is rejected (aligned with the untrusted client behavior in `httpservice`).
- Note in `mcpserver/README.md` and `docs/admin_guide.md` that the separate `mattermost-mcp-server` process is for development, not production.

## Testing

- `go test ./mcpserver/tools/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16e0f987-165f-4af8-aa4f-54f95e49d89d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16e0f987-165f-4af8-aa4f-54f95e49d89d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the standalone server is for development/local use only; direct production deployments should use the embedded MCP managed via the plugin and admin settings.

* **Bug Fixes / Security**
  * Strengthened URL validation and HTTP request handling.
  * Added response size limits to prevent excessive transfers.
  * Made file-fetching operations context-aware.

* **Tests**
  * Added tests covering address validation and malformed-URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->