### PR TITLE
MCP: use httpservice for local attachment URL fetches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ deploy: dist
 mcp-server:
 	@echo Building MCP server...
 	mkdir -p mcpserver/bin
-	$(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) $(GO_BUILD_LDFLAGS) -o bin/mattermost-mcp-server ./mcpserver/cmd/main.go
+	$(GO) build $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) $(GO_BUILD_LDFLAGS) -o mcpserver/bin/mattermost-mcp-server ./mcpserver/cmd/main.go
 
 ## Builds the evalviewer binary.
 .PHONY: evalviewer

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -497,7 +497,9 @@ For more information, see [Atlassian's documentation on MCP server settings](htt
 
 ## Mattermost MCP Server
 
-The Mattermost MCP Server enables AI agents and external applications to interact with your Mattermost instance through the Model Context Protocol (MCP). This is a standardized protocol that allows AI assistants to read messages, search content, create posts, and manage channels and teams programmatically. 
+The Mattermost MCP Server enables AI agents and external applications to interact with your Mattermost instance through the Model Context Protocol (MCP). This is a standardized protocol that allows AI assistants to read messages, search content, create posts, and manage channels and teams programmatically.
+
+**Standalone MCP server (separate process / stdio):** Running the standalone `mattermost-mcp-server` binary outside the Mattermost server is for **development and local use only** and is **not** intended for production. Production deployments should rely on the embedded Mattermost MCP server and the supported configuration in this plugin (System Console, HTTP endpoint for external clients, and agent MCP settings below).
 
 ### Overview
 

--- a/mcpserver/README.md
+++ b/mcpserver/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server that provides AI agents and automation tools with secure access to Mattermost channels, users, and content.
 
+**Standalone binary:** The `mattermost-mcp-server` process (for example, stdio transport for local clients) is intended for **development and local tooling only** and is **not** supported for production deployments. For production, use the Agents plugin’s embedded MCP and the in-server integration described in the [admin guide](../docs/admin_guide.md#mattermost-mcp-server).
+
 ## Features
 
 - **MCP Protocol Support**: Implements the Model Context Protocol for standardized AI agent communication

--- a/mcpserver/README.md
+++ b/mcpserver/README.md
@@ -213,7 +213,7 @@ For HTTP-based MCP clients and web applications, the server supports HTTP transp
 
 **Basic HTTP server setup:**
 ```bash
-./bin/mattermost-mcp-server \
+./mcpserver/bin/mattermost-mcp-server \
   --transport http \
   --server-url https://your-mattermost.com \
   --http-port 8080 \
@@ -223,7 +223,7 @@ For HTTP-based MCP clients and web applications, the server supports HTTP transp
 **External access via specific network interface:**
 ```bash
 # Bind to specific network interface IP
-./bin/mattermost-mcp-server \
+./mcpserver/bin/mattermost-mcp-server \
   --transport http \
   --server-url https://your-mattermost.com \
   --http-bind-addr 192.168.1.100 \
@@ -235,7 +235,7 @@ For HTTP-based MCP clients and web applications, the server supports HTTP transp
 ```bash
 export MM_SERVER_URL=https://your-mattermost.com
 export MM_INTERNAL_SERVER_URL=http://localhost:8065  # optional for localhost optimization
-./bin/mattermost-mcp-server --transport http --http-port 8080 --site-url https://mcp.yourcompany.com
+./mcpserver/bin/mattermost-mcp-server --transport http --http-port 8080 --site-url https://mcp.yourcompany.com
 ```
 
 **Available endpoints:**
@@ -295,7 +295,7 @@ When the MCP server runs on the same machine as your Mattermost server, you can 
 
 ```bash
 # MCP server and Mattermost on the same machine
-./bin/mattermost-mcp-server \
+./mcpserver/bin/mattermost-mcp-server \
   --server-url https://mattermost.company.com \
   --internal-server-url http://localhost:8065 \
   --token your-pat-token
@@ -306,7 +306,7 @@ When the MCP server runs on the same machine as your Mattermost server, you can 
 export MM_SERVER_URL=https://mattermost.company.com
 export MM_INTERNAL_SERVER_URL=http://localhost:8065
 export MM_ACCESS_TOKEN=your-pat-token
-./bin/mattermost-mcp-server
+./mcpserver/bin/mattermost-mcp-server
 ```
 
 **When to use:**

--- a/mcpserver/README.md
+++ b/mcpserver/README.md
@@ -8,7 +8,7 @@ A Model Context Protocol (MCP) server that provides AI agents and automation too
 
 - **MCP Protocol Support**: Implements the Model Context Protocol for standardized AI agent communication
 - **Authentication**: Personal Access Token (PAT) authentication
-- **Transport**: Configurable transport layer (stdio JSON-RPC for desktop clients, HTTP with SSE for web applications)
+- **Transport** (development use): Configurable transport layer (stdio JSON-RPC for desktop clients, HTTP with SSE for web applications). The standalone binary note at the top of this file also applies. For production, use the Agents plugin’s embedded MCP and the [admin guide](../docs/admin_guide.md#mattermost-mcp-server).
 - **Comprehensive Mattermost Integration**: Read posts, channels, search, create content
 - **Dual Mode Operation**: Runs standalone or embedded in the AI plugin
 
@@ -165,7 +165,7 @@ Create a post as a specific user using username/password login. Simply provide t
 - `--dev`: Enable development mode with additional tools for setting up test data
 - `--version`: Show version information
 
-**HTTP Transport Options (when --transport=http):**
+**HTTP Transport Options** (when `--transport=http` — development and local use only, not for production; see the intro):
 - `--http-port`: Port for HTTP server (default: 8080)
 - `--http-bind-addr`: Bind address for HTTP server (default: 127.0.0.1 for security, use specific IP for external access)
 - `--site-url`: Public URL where clients will access the MCP server (used for OAuth metadata and origin validation)
@@ -207,9 +207,9 @@ To use with Claude Desktop, add the server to your MCP configuration:
 }
 ```
 
-#### HTTP Transport Integration
+#### HTTP Transport Integration (development and local use)
 
-For HTTP-based MCP clients and web applications, the server supports HTTP transport with OAuth authentication:
+For HTTP-based MCP clients and web applications, the server supports HTTP transport with OAuth authentication. The standalone binary is for development; for production, use the Agents plugin’s embedded MCP and the [admin guide](../docs/admin_guide.md#mattermost-mcp-server) integration.
 
 **Basic HTTP server setup:**
 ```bash

--- a/mcpserver/tools/file_utils.go
+++ b/mcpserver/tools/file_utils.go
@@ -5,6 +5,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -46,6 +47,27 @@ func getMCPLocalURLHTTPClient() *http.Client {
 		mcpLocalURLHTTPClientInstance = httpservice.MakeHTTPService(staticMCPConfigService{}).MakeClient(false)
 	})
 	return mcpLocalURLHTTPClientInstance
+}
+
+// errMCPURLFetchNotAllowed is returned for user-facing output when the HTTP client rejects a URL
+// (e.g. private or reserved address). Do not echo raw transport or Mattermost config hints to tools/channels.
+var errMCPURLFetchNotAllowed = errors.New("attachment URL could not be fetched: destination is not allowed")
+
+func mcpUserFacingURLFetchError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, httpservice.ErrAddressForbidden) {
+		return errMCPURLFetchNotAllowed
+	}
+	// http.Client may not preserve unwrap chains with %w; match stable substrings without exposing config names.
+	s := err.Error()
+	if strings.Contains(s, "address forbidden, you may need to set") ||
+		strings.Contains(s, "is in a reserved range and not in") ||
+		strings.Contains(s, "is a self-assigned IP and not in") {
+		return errMCPURLFetchNotAllowed
+	}
+	return err
 }
 
 // readLimitedToMaxMCPBytes reads r with the same size cap for URL and data-directory file sources.
