### PR TITLE
Fix hidden tool params placeholder for onlookers

### DIFF
--- a/webapp/src/components/tool_card.test.tsx
+++ b/webapp/src/components/tool_card.test.tsx
@@ -13,7 +13,12 @@ jest.mock('react-redux', () => ({
     useSelector: jest.fn(),
 }));
 
-const mockUseSelector = useSelector as jest.Mock;
+jest.mock('react-bootstrap', () => ({
+    OverlayTrigger: ({children}: {children: React.ReactNode}) => <>{children}</>,
+    Tooltip: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+}), {virtual: true});
+
+const mockUseSelector = useSelector as unknown as jest.Mock;
 const formatTextMock = jest.fn((text: string) => text);
 const messageHtmlToComponentMock = jest.fn((text: string) => <div>{text}</div>);
 
@@ -61,7 +66,12 @@ beforeEach(() => {
     formatTextMock.mockClear();
     messageHtmlToComponentMock.mockClear();
 
-    window.PostUtils = {
+    (window as unknown as Window & {
+        PostUtils: {
+            formatText: typeof formatTextMock;
+            messageHtmlToComponent: typeof messageHtmlToComponentMock;
+        };
+    }).PostUtils = {
         formatText: formatTextMock,
         messageHtmlToComponent: messageHtmlToComponentMock,
     };
@@ -75,7 +85,7 @@ describe('ToolCard argument rendering', () => {
     });
 
     test('does not show the no-parameters message for hidden arguments', () => {
-        renderComponent(makeTool({arguments: undefined}));
+        renderComponent(makeTool({}));
 
         expect(screen.queryByText(/No parameters required/)).toBeNull();
         expect(formatTextMock).not.toHaveBeenCalled();

--- a/webapp/src/components/tool_card.test.tsx
+++ b/webapp/src/components/tool_card.test.tsx
@@ -1,0 +1,84 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {IntlProvider} from 'react-intl';
+import {useSelector} from 'react-redux';
+
+import ToolCard from './tool_card';
+import {ToolCall, ToolCallStatus} from './tool_types';
+
+jest.mock('react-redux', () => ({
+    useSelector: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.Mock;
+const formatTextMock = jest.fn((text: string) => text);
+const messageHtmlToComponentMock = jest.fn((text: string) => <div>{text}</div>);
+
+function makeTool(overrides: Partial<ToolCall> = {}): ToolCall {
+    return {
+        id: 'tool_1',
+        name: 'create_jira_issue',
+        description: '',
+        status: ToolCallStatus.Pending,
+        ...overrides,
+    };
+}
+
+function renderComponent(tool: ToolCall) {
+    return render(
+        <IntlProvider locale='en'>
+            <ToolCard
+                postID='post_1'
+                tool={tool}
+                isCollapsed={false}
+                isProcessing={false}
+                onToggleCollapse={jest.fn()}
+                canExpand={false}
+                showArguments={true}
+                showResults={false}
+            />
+        </IntlProvider>,
+    );
+}
+
+beforeEach(() => {
+    mockUseSelector.mockImplementation((selector) => selector({
+        entities: {
+            general: {
+                config: {
+                    SiteURL: 'http://localhost:8065',
+                },
+            },
+            teams: {
+                currentTeamId: 'team_1',
+            },
+        },
+    }));
+
+    formatTextMock.mockClear();
+    messageHtmlToComponentMock.mockClear();
+
+    window.PostUtils = {
+        formatText: formatTextMock,
+        messageHtmlToComponent: messageHtmlToComponentMock,
+    };
+});
+
+describe('ToolCard argument rendering', () => {
+    test('shows the no-parameters message for explicit empty object arguments', () => {
+        renderComponent(makeTool({arguments: {}}));
+
+        expect(screen.getByText(/No parameters required/)).not.toBeNull();
+    });
+
+    test('does not show the no-parameters message for hidden arguments', () => {
+        renderComponent(makeTool({arguments: undefined}));
+
+        expect(screen.queryByText(/No parameters required/)).toBeNull();
+        expect(formatTextMock).not.toHaveBeenCalled();
+        expect(messageHtmlToComponentMock).not.toHaveBeenCalled();
+    });
+});

--- a/webapp/src/components/tool_card.tsx
+++ b/webapp/src/components/tool_card.tsx
@@ -30,7 +30,7 @@ const ToolCallCard = styled.div`
     box-shadow: none;
 `;
 
-const ToolCallHeader = styled.div<{isCollapsed: boolean; $canExpand: boolean}>`
+const ToolCallHeader = styled.div<{$canExpand: boolean}>`
     display: flex;
     align-items: center;
     gap: 8px;
@@ -397,9 +397,13 @@ const ToolCard: React.FC<ToolCardProps> = ({
             return null;
         }
 
-        const content = isEmptyToolArgumentsObject(tool.arguments) ?
-            formatMessage({id: 'ai.tool_call.no_parameters_required', defaultMessage: 'No parameters required'}) :
-            JSON.stringify(tool.arguments, null, 2);
+        let content = JSON.stringify(tool.arguments, null, 2);
+        if (isEmptyToolArgumentsObject(tool.arguments)) {
+            content = formatMessage({
+                id: 'ai.tool_call.no_parameters_required',
+                defaultMessage: 'No parameters required',
+            });
+        }
         const argumentsMarkdown = `\`\`\`json\n${content}\n\`\`\``;
         return messageHtmlToComponent(
             formatText(argumentsMarkdown, markdownOptions),
@@ -535,7 +539,6 @@ const ToolCard: React.FC<ToolCardProps> = ({
     return (
         <ToolCallCard>
             <ToolCallHeader
-                isCollapsed={isCollapsed}
                 $canExpand={canExpand}
                 onClick={canExpand ? onToggleCollapse : undefined} // eslint-disable-line no-undefined
             >

--- a/webapp/src/components/tool_card.tsx
+++ b/webapp/src/components/tool_card.tsx
@@ -326,6 +326,13 @@ interface ToolCardProps {
     isAutoApproved?: boolean;
 }
 
+export function isEmptyToolArgumentsObject(argumentsValue: ToolCall['arguments']): boolean {
+    return argumentsValue != null &&
+        typeof argumentsValue === 'object' &&
+        !Array.isArray(argumentsValue) &&
+        Object.keys(argumentsValue).length === 0;
+}
+
 const ToolCard: React.FC<ToolCardProps> = ({
     postID,
     tool,
@@ -386,15 +393,13 @@ const ToolCard: React.FC<ToolCardProps> = ({
     }), [postID]);
 
     const renderedArguments = useMemo(() => {
-        if (!showArguments) {
+        if (!showArguments || tool.arguments == null) {
             return null;
         }
 
-        const argumentsValue = tool.arguments ?? {};
-        const isEmpty = typeof argumentsValue === 'object' && !Array.isArray(argumentsValue) && Object.keys(argumentsValue).length === 0;
-        const content = isEmpty ?
+        const content = isEmptyToolArgumentsObject(tool.arguments) ?
             formatMessage({id: 'ai.tool_call.no_parameters_required', defaultMessage: 'No parameters required'}) :
-            JSON.stringify(argumentsValue, null, 2);
+            JSON.stringify(tool.arguments, null, 2);
         const argumentsMarkdown = `\`\`\`json\n${content}\n\`\`\``;
         return messageHtmlToComponent(
             formatText(argumentsMarkdown, markdownOptions),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Fix the tool-call parameter placeholder so onlookers in multiplayer threads do not see a misleading no-parameters message when arguments are present but redacted. Add a focused `ToolCard` regression test for explicit empty arguments vs hidden arguments.

#### Ticket Link
NONE

#### Screenshots
NONE

#### Release Note
```release-note
Fixed a bug where onlookers in multiplayer tool-calling threads could see a misleading "No parameters required" message for tool calls whose arguments were redacted.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cd04978-1de7-4fc2-bad9-363d5d96945b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cd04978-1de7-4fc2-bad9-363d5d96945b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test suite verifying ToolCard argument display for explicitly empty versus omitted parameters (internationalized rendering).

* **Bug Fixes**
  * ToolCard now correctly distinguishes explicitly empty argument objects from hidden/undefined arguments and shows “No parameters required” only when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->