### PR TITLE
MM-68531: Fix agent avatar leaking from previously viewed agent

### DIFF
--- a/webapp/src/components/agents/tabs/config_tab.tsx
+++ b/webapp/src/components/agents/tabs/config_tab.tsx
@@ -238,6 +238,7 @@ const ConfigTab = (props: Props) => {
                 {errors.username && <FieldError>{errors.username}</FieldError>}
                 <AvatarItem
                     botusername={draft.username}
+                    avatarOwnerKey={props.botUserId}
                     changedAvatar={(image: File) => onAvatarChange(image)}
                 />
                 <SelectionItem

--- a/webapp/src/components/system_console/avatar.test.tsx
+++ b/webapp/src/components/system_console/avatar.test.tsx
@@ -223,17 +223,18 @@ describe('AvatarItem', () => {
             rendered.rerender(
                 <IntlProvider locale='en'>
                     <AvatarItem
-                        botusername='beta'
-                        avatarOwnerKey='beta-id'
+                        botusername='alpha'
+                        avatarOwnerKey='hydrated-alpha-id'
                         changedAvatar={jest.fn()}
                     />
                 </IntlProvider>,
             );
 
             await waitFor(() => {
-                expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/beta.png');
+                expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/alpha.png');
             });
 
+            expect(getBotProfilePictureUrl).toHaveBeenCalledTimes(2);
             expect(objectURL.revokeObjectURL).toHaveBeenCalledWith('blob:preview');
             unmount();
             unmount = undefined;

--- a/webapp/src/components/system_console/avatar.test.tsx
+++ b/webapp/src/components/system_console/avatar.test.tsx
@@ -162,7 +162,7 @@ describe('AvatarItem', () => {
 
         const objectURL = mockObjectURL();
 
-        let unmount: (() => void) | undefined;
+        let unmount: (() => void) | null = null;
         try {
             const rendered = renderAvatar('agentnew');
             unmount = rendered.unmount;
@@ -190,7 +190,7 @@ describe('AvatarItem', () => {
             await Promise.resolve();
             expect(screen.getByRole('img').getAttribute('src')).toBe('blob:preview');
             unmount();
-            unmount = undefined;
+            unmount = null;
         } finally {
             unmount?.();
             objectURL.restore();
@@ -203,7 +203,7 @@ describe('AvatarItem', () => {
 
         const objectURL = mockObjectURL();
 
-        let unmount: (() => void) | undefined;
+        let unmount: (() => void) | null = null;
         try {
             const rendered = renderAvatar('alpha', 'alpha-id');
             unmount = rendered.unmount;
@@ -237,7 +237,7 @@ describe('AvatarItem', () => {
             expect(getBotProfilePictureUrl).toHaveBeenCalledTimes(2);
             expect(objectURL.revokeObjectURL).toHaveBeenCalledWith('blob:preview');
             unmount();
-            unmount = undefined;
+            unmount = null;
         } finally {
             unmount?.();
             objectURL.restore();

--- a/webapp/src/components/system_console/avatar.test.tsx
+++ b/webapp/src/components/system_console/avatar.test.tsx
@@ -1,0 +1,171 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {IntlProvider} from 'react-intl';
+
+import AvatarItem from './avatar';
+
+jest.mock('react-intl', () => {
+    const actual = jest.requireActual('react-intl');
+    return {
+        ...actual,
+        useIntl: () => ({
+            formatMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+        }),
+        FormattedMessage: ({defaultMessage}: {defaultMessage: string}) => defaultMessage,
+    };
+});
+
+jest.mock('@/client', () => ({
+    getBotProfilePictureUrl: jest.fn(),
+}));
+
+// Stub the static asset so the placeholder has a stable, predictable src in tests.
+jest.mock('src/../../assets/bot_icon.png', () => 'placeholder-icon.png', {virtual: true});
+
+const {getBotProfilePictureUrl} = jest.requireMock('@/client') as {
+    getBotProfilePictureUrl: jest.Mock<Promise<string>, [string]>;
+};
+
+function renderAvatar(botusername: string) {
+    return render(
+        <IntlProvider locale='en'>
+            <AvatarItem
+                botusername={botusername}
+                changedAvatar={jest.fn()}
+            />
+        </IntlProvider>,
+    );
+}
+
+beforeEach(() => {
+    getBotProfilePictureUrl.mockReset();
+});
+
+describe('AvatarItem', () => {
+    it('refetches the avatar when botusername changes (no leak from previous bot)', async () => {
+        getBotProfilePictureUrl.mockImplementation((username: string) =>
+            Promise.resolve(`/profile/${username}.png`));
+
+        const {rerender} = renderAvatar('alpha');
+
+        // First fetch resolves to alpha's URL.
+        await waitFor(() => {
+            expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/alpha.png');
+        });
+
+        // Switch to beta — same component instance, different bot. Avatar must reflect beta,
+        // not the previously displayed alpha image (regression guard for MM-68531).
+        rerender(
+            <IntlProvider locale='en'>
+                <AvatarItem
+                    botusername='beta'
+                    changedAvatar={jest.fn()}
+                />
+            </IntlProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/beta.png');
+        });
+
+        expect(getBotProfilePictureUrl).toHaveBeenCalledWith('alpha');
+        expect(getBotProfilePictureUrl).toHaveBeenCalledWith('beta');
+    });
+
+    it('falls back to the placeholder when the bot has no resolvable avatar', async () => {
+        getBotProfilePictureUrl.mockResolvedValue('');
+
+        renderAvatar('newbot');
+
+        await waitFor(() => {
+            expect(getBotProfilePictureUrl).toHaveBeenCalledWith('newbot');
+        });
+
+        expect(screen.getByRole('img').getAttribute('src')).toBe('placeholder-icon.png');
+    });
+
+    it('ignores a stale fetch result when botusername changes during the request', async () => {
+        let resolveAlpha: ((value: string) => void) | undefined;
+        const alphaPending = new Promise<string>((resolve) => {
+            resolveAlpha = resolve;
+        });
+        getBotProfilePictureUrl.mockImplementationOnce(() => alphaPending);
+        getBotProfilePictureUrl.mockImplementationOnce(() => Promise.resolve('/profile/beta.png'));
+
+        const {rerender} = renderAvatar('alpha');
+
+        rerender(
+            <IntlProvider locale='en'>
+                <AvatarItem
+                    botusername='beta'
+                    changedAvatar={jest.fn()}
+                />
+            </IntlProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/beta.png');
+        });
+
+        // Late alpha response must not overwrite beta's image.
+        resolveAlpha?.('/profile/alpha.png');
+        await Promise.resolve();
+        expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/beta.png');
+    });
+
+    it('preserves a locally uploaded preview when the username changes', async () => {
+        getBotProfilePictureUrl.mockResolvedValue('');
+
+        // Stub createObjectURL since jsdom doesn't implement it.
+        const createObjectURL = jest.fn(() => 'blob:preview');
+        const originalCreateObjectURL = (URL as unknown as {createObjectURL?: typeof createObjectURL}).createObjectURL;
+        (URL as unknown as {createObjectURL: typeof createObjectURL}).createObjectURL = createObjectURL;
+
+        // FileReader.readAsArrayBuffer just needs to fire onload; we don't care about the bytes.
+        class FakeFileReader {
+            onload: (() => void) | null = null;
+            readAsArrayBuffer() {
+                this.onload?.();
+            }
+        }
+        const originalFileReader = global.FileReader;
+
+        // @ts-expect-error - replacing for the test only
+        global.FileReader = FakeFileReader;
+
+        try {
+            const {rerender} = renderAvatar('agentnew');
+            await waitFor(() => {
+                expect(getBotProfilePictureUrl).toHaveBeenCalledWith('agentnew');
+            });
+
+            const file = new File(['x'], 'a.png', {type: 'image/png'});
+            const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+            fireEvent.change(input, {target: {files: [file]}});
+
+            await waitFor(() => {
+                expect(screen.getByRole('img').getAttribute('src')).toBe('blob:preview');
+            });
+
+            // The preview must persist when the user edits the username while a local upload
+            // preview is active; the avatar must not snap back to the placeholder.
+            rerender(
+                <IntlProvider locale='en'>
+                    <AvatarItem
+                        botusername='agentnewx'
+                        changedAvatar={jest.fn()}
+                    />
+                </IntlProvider>,
+            );
+
+            await Promise.resolve();
+            expect(screen.getByRole('img').getAttribute('src')).toBe('blob:preview');
+        } finally {
+            (URL as unknown as {createObjectURL?: typeof createObjectURL}).createObjectURL = originalCreateObjectURL;
+            global.FileReader = originalFileReader;
+        }
+    });
+});

--- a/webapp/src/components/system_console/avatar.test.tsx
+++ b/webapp/src/components/system_console/avatar.test.tsx
@@ -87,6 +87,31 @@ describe('AvatarItem', () => {
         expect(screen.getByRole('img').getAttribute('src')).toBe('placeholder-icon.png');
     });
 
+    it('keeps the placeholder when the avatar fetch rejects (no unhandled rejection)', async () => {
+        // Simulates the 404 path that fires while a user is typing a draft username before
+        // the underlying bot account exists, or any transient auth/network failure.
+        getBotProfilePictureUrl.mockRejectedValue(new Error('Not Found'));
+
+        const unhandled = jest.fn();
+        process.on('unhandledRejection', unhandled);
+
+        try {
+            renderAvatar('draftbot');
+
+            await waitFor(() => {
+                expect(getBotProfilePictureUrl).toHaveBeenCalledWith('draftbot');
+            });
+
+            // Flush any pending microtasks so the rejection has a chance to surface.
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(screen.getByRole('img').getAttribute('src')).toBe('placeholder-icon.png');
+            expect(unhandled).not.toHaveBeenCalled();
+        } finally {
+            process.off('unhandledRejection', unhandled);
+        }
+    });
+
     it('ignores a stale fetch result when botusername changes during the request', async () => {
         let resolveAlpha: ((value: string) => void) | undefined;
         const alphaPending = new Promise<string>((resolve) => {

--- a/webapp/src/components/system_console/avatar.test.tsx
+++ b/webapp/src/components/system_console/avatar.test.tsx
@@ -22,18 +22,18 @@ jest.mock('@/client', () => ({
     getBotProfilePictureUrl: jest.fn(),
 }));
 
-// Stub the static asset so the placeholder has a stable, predictable src in tests.
 jest.mock('src/../../assets/bot_icon.png', () => 'placeholder-icon.png', {virtual: true});
 
 const {getBotProfilePictureUrl} = jest.requireMock('@/client') as {
     getBotProfilePictureUrl: jest.Mock<Promise<string>, [string]>;
 };
 
-function renderAvatar(botusername: string) {
+function renderAvatar(botusername: string, avatarOwnerKey?: string) {
     return render(
         <IntlProvider locale='en'>
             <AvatarItem
                 botusername={botusername}
+                avatarOwnerKey={avatarOwnerKey}
                 changedAvatar={jest.fn()}
             />
         </IntlProvider>,
@@ -44,6 +44,29 @@ beforeEach(() => {
     getBotProfilePictureUrl.mockReset();
 });
 
+function mockObjectURL(previewURL = 'blob:preview') {
+    const createObjectURL = jest.fn(() => previewURL);
+    const revokeObjectURL = jest.fn();
+    const url = URL as unknown as {
+        createObjectURL?: typeof createObjectURL;
+        revokeObjectURL?: typeof revokeObjectURL;
+    };
+    const originalCreateObjectURL = url.createObjectURL;
+    const originalRevokeObjectURL = url.revokeObjectURL;
+
+    url.createObjectURL = createObjectURL;
+    url.revokeObjectURL = revokeObjectURL;
+
+    return {
+        createObjectURL,
+        revokeObjectURL,
+        restore: () => {
+            url.createObjectURL = originalCreateObjectURL;
+            url.revokeObjectURL = originalRevokeObjectURL;
+        },
+    };
+}
+
 describe('AvatarItem', () => {
     it('refetches the avatar when botusername changes (no leak from previous bot)', async () => {
         getBotProfilePictureUrl.mockImplementation((username: string) =>
@@ -51,13 +74,10 @@ describe('AvatarItem', () => {
 
         const {rerender} = renderAvatar('alpha');
 
-        // First fetch resolves to alpha's URL.
         await waitFor(() => {
             expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/alpha.png');
         });
 
-        // Switch to beta — same component instance, different bot. Avatar must reflect beta,
-        // not the previously displayed alpha image (regression guard for MM-68531).
         rerender(
             <IntlProvider locale='en'>
                 <AvatarItem
@@ -88,8 +108,6 @@ describe('AvatarItem', () => {
     });
 
     it('keeps the placeholder when the avatar fetch rejects (no unhandled rejection)', async () => {
-        // Simulates the 404 path that fires while a user is typing a draft username before
-        // the underlying bot account exists, or any transient auth/network failure.
         getBotProfilePictureUrl.mockRejectedValue(new Error('Not Found'));
 
         const unhandled = jest.fn();
@@ -102,7 +120,6 @@ describe('AvatarItem', () => {
                 expect(getBotProfilePictureUrl).toHaveBeenCalledWith('draftbot');
             });
 
-            // Flush any pending microtasks so the rejection has a chance to surface.
             await new Promise((resolve) => setTimeout(resolve, 0));
 
             expect(screen.getByRole('img').getAttribute('src')).toBe('placeholder-icon.png');
@@ -135,7 +152,6 @@ describe('AvatarItem', () => {
             expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/beta.png');
         });
 
-        // Late alpha response must not overwrite beta's image.
         resolveAlpha?.('/profile/alpha.png');
         await Promise.resolve();
         expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/beta.png');
@@ -144,25 +160,12 @@ describe('AvatarItem', () => {
     it('preserves a locally uploaded preview when the username changes', async () => {
         getBotProfilePictureUrl.mockResolvedValue('');
 
-        // Stub createObjectURL since jsdom doesn't implement it.
-        const createObjectURL = jest.fn(() => 'blob:preview');
-        const originalCreateObjectURL = (URL as unknown as {createObjectURL?: typeof createObjectURL}).createObjectURL;
-        (URL as unknown as {createObjectURL: typeof createObjectURL}).createObjectURL = createObjectURL;
+        const objectURL = mockObjectURL();
 
-        // FileReader.readAsArrayBuffer just needs to fire onload; we don't care about the bytes.
-        class FakeFileReader {
-            onload: (() => void) | null = null;
-            readAsArrayBuffer() {
-                this.onload?.();
-            }
-        }
-        const originalFileReader = global.FileReader;
-
-        // @ts-expect-error - replacing for the test only
-        global.FileReader = FakeFileReader;
-
+        let unmount: (() => void) | undefined;
         try {
-            const {rerender} = renderAvatar('agentnew');
+            const rendered = renderAvatar('agentnew');
+            unmount = rendered.unmount;
             await waitFor(() => {
                 expect(getBotProfilePictureUrl).toHaveBeenCalledWith('agentnew');
             });
@@ -175,9 +178,7 @@ describe('AvatarItem', () => {
                 expect(screen.getByRole('img').getAttribute('src')).toBe('blob:preview');
             });
 
-            // The preview must persist when the user edits the username while a local upload
-            // preview is active; the avatar must not snap back to the placeholder.
-            rerender(
+            rendered.rerender(
                 <IntlProvider locale='en'>
                     <AvatarItem
                         botusername='agentnewx'
@@ -188,9 +189,57 @@ describe('AvatarItem', () => {
 
             await Promise.resolve();
             expect(screen.getByRole('img').getAttribute('src')).toBe('blob:preview');
+            unmount();
+            unmount = undefined;
         } finally {
-            (URL as unknown as {createObjectURL?: typeof createObjectURL}).createObjectURL = originalCreateObjectURL;
-            global.FileReader = originalFileReader;
+            unmount?.();
+            objectURL.restore();
+        }
+    });
+
+    it('clears a locally uploaded preview when the avatar owner changes', async () => {
+        getBotProfilePictureUrl.mockImplementation((username: string) =>
+            Promise.resolve(`/profile/${username}.png`));
+
+        const objectURL = mockObjectURL();
+
+        let unmount: (() => void) | undefined;
+        try {
+            const rendered = renderAvatar('alpha', 'alpha-id');
+            unmount = rendered.unmount;
+
+            await waitFor(() => {
+                expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/alpha.png');
+            });
+
+            const file = new File(['x'], 'a.png', {type: 'image/png'});
+            const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+            fireEvent.change(input, {target: {files: [file]}});
+
+            await waitFor(() => {
+                expect(screen.getByRole('img').getAttribute('src')).toBe('blob:preview');
+            });
+
+            rendered.rerender(
+                <IntlProvider locale='en'>
+                    <AvatarItem
+                        botusername='beta'
+                        avatarOwnerKey='beta-id'
+                        changedAvatar={jest.fn()}
+                    />
+                </IntlProvider>,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByRole('img').getAttribute('src')).toBe('/profile/beta.png');
+            });
+
+            expect(objectURL.revokeObjectURL).toHaveBeenCalledWith('blob:preview');
+            unmount();
+            unmount = undefined;
+        } finally {
+            unmount?.();
+            objectURL.restore();
         }
     });
 });

--- a/webapp/src/components/system_console/avatar.tsx
+++ b/webapp/src/components/system_console/avatar.tsx
@@ -23,7 +23,7 @@ type AvatarItemProps = {
 const AvatarItem = (props: AvatarItemProps) => {
     const [icon, setIcon] = useState<string>(aiIcon);
     const hasLocalUpload = useRef(false);
-    const localPreviewURL = useRef<string>();
+    const localPreviewURL = useRef<string | null>(null);
     const avatarOwnerKey = useRef(props.avatarOwnerKey);
     const hiddenInput = useRef<HTMLInputElement>(null);
 
@@ -37,7 +37,7 @@ const AvatarItem = (props: AvatarItemProps) => {
 
         if (localPreviewURL.current) {
             URL.revokeObjectURL(localPreviewURL.current);
-            localPreviewURL.current = undefined;
+            localPreviewURL.current = null;
         }
 
         setIcon(aiIcon);
@@ -96,7 +96,7 @@ const AvatarItem = (props: AvatarItemProps) => {
             hasLocalUpload.current = false;
             if (localPreviewURL.current) {
                 URL.revokeObjectURL(localPreviewURL.current);
-                localPreviewURL.current = undefined;
+                localPreviewURL.current = null;
             }
             setIcon(aiIcon);
         }

--- a/webapp/src/components/system_console/avatar.tsx
+++ b/webapp/src/components/system_console/avatar.tsx
@@ -77,7 +77,7 @@ const AvatarItem = (props: AvatarItemProps) => {
         return () => {
             cancelled = true;
         };
-    }, [props.botusername]);
+    }, [props.botusername, props.avatarOwnerKey]);
 
     const onUploadChange = (e: ChangeEvent<HTMLInputElement>) => {
         if (e.target.files && e.target.files[0]) {

--- a/webapp/src/components/system_console/avatar.tsx
+++ b/webapp/src/components/system_console/avatar.tsx
@@ -16,23 +16,41 @@ import {ItemLabel} from './item';
 
 type AvatarItemProps = {
     botusername: string;
+    avatarOwnerKey?: string;
     changedAvatar: (image: File) => void;
 }
 
 const AvatarItem = (props: AvatarItemProps) => {
     const [icon, setIcon] = useState<string>(aiIcon);
-
-    // Tracks whether the user has uploaded a local image in this session. While true, we
-    // skip the username-driven fetch so that typing into the username field does not wipe
-    // the unsaved upload preview.
     const hasLocalUpload = useRef(false);
+    const localPreviewURL = useRef<string>();
+    const avatarOwnerKey = useRef(props.avatarOwnerKey);
     const hiddenInput = useRef<HTMLInputElement>(null);
 
-    // Refetch the avatar whenever botusername changes so this widget can be reused across
-    // different bots/agents (e.g. when navigating between agents in the edit page) without
-    // showing the previous bot's avatar. Reset to the placeholder before the new fetch
-    // resolves to avoid a brief flash of the previous bot's image, and ignore late
-    // responses from a stale fetch via a "cancelled" flag.
+    useEffect(() => {
+        if (avatarOwnerKey.current === props.avatarOwnerKey) {
+            return;
+        }
+
+        avatarOwnerKey.current = props.avatarOwnerKey;
+        hasLocalUpload.current = false;
+
+        if (localPreviewURL.current) {
+            URL.revokeObjectURL(localPreviewURL.current);
+            localPreviewURL.current = undefined;
+        }
+
+        setIcon(aiIcon);
+    }, [props.avatarOwnerKey]);
+
+    useEffect(() => {
+        return () => {
+            if (localPreviewURL.current) {
+                URL.revokeObjectURL(localPreviewURL.current);
+            }
+        };
+    }, []);
+
     useEffect(() => {
         let cancelled = false;
         if (hasLocalUpload.current) {
@@ -47,17 +65,13 @@ const AvatarItem = (props: AvatarItemProps) => {
             };
         }
         (async () => {
-            // Fetches can reject (e.g. 404 while the user is still typing a draft username
-            // before the bot exists, or transient auth/network errors). Swallow the rejection
-            // and keep the placeholder icon already set above so we never bubble an unhandled
-            // promise rejection or wipe state we don't own.
             try {
                 const userIcon = await getBotProfilePictureUrl(props.botusername);
                 if (!cancelled && userIcon) {
                     setIcon(userIcon);
                 }
             } catch {
-                // Placeholder is already in place; nothing more to do.
+                // Keep the placeholder for unknown or temporarily unreachable users.
             }
         })();
         return () => {
@@ -65,20 +79,25 @@ const AvatarItem = (props: AvatarItemProps) => {
         };
     }, [props.botusername]);
 
-    const onUploadChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const onUploadChange = (e: ChangeEvent<HTMLInputElement>) => {
         if (e.target.files && e.target.files[0]) {
             const file = e.target.files[0];
 
             hasLocalUpload.current = true;
-            const reader = new FileReader();
-            reader.onload = () => {
-                setIcon(URL.createObjectURL(file));
-            };
-            reader.readAsArrayBuffer(file);
+            if (localPreviewURL.current) {
+                URL.revokeObjectURL(localPreviewURL.current);
+            }
+
+            localPreviewURL.current = URL.createObjectURL(file);
+            setIcon(localPreviewURL.current);
             e.target.value = '';
             props.changedAvatar(file);
         } else {
             hasLocalUpload.current = false;
+            if (localPreviewURL.current) {
+                URL.revokeObjectURL(localPreviewURL.current);
+                localPreviewURL.current = undefined;
+            }
             setIcon(aiIcon);
         }
     };

--- a/webapp/src/components/system_console/avatar.tsx
+++ b/webapp/src/components/system_console/avatar.tsx
@@ -47,9 +47,17 @@ const AvatarItem = (props: AvatarItemProps) => {
             };
         }
         (async () => {
-            const userIcon = await getBotProfilePictureUrl(props.botusername);
-            if (!cancelled && userIcon) {
-                setIcon(userIcon);
+            // Fetches can reject (e.g. 404 while the user is still typing a draft username
+            // before the bot exists, or transient auth/network errors). Swallow the rejection
+            // and keep the placeholder icon already set above so we never bubble an unhandled
+            // promise rejection or wipe state we don't own.
+            try {
+                const userIcon = await getBotProfilePictureUrl(props.botusername);
+                if (!cancelled && userIcon) {
+                    setIcon(userIcon);
+                }
+            } catch {
+                // Placeholder is already in place; nothing more to do.
             }
         })();
         return () => {

--- a/webapp/src/components/system_console/avatar.tsx
+++ b/webapp/src/components/system_console/avatar.tsx
@@ -21,22 +21,47 @@ type AvatarItemProps = {
 
 const AvatarItem = (props: AvatarItemProps) => {
     const [icon, setIcon] = useState<string>(aiIcon);
+
+    // Tracks whether the user has uploaded a local image in this session. While true, we
+    // skip the username-driven fetch so that typing into the username field does not wipe
+    // the unsaved upload preview.
+    const hasLocalUpload = useRef(false);
     const hiddenInput = useRef<HTMLInputElement>(null);
 
+    // Refetch the avatar whenever botusername changes so this widget can be reused across
+    // different bots/agents (e.g. when navigating between agents in the edit page) without
+    // showing the previous bot's avatar. Reset to the placeholder before the new fetch
+    // resolves to avoid a brief flash of the previous bot's image, and ignore late
+    // responses from a stale fetch via a "cancelled" flag.
     useEffect(() => {
-        const getUserIcon = async () => {
+        let cancelled = false;
+        if (hasLocalUpload.current) {
+            return () => {
+                cancelled = true;
+            };
+        }
+        setIcon(aiIcon);
+        if (!props.botusername) {
+            return () => {
+                cancelled = true;
+            };
+        }
+        (async () => {
             const userIcon = await getBotProfilePictureUrl(props.botusername);
-            if (userIcon) {
+            if (!cancelled && userIcon) {
                 setIcon(userIcon);
             }
+        })();
+        return () => {
+            cancelled = true;
         };
-        getUserIcon();
-    }, []);
+    }, [props.botusername]);
 
     const onUploadChange = async (e: ChangeEvent<HTMLInputElement>) => {
         if (e.target.files && e.target.files[0]) {
             const file = e.target.files[0];
 
+            hasLocalUpload.current = true;
             const reader = new FileReader();
             reader.onload = () => {
                 setIcon(URL.createObjectURL(file));
@@ -45,6 +70,7 @@ const AvatarItem = (props: AvatarItemProps) => {
             e.target.value = '';
             props.changedAvatar(file);
         } else {
+            hasLocalUpload.current = false;
             setIcon(aiIcon);
         }
     };

--- a/webapp/src/components/system_console/bot.tsx
+++ b/webapp/src/components/system_console/bot.tsx
@@ -278,6 +278,7 @@ const Bot = (props: Props) => {
                         />
                         <AvatarItem
                             botusername={props.bot.name}
+                            avatarOwnerKey={props.bot.id}
                             changedAvatar={props.changedAvatar}
                         />
                         <SelectionItem


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
`AvatarItem` cached the bot icon in component state but only fetched on mount (`useEffect` deps were `[]`), so when the same instance was reused across different bots/agents the previously displayed avatar would leak into the new agent's edit view. The current Agents page conditionally unmounts the edit view between agents so the bug is masked there, but it still affects any flow that keeps the form mounted (e.g. the legacy System Console accordion if the user renames a bot, or any future change to the agents flow that switches agents in place).

This change refetches the avatar whenever `botusername` changes, resets the icon to the placeholder before the new fetch resolves to avoid a brief flash of the previous bot's image, and ignores late stale-fetch responses via a `cancelled` flag. The local upload preview is preserved when the username field is edited so users renaming a draft agent don't lose their unsaved avatar selection.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-68531

#### Walkthrough

Demo video showing Alpha/Beta/Alpha/Beta cycling — each agent shows its own avatar, no leak. Also shows that uploading a custom image during create persists when typing in the username field.

[Demo video](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/fix-agent-avatar-stale-308a/verify_fix_avatar_no_leak.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA5OAYLOSTZRRX5L52%2F20260429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260429T013014Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=e1c4bd4aa30312b7146967c5d49f5154af3e945fe3573aa1bbed1b5746235849)

<a href="https://cursor.com/agents/bc-a90090e8-417b-450a-8d03-8c2bfeb3308a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverify_fix_avatar_no_leak.mp4"><img src="https://cursor.com/artifacts/c/art-19256c85-fbab-4856-9260-76337bf741b0" alt="verify_fix_avatar_no_leak.mp4" /></a>

##### Screenshots

| State | Screenshot |
|---|---|
| Agent list (Alpha has custom red Debian logo, Beta has default identicon) | ![list](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/fix-agent-avatar-stale-308a/screenshot_agents_list.webp?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA5OAYLOSTZRRX5L52%2F20260429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260429T013012Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=dca289b04bd3c0eb736460b3ef87e4bc16fb9357110b294cd086fc0db540c205) |
| Edit Agent Alpha — shows red Debian logo (correct) | ![alpha](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/fix-agent-avatar-stale-308a/screenshot_after_fix_alpha_correct_avatar.webp?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA5OAYLOSTZRRX5L52%2F20260429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260429T013011Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=768cf512c17841358890423d3e0d2ad00f594eda0532b44377af385970e3043c) |
| Edit Agent Beta after viewing Alpha — shows Beta's default avatar (no leak) | ![beta](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/fix-agent-avatar-stale-308a/screenshot_after_fix_beta_correct_avatar.webp?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA5OAYLOSTZRRX5L52%2F20260429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260429T013011Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=707cb78000e3470a1bcf6d221c489bc16f12a9967deffd45cc3ef395247e0eec) |
| New agent — local upload preview shown after selecting `htop.png` | ![upload](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/fix-agent-avatar-stale-308a/screenshot_upload_preview.webp?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA5OAYLOSTZRRX5L52%2F20260429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260429T013013Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=d204fc8586a0f22ed6ed37d84eda1e54761071129266035fbe6bf708d70539c6) |
| Same form, after typing into the username field — preview persists | ![persist](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/fix-agent-avatar-stale-308a/screenshot_upload_preview_persists.webp?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA5OAYLOSTZRRX5L52%2F20260429%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260429T013012Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=4ec4a11e39fa59de284b4ed7d61fe5a52cd9f302df5e27ce3406869c9b509fb0) |

##### Programmatic verification

The new tests in `webapp/src/components/system_console/avatar.test.tsx` act as regression guards. With the fix removed (only changing `avatar.tsx` back to the previous implementation), the "refetches when botusername changes" and "ignores stale fetch result" tests both fail, confirming they exercise the underlying defect.

#### Test Plan
- `cd webapp && npx jest --config jest.config.js src/components/system_console/avatar.test.tsx` — 4/4 passing
- `cd webapp && npx jest --config jest.config.js` — 66/66 passing across 8 suites
- `cd webapp && npx tsc --noEmit` — clean
- `cd webapp && npx eslint src/components/system_console/avatar.tsx src/components/system_console/avatar.test.tsx` — clean (one pre-existing import warning unrelated to this change)
- Manual: deploy plugin to local Mattermost, hard refresh agent list, alternate clicking Agent Alpha (custom avatar) and Agent Beta (default avatar) — each edit view shows the correct avatar; create flow upload preview persists across username edits.

#### Release Note
```release-note
Fixed an issue where opening an agent without a custom avatar in edit mode could display the avatar of a previously viewed agent.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a90090e8-417b-450a-8d03-8c2bfeb3308a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a90090e8-417b-450a-8d03-8c2bfeb3308a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar now resets to a placeholder and reliably updates when switching bots or agents; avoids stale/late fetches and unhandled promise rejections
  * Revokes stale local preview URLs to prevent resource leaks

* **Behaviour**
  * Remote avatar fetches run on bot/owner changes but are paused while a local preview is active; local previews persist across bot/agent changes and clear when ownership changes

* **New Features**
  * Avatar ownership keyed via a new identifier to control reset behavior

* **Tests**
  * Added tests for updates, race conditions, error handling, and local uploads
<!-- end of auto-generated comment: release notes by coderabbit.ai -->