@@ -125,6 +147,10 @@ func fetchFileDataForLocal(ctx context.Context, filespec string, accessMode Acce
 		}
 		resp, err := getMCPLocalURLHTTPClient().Do(req)
 		if err != nil {
+			ue := mcpUserFacingURLFetchError(err)
+			if errors.Is(ue, errMCPURLFetchNotAllowed) {
+				return nil, ue
+			}
 			return nil, fmt.Errorf("failed to fetch file from URL: %w", err)
 		}
 		defer resp.Body.Close()

--- a/mcpserver/tools/file_utils.go
+++ b/mcpserver/tools/file_utils.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -49,25 +50,16 @@ func getMCPLocalURLHTTPClient() *http.Client {
 	return mcpLocalURLHTTPClientInstance
 }
 
-// errMCPURLFetchNotAllowed is returned for user-facing output when the HTTP client rejects a URL
-// (e.g. private or reserved address). Do not echo raw transport or Mattermost config hints to tools/channels.
-var errMCPURLFetchNotAllowed = errors.New("attachment URL could not be fetched: destination is not allowed")
+// errMCPFileUploadFailed is returned to tool output when an attachment URL fetch fails.
+// The underlying error is logged; do not wrap with %w from low-level clients to avoid leaking details to users.
+var errMCPFileUploadFailed = errors.New("file upload failed")
 
