### PR TITLE
[MM-68531] Preserve attachments in conversation turns

### DIFF
--- a/conversation/content_block.go
+++ b/conversation/content_block.go
@@ -66,7 +66,7 @@ type ContentBlock struct {
 	// File / Image fields
 	Filename string `json:"filename,omitempty"`
 	MimeType string `json:"mime_type,omitempty"`
-	FileID   string `json:"file_id,omitempty"` // image blocks: references Mattermost file attachment
+	FileID   string `json:"file_id,omitempty"` // file/image blocks: references Mattermost file attachment
 
 	// Annotations fields
 	WebSearchContext *WebSearchContext `json:"web_search_context,omitempty"`

--- a/conversation/helpers.go
+++ b/conversation/helpers.go
@@ -19,6 +19,23 @@ func textBlocks(message string) []ContentBlock {
 	return []ContentBlock{{Type: BlockTypeText, Text: message}}
 }
 
+// userContentBlocks creates content blocks for a user message and any attached
+// Mattermost files. Attachments are stored by file ID and hydrated into
+// llm.File readers later when building the CompletionRequest.
+func userContentBlocks(message string, fileIDs []string) []ContentBlock {
+	blocks := textBlocks(message)
+	for _, fileID := range fileIDs {
+		if fileID == "" {
+			continue
+		}
+		blocks = append(blocks, ContentBlock{
+			Type:   BlockTypeFile,
+			FileID: fileID,
+		})
+	}
+	return blocks
+}
+
 // marshalBlocks serializes content blocks to JSON for store.Turn.Content.
 func marshalBlocks(blocks []ContentBlock) (json.RawMessage, error) {
 	if blocks == nil {

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -362,9 +362,9 @@ func (s *Service) turnsToLLMPosts(turns []store.Turn, redactUnshared bool) ([]ll
 			return nil, fmt.Errorf("failed to unmarshal turn %s content: %w", turn.ID, err)
 		}
 		if turn.Role == "assistant" && i+1 < len(turns) && turns[i+1].Role == "tool_result" {
-			nextBlocks, err := unmarshalBlocks(turns[i+1].Content)
-			if err != nil {
-				return nil, fmt.Errorf("failed to unmarshal turn %s content: %w", turns[i+1].ID, err)
+			nextBlocks, nextErr := unmarshalBlocks(turns[i+1].Content)
+			if nextErr != nil {
+				return nil, fmt.Errorf("failed to unmarshal turn %s content: %w", turns[i+1].ID, nextErr)
 			}
 			blocks = append(blocks, nextBlocks...)
 			i++

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -70,6 +70,7 @@ type CreateConversationParams struct {
 	Operation    string  // e.g., "conversation", "thread_analysis", "search"
 	SystemPrompt string  // already-formatted system prompt text
 	UserMessage  string  // the first user message content
+	UserFileIDs  []string
 	UserPostID   *string // nullable: post ID for the user turn, if a post exists
 }
 
@@ -103,7 +104,7 @@ func (s *Service) CreateConversation(params CreateConversationParams) (*CreateCo
 	}
 
 	turnID := model.NewId()
-	content, err := marshalBlocks(textBlocks(params.UserMessage))
+	content, err := marshalBlocks(userContentBlocks(params.UserMessage, params.UserFileIDs))
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal user message: %w", err)
 	}
@@ -171,8 +172,9 @@ type GetOrCreateParams struct {
 	ChannelID    string
 	RootPostID   string // the thread root post ID
 	Operation    string
-	SystemPrompt string  // formatted system prompt (used only if creating)
-	UserMessage  string  // new user message
+	SystemPrompt string // formatted system prompt (used only if creating)
+	UserMessage  string // new user message
+	UserFileIDs  []string
 	UserPostID   *string // post ID for the new user turn
 }
 
@@ -192,7 +194,7 @@ func (s *Service) GetOrCreateConversation(params GetOrCreateParams) (*GetOrCreat
 	}
 
 	if existing != nil {
-		turnID, appendErr := s.appendUserTurn(existing.ID, params.UserMessage, params.UserPostID)
+		turnID, appendErr := s.appendUserTurn(existing.ID, params.UserMessage, params.UserFileIDs, params.UserPostID)
 		if appendErr != nil {
 			return nil, appendErr
 		}
@@ -215,6 +217,7 @@ func (s *Service) GetOrCreateConversation(params GetOrCreateParams) (*GetOrCreat
 		Operation:    params.Operation,
 		SystemPrompt: params.SystemPrompt,
 		UserMessage:  params.UserMessage,
+		UserFileIDs:  params.UserFileIDs,
 		UserPostID:   params.UserPostID,
 	})
 	if errors.Is(err, store.ErrConversationConflict) {
@@ -226,7 +229,7 @@ func (s *Service) GetOrCreateConversation(params GetOrCreateParams) (*GetOrCreat
 		if raceConv == nil {
 			return nil, fmt.Errorf("conversation vanished after conflict")
 		}
-		turnID, appendErr := s.appendUserTurn(raceConv.ID, params.UserMessage, params.UserPostID)
+		turnID, appendErr := s.appendUserTurn(raceConv.ID, params.UserMessage, params.UserFileIDs, params.UserPostID)
 		if appendErr != nil {
 			return nil, appendErr
 		}
@@ -253,8 +256,8 @@ func (s *Service) GetOrCreateConversation(params GetOrCreateParams) (*GetOrCreat
 }
 
 // appendUserTurn creates a new user turn at the next available sequence number.
-func (s *Service) appendUserTurn(conversationID, message string, postID *string) (string, error) {
-	content, err := marshalBlocks(textBlocks(message))
+func (s *Service) appendUserTurn(conversationID, message string, fileIDs []string, postID *string) (string, error) {
+	content, err := marshalBlocks(userContentBlocks(message, fileIDs))
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal user message: %w", err)
 	}
@@ -331,7 +334,7 @@ func (s *Service) BuildCompletionRequest(
 		Message: conv.SystemPrompt,
 	})
 
-	turnPosts, err := turnsToLLMPosts(turns, redactUnshared)
+	turnPosts, err := s.turnsToLLMPosts(turns, redactUnshared)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +353,7 @@ func (s *Service) BuildCompletionRequest(
 // single llm.Post. Without this merge, tool_use entries go out with empty
 // Result fields and bifrost emits empty-content tool messages, which
 // Anthropic rejects with "text content blocks must be non-empty".
-func turnsToLLMPosts(turns []store.Turn, redactUnshared bool) ([]llm.Post, error) {
+func (s *Service) turnsToLLMPosts(turns []store.Turn, redactUnshared bool) ([]llm.Post, error) {
 	posts := make([]llm.Post, 0, len(turns))
 	for i := 0; i < len(turns); i++ {
 		turn := turns[i]
@@ -366,9 +369,63 @@ func turnsToLLMPosts(turns []store.Turn, redactUnshared bool) ([]llm.Post, error
 			blocks = append(blocks, nextBlocks...)
 			i++
 		}
-		posts = append(posts, BlocksToPost(blocks, turn.Role, redactUnshared))
+		post, err := s.blocksToPost(blocks, turn.Role, redactUnshared)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert turn %s blocks: %w", turn.ID, err)
+		}
+		posts = append(posts, post)
 	}
 	return posts, nil
+}
+
+func (s *Service) blocksToPost(blocks []ContentBlock, role string, redactUnshared bool) (llm.Post, error) {
+	post := BlocksToPost(blocks, role, redactUnshared)
+	if role != "user" {
+		return post, nil
+	}
+
+	files, err := s.resolvePostFiles(blocks)
+	if err != nil {
+		return llm.Post{}, err
+	}
+	post.Files = files
+	return post, nil
+}
+
+func (s *Service) resolvePostFiles(blocks []ContentBlock) ([]llm.File, error) {
+	fileBlocks := make([]ContentBlock, 0)
+	for _, block := range blocks {
+		if (block.Type == BlockTypeFile || block.Type == BlockTypeImage) && block.FileID != "" {
+			fileBlocks = append(fileBlocks, block)
+		}
+	}
+	if len(fileBlocks) == 0 {
+		return nil, nil
+	}
+	if s.mmClient == nil {
+		return nil, fmt.Errorf("mmClient is required to load file attachments")
+	}
+
+	files := make([]llm.File, 0, len(fileBlocks))
+	for _, block := range fileBlocks {
+		fileInfo, err := s.mmClient.GetFileInfo(block.FileID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get file info for %s: %w", block.FileID, err)
+		}
+
+		reader, err := s.mmClient.GetFile(block.FileID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get file %s: %w", block.FileID, err)
+		}
+
+		files = append(files, llm.File{
+			MimeType: fileInfo.MimeType,
+			Size:     fileInfo.Size,
+			Reader:   reader,
+		})
+	}
+
+	return files, nil
 }
 
 // CreatePlaceholderAssistantTurn creates an empty assistant turn linked to the response post.
@@ -605,7 +662,7 @@ func (s *Service) BuildChannelMentionRequest(
 	// (precedingSeq = 0). Route through turnsToLLMPosts so tool_use and
 	// tool_result within the same tool round merge into a single llm.Post,
 	// matching BuildCompletionRequest's behavior.
-	leadingPosts, err := turnsToLLMPosts(turnsByPrecedingPost[0], redactUnshared)
+	leadingPosts, err := s.turnsToLLMPosts(turnsByPrecedingPost[0], redactUnshared)
 	if err != nil {
 		return nil, err
 	}
@@ -618,7 +675,7 @@ func (s *Service) BuildChannelMentionRequest(
 			// preceding assistant turn's tool_use blocks.
 			turn := turnByPostID[threadPost.Id]
 			run := append([]store.Turn{turn}, turnsByPrecedingPost[turn.Sequence]...)
-			runPosts, err := turnsToLLMPosts(run, redactUnshared)
+			runPosts, err := s.turnsToLLMPosts(run, redactUnshared)
 			if err != nil {
 				return nil, err
 			}

--- a/conversation/service_test.go
+++ b/conversation/service_test.go
@@ -4,9 +4,11 @@
 package conversation
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -15,6 +17,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/mmapi"
+	"github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
 	"github.com/mattermost/mattermost-plugin-agents/store"
 	"github.com/mattermost/mattermost-plugin-agents/toolrunner"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -182,6 +185,35 @@ func TestCreateConversation(t *testing.T) {
 				require.NoError(t, err)
 				require.Len(t, turns, 1)
 				assert.Nil(t, turns[0].PostID)
+			},
+		},
+		{
+			name: "stores attached file IDs on the user turn",
+			params: CreateConversationParams{
+				UserID:       model.NewId(),
+				BotID:        model.NewId(),
+				Operation:    "conversation",
+				SystemPrompt: "You are helpful",
+				UserMessage:  "Please analyze this image",
+				UserFileIDs:  []string{"file_1", "", "file_2"},
+			},
+			validate: func(t *testing.T, svc *Service, s *store.Store, result *CreateConversationResult, err error) {
+				require.NoError(t, err)
+
+				turns, err := s.GetTurnsForConversation(result.ConversationID)
+				require.NoError(t, err)
+				require.Len(t, turns, 1)
+
+				var blocks []ContentBlock
+				err = json.Unmarshal(turns[0].Content, &blocks)
+				require.NoError(t, err)
+				require.Len(t, blocks, 3)
+				assert.Equal(t, BlockTypeText, blocks[0].Type)
+				assert.Equal(t, "Please analyze this image", blocks[0].Text)
+				assert.Equal(t, BlockTypeFile, blocks[1].Type)
+				assert.Equal(t, "file_1", blocks[1].FileID)
+				assert.Equal(t, BlockTypeFile, blocks[2].Type)
+				assert.Equal(t, "file_2", blocks[2].FileID)
 			},
 		},
 	}
@@ -429,6 +461,43 @@ func TestBuildCompletionRequest_NewConversation(t *testing.T) {
 	assert.Equal(t, "You are helpful", req.Posts[0].Message)
 	assert.Equal(t, llm.PostRoleUser, req.Posts[1].Role)
 	assert.Equal(t, "What is 2+2?", req.Posts[1].Message)
+}
+
+func TestBuildCompletionRequest_LoadsAttachedFilesForUserTurns(t *testing.T) {
+	svc, s := setupTestService(t)
+
+	fileID := model.NewId()
+	fileBody := []byte("png-bytes")
+	fileInfo := &model.FileInfo{Id: fileID, MimeType: "image/png", Size: int64(len(fileBody))}
+	mmClient := mocks.NewMockClient(t)
+	mmClient.On("GetFileInfo", fileID).Return(fileInfo, nil).Once()
+	mmClient.On("GetFile", fileID).Return(io.NopCloser(bytes.NewReader(fileBody)), nil).Once()
+	svc.mmClient = mmClient
+
+	result, err := svc.CreateConversation(CreateConversationParams{
+		UserID:       model.NewId(),
+		BotID:        model.NewId(),
+		Operation:    "conversation",
+		SystemPrompt: "You are helpful",
+		UserMessage:  "Describe the attachment",
+		UserFileIDs:  []string{fileID},
+	})
+	require.NoError(t, err)
+
+	conv, err := s.GetConversation(result.ConversationID)
+	require.NoError(t, err)
+
+	req, err := svc.BuildCompletionRequest(conv, &llm.Context{})
+	require.NoError(t, err)
+	require.Len(t, req.Posts, 2)
+	require.Len(t, req.Posts[1].Files, 1)
+	assert.Equal(t, "Describe the attachment", req.Posts[1].Message)
+	assert.Equal(t, "image/png", req.Posts[1].Files[0].MimeType)
+	assert.Equal(t, int64(len(fileBody)), req.Posts[1].Files[0].Size)
+
+	readBody, err := io.ReadAll(req.Posts[1].Files[0].Reader)
+	require.NoError(t, err)
+	assert.Equal(t, fileBody, readBody)
 }
 
 func TestBuildCompletionRequest_MultiTurn(t *testing.T) {

--- a/conversations/conversations.go
+++ b/conversations/conversations.go
@@ -145,6 +145,7 @@ func (c *Conversations) CreateOrGetDMConversation(
 			Operation:    "conversation",
 			SystemPrompt: systemPrompt,
 			UserMessage:  post.Message,
+			UserFileIDs:  post.FileIds,
 			UserPostID:   &postID,
 		})
 		if err != nil {
@@ -161,6 +162,7 @@ func (c *Conversations) CreateOrGetDMConversation(
 		Operation:    "conversation",
 		SystemPrompt: systemPrompt,
 		UserMessage:  post.Message,
+		UserFileIDs:  post.FileIds,
 		UserPostID:   &postID,
 	})
 	if err != nil {

--- a/conversations/dm_conversation_test.go
+++ b/conversations/dm_conversation_test.go
@@ -4,8 +4,10 @@
 package conversations_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 	"testing"
@@ -18,6 +20,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/llmcontext"
 	"github.com/mattermost/mattermost-plugin-agents/mcp"
+	"github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
 	"github.com/mattermost/mattermost-plugin-agents/prompts"
 	"github.com/mattermost/mattermost-plugin-agents/store"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -930,4 +933,55 @@ func TestDMCompletionRequest_BuiltFromTurns(t *testing.T) {
 	// Should contain both user messages from turns
 	assert.Contains(t, req.Posts[1].Message, "What is 2+2?")
 	assert.Contains(t, req.Posts[2].Message, "And what is 3+3?")
+}
+
+func TestDMCompletionRequest_IncludesAttachedFiles(t *testing.T) {
+	env := setupDMTestEnv(t, dmMakeTextStream("response"))
+
+	fileID := "file-image-1"
+	fileBody := []byte("fake-image-bytes")
+	fileInfo := &model.FileInfo{Id: fileID, MimeType: "image/png", Size: int64(len(fileBody))}
+	mmClient := mocks.NewMockClient(t)
+	mmClient.On("GetFileInfo", fileID).Return(fileInfo, nil).Once()
+	mmClient.On("GetFile", fileID).Return(io.NopCloser(bytes.NewReader(fileBody)), nil).Once()
+	env.convService = conversation.NewService(env.convStore, nil, mmClient, nil)
+	env.conversations.SetConversationService(env.convService)
+
+	post := &model.Post{
+		Id:        "post-with-image",
+		UserId:    env.userID,
+		ChannelId: env.channelID,
+		Message:   "Please analyze this image",
+		FileIds:   []string{fileID},
+	}
+
+	convResult, err := env.conversations.CreateOrGetDMConversation(
+		env.botID,
+		env.user,
+		env.channel,
+		post,
+		nil,
+	)
+	require.NoError(t, err)
+
+	_, err = env.conversations.ProcessDMRequest(
+		convResult.ConversationID,
+		env.fakeLLM,
+		nil,
+	)
+	require.NoError(t, err)
+
+	env.fakeLLM.mu.Lock()
+	require.Len(t, env.fakeLLM.requests, 1)
+	req := env.fakeLLM.requests[0]
+	env.fakeLLM.mu.Unlock()
+
+	require.Len(t, req.Posts, 2)
+	require.Len(t, req.Posts[1].Files, 1)
+	assert.Equal(t, "Please analyze this image", req.Posts[1].Message)
+	assert.Equal(t, "image/png", req.Posts[1].Files[0].MimeType)
+	assert.Equal(t, int64(len(fileBody)), req.Posts[1].Files[0].Size)
+	readBody, err := io.ReadAll(req.Posts[1].Files[0].Reader)
+	require.NoError(t, err)
+	assert.Equal(t, fileBody, readBody)
 }

--- a/conversations/handle_messages.go
+++ b/conversations/handle_messages.go
@@ -208,6 +208,7 @@ func (c *Conversations) handleMentionViaConversation(
 		Operation:    "conversation",
 		SystemPrompt: systemPrompt,
 		UserMessage:  post.Message,
+		UserFileIDs:  post.FileIds,
 		UserPostID:   &userPostID,
 	})
 	if convErr != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Preserve uploaded attachment file IDs when creating/appending conversation user turns, then hydrate those file IDs back into `llm.Post.Files` when building DM and channel-mention completion requests so image/file attachments are no longer dropped before the LLM call.

Validation run in this environment:
- `go test -c -o /tmp/conversation.test ./conversation`
- `go test -c -o /tmp/conversations.test ./conversations`
- `go run ./tmp_runtime_validation` before removing the temporary validator file
- Follow-up CI lint fix: resolved the `govet` shadowed `err` in `conversation/service.go`

Environment note:
- Package-level runtime tests for `conversation` / `conversations` still require Docker because their `TestMain` spins up Postgres via testcontainers, which is unavailable on this VM.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-68531

#### Screenshots
None.

#### Release Note
```release-note
Fixed conversation attachment handling so uploaded files and images are preserved in DM and channel-mention conversation requests instead of being dropped before the LLM call.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21fb9799-3c44-4be0-99d3-53125315c705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21fb9799-3c44-4be0-99d3-53125315c705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can attach files to messages when creating or continuing conversations.
  * Attached files are automatically resolved and included when conversations are sent to language model services.
  * File support now applies consistently across direct messages, channel-mention flows and DM creation.

* **Tests**
  * Added test coverage validating file attachment handling, metadata loading and inclusion in generated LLM requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->