### PR TITLE
fix(webapp): Portal bot dropdown in search to prevent clipping

### DIFF
--- a/webapp/src/components/bot_selector.tsx
+++ b/webapp/src/components/bot_selector.tsx
@@ -74,7 +74,6 @@ export const BotDropdown = (props: BotDropdownProps) => {
             title={props.activeBot?.displayName}
             dotMenuButton={props.container}
             dropdownMenu={StyledDropdownMenu}
-            portal={false}
             testId={props.testId}
         >
             <MenuInfoMessage>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **SEARCH WITH** bot selector in the Agents search tab used `BotDropdown` with `portal={false}`, so the floating menu stayed inside the search UI subtree. That parent uses overflow clipping, so `@floating-ui` flipped the menu upward and it looked trapped at the top of the modal.

Removed the explicit `portal={false}` so `Dropdown` uses its default `FloatingPortal`. The menu now renders at the document root (same as other dropdowns), opens below the trigger with default `bottom-start` placement, and is no longer clipped by the search container.

## Testing

- `cd webapp && npm run check-types`

## Walkthrough

A short before/after screen recording was shared earlier in this PR thread (old build with upward/clipped menu vs. fix with downward menu). I can re-upload or re-link it if that attachment is no longer visible after the branch cleanup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abc51250-7302-4f51-81fe-c5d739d8bcbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abc51250-7302-4f51-81fe-c5d739d8bcbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated dropdown rendering behavior in the bot selector so the menu uses the component’s default portal behavior.
* **Tests**
  * Added a recorded end-to-end test for the semantic search bot dropdown UI, with conditional video capture and lifecycle management.
* **Chores**
  * Excluded demo specs from non-real-API test group selection to adjust test grouping coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->