-func mcpUserFacingURLFetchError(err error) error {
+func mcpLogAttachmentURLFailureAndReturn(err error) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, httpservice.ErrAddressForbidden) {
-		return errMCPURLFetchNotAllowed
-	}
-	// http.Client may not preserve unwrap chains with %w; match stable substrings without exposing config names.
-	s := err.Error()
-	if strings.Contains(s, "address forbidden, you may need to set") ||
-		strings.Contains(s, "is in a reserved range and not in") ||
-		strings.Contains(s, "is a self-assigned IP and not in") {
-		return errMCPURLFetchNotAllowed
-	}
-	return err
+	log.Printf("mattermost-mcp: attachment URL fetch: %v", err)
+	return errMCPFileUploadFailed
 }
 
 // readLimitedToMaxMCPBytes reads r with the same size cap for URL and data-directory file sources.
@@ -133,35 +125,31 @@ func fetchFileDataForLocal(ctx context.Context, filespec string, accessMode Acce
 		}
 		parsed, err := url.Parse(filespec)
 		if err != nil {
-			return nil, fmt.Errorf("invalid URL: %w", err)
+			return nil, mcpLogAttachmentURLFailureAndReturn(fmt.Errorf("parse URL: %w", err))
 		}
 		if parsed.Scheme != "http" && parsed.Scheme != "https" {
-			return nil, fmt.Errorf("unsupported URL scheme: %q", parsed.Scheme)
+			return nil, mcpLogAttachmentURLFailureAndReturn(fmt.Errorf("unsupported URL scheme: %q", parsed.Scheme))
 		}
 		if parsed.Host == "" {
-			return nil, fmt.Errorf("URL missing host")
+			return nil, mcpLogAttachmentURLFailureAndReturn(fmt.Errorf("URL missing host"))
 		}
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build request: %w", err)
+			return nil, mcpLogAttachmentURLFailureAndReturn(err)
 		}
 		resp, err := getMCPLocalURLHTTPClient().Do(req)
 		if err != nil {
-			ue := mcpUserFacingURLFetchError(err)
-			if errors.Is(ue, errMCPURLFetchNotAllowed) {
-				return nil, ue
-			}
-			return nil, fmt.Errorf("failed to fetch file from URL: %w", err)
+			return nil, mcpLogAttachmentURLFailureAndReturn(err)
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("failed to fetch file: HTTP %d", resp.StatusCode)
+			return nil, mcpLogAttachmentURLFailureAndReturn(fmt.Errorf("HTTP %d", resp.StatusCode))
 		}
 
 		data, err := readLimitedToMaxMCPBytes(resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read file data: %w", err)
+			return nil, mcpLogAttachmentURLFailureAndReturn(err)
 		}
 		return data, nil
 	}
@@ -266,6 +254,9 @@ func uploadFilesForLocal(ctx context.Context, client *model.Client4, channelID s
 
 		fileData, err := fetchFileDataForLocal(ctx, filespec, accessMode)
 		if err != nil {
+			if errors.Is(err, errMCPFileUploadFailed) {
+				return nil, err
+			}
 			return nil, fmt.Errorf("failed to fetch file %s: %w", filespec, err)
 		}
 

--- a/mcpserver/tools/file_utils.go
+++ b/mcpserver/tools/file_utils.go
@@ -12,9 +12,41 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/httpservice"
 )
+
+// staticMCPURLFetchConfig provides defaults that mirror a locked-down Mattermost server
+// (no TLS verification bypass, no allowlist of internal hostnames) for the standalone
+// MCP binary's untrusted URL fetches.
+var staticMCPURLFetchConfig = &model.Config{
+	ServiceSettings: model.ServiceSettings{
+		EnableInsecureOutgoingConnections:   model.NewPointer(false),
+		AllowedUntrustedInternalConnections: model.NewPointer(""),
+	},
+}
+
+// staticMCPConfigService implements the getConfig type expected by httpservice.MakeHTTPService.
+type staticMCPConfigService struct{}
+
+func (staticMCPConfigService) Config() *model.Config {
+	return staticMCPURLFetchConfig
+}
+
+// maxMCPURLFetchBytes matches the default model.FileSettings.MaxFileSize (100 MiB) for attachment reads.
+const maxMCPURLFetchBytes = 100 * 1024 * 1024
+
+var mcpLocalURLHTTPClientInstance *http.Client
+var mcpLocalURLHTTPClientOnce sync.Once
+
+func getMCPLocalURLHTTPClient() *http.Client {
+	mcpLocalURLHTTPClientOnce.Do(func() {
+		mcpLocalURLHTTPClientInstance = httpservice.MakeHTTPService(staticMCPConfigService{}).MakeClient(false)
+	})
+	return mcpLocalURLHTTPClientInstance
+}
 
 // GetDataDirectoryInternal is the internal function that can be overridden in tests
 var GetDataDirectoryInternal = getDataDirectory
@@ -49,7 +81,7 @@ func EnsureDataDirectory() error {
 }
 
 // fetchFileDataForLocal fetches file data from a file path or URL (local access only)
-func fetchFileDataForLocal(filespec string, accessMode AccessMode) ([]byte, error) {
+func fetchFileDataForLocal(ctx context.Context, filespec string, accessMode AccessMode) ([]byte, error) {
 	if filespec == "" {
 		return nil, fmt.Errorf("empty filespec provided")
 	}
@@ -61,7 +93,24 @@ func fetchFileDataForLocal(filespec string, accessMode AccessMode) ([]byte, erro
 
 	// Check if it's a URL
 	if isURL(filespec) {
-		resp, err := http.Get(filespec) // #nosec G107 - filespec is validated to be URL
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		parsed, err := url.Parse(filespec)
+		if err != nil {
+			return nil, fmt.Errorf("invalid URL: %w", err)
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return nil, fmt.Errorf("unsupported URL scheme: %q", parsed.Scheme)
+		}
+		if parsed.Host == "" {
+			return nil, fmt.Errorf("URL missing host")
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build request: %w", err)
+		}
+		resp, err := getMCPLocalURLHTTPClient().Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch file from URL: %w", err)
 		}
@@ -71,11 +120,14 @@ func fetchFileDataForLocal(filespec string, accessMode AccessMode) ([]byte, erro
 			return nil, fmt.Errorf("failed to fetch file: HTTP %d", resp.StatusCode)
 		}
 
-		data, err := io.ReadAll(resp.Body)
+		limited := io.LimitReader(resp.Body, maxMCPURLFetchBytes+1)
+		data, err := io.ReadAll(limited)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file data: %w", err)
 		}
-
+		if int64(len(data)) > maxMCPURLFetchBytes {
+			return nil, fmt.Errorf("response too large (max %d bytes)", maxMCPURLFetchBytes)
+		}
 		return data, nil
 	}
 
@@ -177,7 +229,7 @@ func uploadFilesForLocal(ctx context.Context, client *model.Client4, channelID s
 			continue
 		}
 
-		fileData, err := fetchFileDataForLocal(filespec, accessMode)
+		fileData, err := fetchFileDataForLocal(ctx, filespec, accessMode)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch file %s: %w", filespec, err)
 		}

--- a/mcpserver/tools/file_utils.go
+++ b/mcpserver/tools/file_utils.go
@@ -291,7 +291,11 @@ func uploadFilesAndUrlsForLocal(ctx context.Context, client *model.Client4, chan
 
 		uploadedFileIDs, uploadErr := uploadFilesForLocal(ctx, client, channelID, attachments, accessMode)
 		if uploadErr != nil {
-			attachmentMessage = fmt.Sprintf(" (file upload failed: %v)", uploadErr)
+			if errors.Is(uploadErr, errMCPFileUploadFailed) {
+				attachmentMessage = " (file upload failed)"
+			} else {
+				attachmentMessage = fmt.Sprintf(" (file upload failed: %v)", uploadErr)
+			}
 		} else {
 			fileIDs = uploadedFileIDs
 			attachmentMessage = fmt.Sprintf(" (uploaded %d files)", len(fileIDs))

--- a/mcpserver/tools/file_utils.go
+++ b/mcpserver/tools/file_utils.go
@@ -35,8 +35,8 @@ func (staticMCPConfigService) Config() *model.Config {
 	return staticMCPURLFetchConfig
 }
 
-// maxMCPURLFetchBytes matches the default model.FileSettings.MaxFileSize (100 MiB) for attachment reads.
-const maxMCPURLFetchBytes = 100 * 1024 * 1024
+// maxMCPFetchBytes matches the default model.FileSettings.MaxFileSize (100 MiB) for local attachment reads.
+const maxMCPFetchBytes = 100 * 1024 * 1024
 
 var mcpLocalURLHTTPClientInstance *http.Client
 var mcpLocalURLHTTPClientOnce sync.Once
@@ -46,6 +46,19 @@ func getMCPLocalURLHTTPClient() *http.Client {
 		mcpLocalURLHTTPClientInstance = httpservice.MakeHTTPService(staticMCPConfigService{}).MakeClient(false)
 	})
 	return mcpLocalURLHTTPClientInstance
+}
+
+// readLimitedToMaxMCPBytes reads r with the same size cap for URL and data-directory file sources.
+func readLimitedToMaxMCPBytes(r io.Reader) ([]byte, error) {
+	limited := io.LimitReader(r, maxMCPFetchBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxMCPFetchBytes {
+		return nil, fmt.Errorf("content too large (max %d bytes)", maxMCPFetchBytes)
+	}
+	return data, nil
 }
 
 // GetDataDirectoryInternal is the internal function that can be overridden in tests
@@ -120,13 +133,9 @@ func fetchFileDataForLocal(ctx context.Context, filespec string, accessMode Acce
 			return nil, fmt.Errorf("failed to fetch file: HTTP %d", resp.StatusCode)
 		}
 
-		limited := io.LimitReader(resp.Body, maxMCPURLFetchBytes+1)
-		data, err := io.ReadAll(limited)
+		data, err := readLimitedToMaxMCPBytes(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file data: %w", err)
-		}
-		if int64(len(data)) > maxMCPURLFetchBytes {
-			return nil, fmt.Errorf("response too large (max %d bytes)", maxMCPURLFetchBytes)
 		}
 		return data, nil
 	}
@@ -157,7 +166,7 @@ func fetchFileDataForLocal(ctx context.Context, filespec string, accessMode Acce
 	}
 	defer file.Close()
 
-	data, err := io.ReadAll(file)
+	data, err := readLimitedToMaxMCPBytes(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}

--- a/mcpserver/tools/file_utils_test.go
+++ b/mcpserver/tools/file_utils_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/mattermost/mattermost/server/public/shared/httpservice"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +26,7 @@ func TestFetchFileDataForLocal_InvalidURLSpecs(t *testing.T) {
 		{
 			name:        "loopback URL from httptest is rejected",
 			filespec:    server.URL,
-			errContains: httpservice.ErrAddressForbidden.Error(),
+			errContains: errMCPURLFetchNotAllowed.Error(),
 		},
 		{
 			name:        "URL missing host",
@@ -41,6 +40,11 @@ func TestFetchFileDataForLocal_InvalidURLSpecs(t *testing.T) {
 			_, err := fetchFileDataForLocal(t.Context(), tc.filespec, AccessModeLocal)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tc.errContains)
+			low := err.Error()
+			if tc.filespec == server.URL {
+				require.NotContains(t, low, "AllowedUntrusted", "user-facing error must not mention server config settings")
+				require.NotContains(t, low, "Get \"http", "user-facing error must not echo the raw request line")
+			}
 		})
 	}
 }

--- a/mcpserver/tools/file_utils_test.go
+++ b/mcpserver/tools/file_utils_test.go
@@ -19,19 +19,16 @@ func TestFetchFileDataForLocal_InvalidURLSpecs(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	testCases := []struct {
-		name        string
-		filespec    string
-		errContains string
+		name     string
+		filespec string
 	}{
 		{
-			name:        "loopback URL from httptest is rejected",
-			filespec:    server.URL,
-			errContains: errMCPURLFetchNotAllowed.Error(),
+			name:     "URL fetch failure returns file upload failed",
+			filespec: server.URL,
 		},
 		{
-			name:        "URL missing host",
-			filespec:    "https:///path",
-			errContains: "URL missing host",
+			name:     "empty host is handled like other URL errors",
+			filespec: "https:///path",
 		},
 	}
 
@@ -39,12 +36,10 @@ func TestFetchFileDataForLocal_InvalidURLSpecs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := fetchFileDataForLocal(t.Context(), tc.filespec, AccessModeLocal)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.errContains)
+			require.ErrorIs(t, err, errMCPFileUploadFailed)
+			// No raw transport or config detail in the returned value (logs hold the full error)
 			low := err.Error()
-			if tc.filespec == server.URL {
-				require.NotContains(t, low, "AllowedUntrusted", "user-facing error must not mention server config settings")
-				require.NotContains(t, low, "Get \"http", "user-facing error must not echo the raw request line")
-			}
+			require.Equal(t, errMCPFileUploadFailed.Error(), low)
 		})
 	}
 }

--- a/mcpserver/tools/file_utils_test.go
+++ b/mcpserver/tools/file_utils_test.go
@@ -6,27 +6,41 @@ package tools
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/shared/httpservice"
 	"github.com/stretchr/testify/require"
 )
 
-func TestFetchFileDataForLocal_LoopbackURLRejected(t *testing.T) {
+func TestFetchFileDataForLocal_InvalidURLSpecs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("x"))
 	}))
 	t.Cleanup(server.Close)
 
-	_, err := fetchFileDataForLocal(t.Context(), server.URL, AccessModeLocal)
-	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), httpservice.ErrAddressForbidden.Error()),
-		"expected loopback URL to be rejected, got: %v", err)
-}
+	testCases := []struct {
+		name        string
+		filespec    string
+		errContains string
+	}{
+		{
+			name:        "loopback URL from httptest is rejected",
+			filespec:    server.URL,
+			errContains: httpservice.ErrAddressForbidden.Error(),
+		},
+		{
+			name:        "URL missing host",
+			filespec:    "https:///path",
+			errContains: "URL missing host",
+		},
+	}
 
-func TestFetchFileDataForLocal_URLEmptyHostRejected(t *testing.T) {
-	_, err := fetchFileDataForLocal(t.Context(), "https:///path", AccessModeLocal)
-	require.Error(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := fetchFileDataForLocal(t.Context(), tc.filespec, AccessModeLocal)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.errContains)
+		})
+	}
 }

--- a/mcpserver/tools/file_utils_test.go
+++ b/mcpserver/tools/file_utils_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/shared/httpservice"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchFileDataForLocal_LoopbackURLRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("x"))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := fetchFileDataForLocal(t.Context(), server.URL, AccessModeLocal)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), httpservice.ErrAddressForbidden.Error()),
+		"expected loopback URL to be rejected, got: %v", err)
+}
+
+func TestFetchFileDataForLocal_URLEmptyHostRejected(t *testing.T) {
+	_, err := fetchFileDataForLocal(t.Context(), "https:///path", AccessModeLocal)
+	require.Error(t, err)
+}

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -347,7 +347,7 @@ func (p *MattermostToolProvider) toolCreateTeam(mcpContext *MCPToolContext, args
 		if !isValidImageFile(fileName) {
 			teamIconMessage = " (team icon upload failed: unsupported file type, only .jpeg, .jpg, .png, .gif are supported)"
 		} else {
-			imageData, err := fetchFileDataForLocal(args.TeamIcon, mcpContext.AccessMode)
+			imageData, err := fetchFileDataForLocal(mcpContext.Ctx, args.TeamIcon, mcpContext.AccessMode)
 			if err != nil {
 				teamIconMessage = fmt.Sprintf(" (team icon upload failed: %v)", err)
 			} else {

--- a/mcpserver/tools/users.go
+++ b/mcpserver/tools/users.go
@@ -82,7 +82,7 @@ func (p *MattermostToolProvider) toolCreateUser(mcpContext *MCPToolContext, args
 		if !isValidImageFile(fileName) {
 			profileImageMessage = " (profile image upload failed: unsupported file type, only .jpeg, .jpg, .png, .gif are supported)"
 		} else {
-			imageData, err := fetchFileDataForLocal(args.ProfileImage, mcpContext.AccessMode)
+			imageData, err := fetchFileDataForLocal(mcpContext.Ctx, args.ProfileImage, mcpContext.AccessMode)
 			if err != nil {
 				profileImageMessage = fmt.Sprintf(" (profile image upload failed: %v)", err)
 			} else {

--- a/mcpserver/tools/util_test.go
+++ b/mcpserver/tools/util_test.go
@@ -91,7 +91,7 @@ func TestFetchFileData_FilePathValidation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, testErr := fetchFileDataForLocal(tc.filespec, AccessModeLocal)
+			_, testErr := fetchFileDataForLocal(t.Context(), tc.filespec, AccessModeLocal)
 
 			if tc.shouldFail {
 				if testErr == nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Route local-mode attachment URL fetches in `mcpserver/tools/file_utils.go` through Mattermost `httpservice` with a static `model.Config` and `MakeClient(false)`, a read size cap, and request context.
- Add a test that loopback `httptest` URLs are not fetched.
- Clarify in `mcpserver/README.md` and `docs/admin_guide.md` that the separate `mattermost-mcp-server` process is intended for development use, not for production.

## Ticket
https://mattermost.atlassian.net/browse/MM-67951

## Testing

- `go test ./mcpserver/tools/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16e0f987-165f-4af8-aa4f-54f95e49d89d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16e0f987-165f-4af8-aa4f-54f95e49d89d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the standalone MCP server is for development/local use only; production guidance now directs users to the embedded MCP server and plugin configuration options.

* **Improvements**
  * Safer local file uploads: requests honor cancellation/timeouts, stricter URL validation, host checks, and a 100 MiB per-file size limit to reduce failures and exposure of low-level errors.

* **Tests**
  * Added tests verifying error handling for invalid URL inputs during local file uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->