### PR TITLE
Fix search sources panel showing 'now' for every post timestamp

### DIFF
--- a/webapp/src/components/post_preview.test.tsx
+++ b/webapp/src/components/post_preview.test.tsx
@@ -1,0 +1,91 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {act, render, waitFor} from '@testing-library/react';
+
+import {PostPreview} from './post_preview';
+
+const mockGetPost = jest.fn();
+const mockGetProfilesByIds = jest.fn();
+
+jest.mock('@/client', () => ({
+    getPost: (id: string) => mockGetPost(id),
+    getProfilesByIds: (ids: string[]) => mockGetProfilesByIds(ids),
+}));
+
+const mockUseSelector = jest.fn();
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+    useSelector: (selector: any) => mockUseSelector(selector),
+    useDispatch: () => mockDispatch,
+}));
+
+const postMessagePreviewMock: jest.Mock<null, [any]> = jest.fn<null, [any]>(() => null);
+
+jest.mock('@/mm_webapp', () => ({
+    PostMessagePreview: (props: any) => postMessagePreviewMock(props),
+}));
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockImplementation((selector: any) => selector({
+        entities: {
+            channels: {
+                channels: {
+                    channel_1: {id: 'channel_1', team_id: 'team_1', type: 'O'},
+                },
+            },
+            teams: {
+                teams: {
+                    team_1: {id: 'team_1', name: 'team-name'},
+                },
+            },
+        },
+    }));
+});
+
+describe('PostPreview', () => {
+    test('passes the source post create_at into PostMessagePreview metadata', async () => {
+        const sourcePost = {
+            id: 'post_1',
+            user_id: 'user_1',
+            channel_id: 'channel_1',
+            message: 'hello world',
+            create_at: 1700000000000,
+        };
+
+        mockGetPost.mockResolvedValue(sourcePost);
+        mockGetProfilesByIds.mockResolvedValue([{id: 'user_1', username: 'someone'}]);
+
+        await act(async () => {
+            render(
+                <PostPreview
+                    postId='post_1'
+                    userId='user_1'
+                    channelId='channel_1'
+                    content='hello world'
+                />,
+            );
+        });
+
+        await waitFor(() => {
+            expect(mockGetPost).toHaveBeenCalledWith('post_1');
+        });
+
+        // Wait for the async fetch to update component state and re-render.
+        await waitFor(() => {
+            const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0] as any;
+            expect(lastCall?.metadata?.post?.create_at).toBe(1700000000000);
+        });
+
+        const lastProps = postMessagePreviewMock.mock.calls.at(-1)?.[0] as any;
+        expect(lastProps.metadata.post_id).toBe('post_1');
+        expect(lastProps.metadata.channel_id).toBe('channel_1');
+        expect(lastProps.metadata.team_name).toBe('team-name');
+        expect(lastProps.metadata.post.message).toBe('hello world');
+        expect(lastProps.metadata.post.user_id).toBe('user_1');
+        expect(lastProps.metadata.post.id).toBe('post_1');
+    });
+});

--- a/webapp/src/components/post_preview.test.tsx
+++ b/webapp/src/components/post_preview.test.tsx
@@ -6,6 +6,25 @@ import {act, render, waitFor} from '@testing-library/react';
 
 import {PostPreview} from './post_preview';
 
+interface PostPreviewMetadata {
+    channel_display_name: string | null;
+    channel_id: string;
+    channel_type?: string;
+    post_id: string;
+    team_name: string;
+    post: {
+        id: string;
+        message: string;
+        user_id: string;
+        channel_id: string;
+        create_at?: number;
+    };
+}
+
+interface PostMessagePreviewProps {
+    metadata: PostPreviewMetadata;
+}
+
 const mockGetPost = jest.fn();
 const mockGetProfilesByIds = jest.fn();
 
@@ -14,36 +33,39 @@ jest.mock('@/client', () => ({
     getProfilesByIds: (ids: string[]) => mockGetProfilesByIds(ids),
 }));
 
-const mockUseSelector = jest.fn();
+type SelectorFn = (state: unknown) => unknown;
+const mockUseSelector = jest.fn<unknown, [SelectorFn]>();
 const mockDispatch = jest.fn();
 
 jest.mock('react-redux', () => ({
-    useSelector: (selector: any) => mockUseSelector(selector),
+    useSelector: (selector: SelectorFn) => mockUseSelector(selector),
     useDispatch: () => mockDispatch,
 }));
 
-const postMessagePreviewMock: jest.Mock<null, [any]> = jest.fn<null, [any]>(() => null);
+const postMessagePreviewMock = jest.fn<null, [PostMessagePreviewProps]>(() => null);
 
 jest.mock('@/mm_webapp', () => ({
-    PostMessagePreview: (props: any) => postMessagePreviewMock(props),
+    PostMessagePreview: (props: PostMessagePreviewProps) => postMessagePreviewMock(props),
 }));
+
+const baseState = {
+    entities: {
+        channels: {
+            channels: {
+                channel_1: {id: 'channel_1', team_id: 'team_1', type: 'O'},
+            },
+        },
+        teams: {
+            teams: {
+                team_1: {id: 'team_1', name: 'team-name'},
+            },
+        },
+    },
+};
 
 beforeEach(() => {
     jest.clearAllMocks();
-    mockUseSelector.mockImplementation((selector: any) => selector({
-        entities: {
-            channels: {
-                channels: {
-                    channel_1: {id: 'channel_1', team_id: 'team_1', type: 'O'},
-                },
-            },
-            teams: {
-                teams: {
-                    team_1: {id: 'team_1', name: 'team-name'},
-                },
-            },
-        },
-    }));
+    mockUseSelector.mockImplementation((selector) => selector(baseState));
 });
 
 describe('PostPreview', () => {
@@ -74,18 +96,136 @@ describe('PostPreview', () => {
             expect(mockGetPost).toHaveBeenCalledWith('post_1');
         });
 
-        // Wait for the async fetch to update component state and re-render.
         await waitFor(() => {
-            const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0] as any;
-            expect(lastCall?.metadata?.post?.create_at).toBe(1700000000000);
+            const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0];
+            expect(lastCall?.metadata.post.create_at).toBe(1700000000000);
         });
 
-        const lastProps = postMessagePreviewMock.mock.calls.at(-1)?.[0] as any;
-        expect(lastProps.metadata.post_id).toBe('post_1');
-        expect(lastProps.metadata.channel_id).toBe('channel_1');
-        expect(lastProps.metadata.team_name).toBe('team-name');
-        expect(lastProps.metadata.post.message).toBe('hello world');
-        expect(lastProps.metadata.post.user_id).toBe('user_1');
-        expect(lastProps.metadata.post.id).toBe('post_1');
+        const lastProps = postMessagePreviewMock.mock.calls.at(-1)?.[0];
+        expect(lastProps?.metadata.post_id).toBe('post_1');
+        expect(lastProps?.metadata.channel_id).toBe('channel_1');
+        expect(lastProps?.metadata.team_name).toBe('team-name');
+        expect(lastProps?.metadata.post.message).toBe('hello world');
+        expect(lastProps?.metadata.post.user_id).toBe('user_1');
+        expect(lastProps?.metadata.post.id).toBe('post_1');
+    });
+
+    test('clears create_at when navigating to a post without a timestamp', async () => {
+        mockGetPost.mockResolvedValueOnce({
+            id: 'post_1',
+            user_id: 'user_1',
+            channel_id: 'channel_1',
+            message: 'first',
+            create_at: 1700000000000,
+        });
+        mockGetProfilesByIds.mockResolvedValue([{id: 'user_1', username: 'someone'}]);
+
+        let rerender: ReturnType<typeof render>['rerender'] | undefined;
+        await act(async () => {
+            const result = render(
+                <PostPreview
+                    postId='post_1'
+                    userId='user_1'
+                    channelId='channel_1'
+                    content='first'
+                />,
+            );
+            rerender = result.rerender;
+        });
+
+        await waitFor(() => {
+            const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0];
+            expect(lastCall?.metadata.post.create_at).toBe(1700000000000);
+        });
+
+        // Simulate a follow-up post that has no create_at on the response.
+        mockGetPost.mockResolvedValueOnce({
+            id: 'post_2',
+            user_id: 'user_1',
+            channel_id: 'channel_1',
+            message: 'second',
+        });
+
+        await act(async () => {
+            rerender?.(
+                <PostPreview
+                    postId='post_2'
+                    userId='user_1'
+                    channelId='channel_1'
+                    content='second'
+                />,
+            );
+        });
+
+        await waitFor(() => {
+            expect(mockGetPost).toHaveBeenCalledWith('post_2');
+        });
+
+        await waitFor(() => {
+            const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0];
+            expect(lastCall?.metadata.post_id).toBe('post_2');
+            expect(lastCall?.metadata.post.create_at).toBeUndefined();
+        });
+    });
+
+    test('does not retain stale create_at when the fetch fails', async () => {
+        mockGetPost.mockResolvedValueOnce({
+            id: 'post_1',
+            user_id: 'user_1',
+            channel_id: 'channel_1',
+            message: 'first',
+            create_at: 1700000000000,
+        });
+        mockGetProfilesByIds.mockResolvedValue([{id: 'user_1', username: 'someone'}]);
+
+        let rerender: ReturnType<typeof render>['rerender'] | undefined;
+        await act(async () => {
+            const result = render(
+                <PostPreview
+                    postId='post_1'
+                    userId='user_1'
+                    channelId='channel_1'
+                    content='first'
+                />,
+            );
+            rerender = result.rerender;
+        });
+
+        await waitFor(() => {
+            const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0];
+            expect(lastCall?.metadata.post.create_at).toBe(1700000000000);
+        });
+
+        // Suppress expected error log emitted by the catch handler.
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {
+            // no-op
+        });
+
+        try {
+            mockGetPost.mockRejectedValueOnce(new Error('boom'));
+
+            await act(async () => {
+                rerender?.(
+                    <PostPreview
+                        postId='post_2'
+                        userId='user_1'
+                        channelId='channel_1'
+                        content='second'
+                    />,
+                );
+            });
+
+            await waitFor(() => {
+                expect(mockGetPost).toHaveBeenCalledWith('post_2');
+            });
+
+            await waitFor(() => {
+                const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0];
+                expect(lastCall?.metadata.post_id).toBe('post_2');
+                expect(lastCall?.metadata.post.create_at).toBeUndefined();
+            });
+        } finally {
+            consoleError.mockRestore();
+        }
     });
 });

--- a/webapp/src/components/post_preview.test.tsx
+++ b/webapp/src/components/post_preview.test.tsx
@@ -6,25 +6,6 @@ import {act, render, waitFor} from '@testing-library/react';
 
 import {PostPreview} from './post_preview';
 
-interface PostPreviewMetadata {
-    channel_display_name: string | null;
-    channel_id: string;
-    channel_type?: string;
-    post_id: string;
-    team_name: string;
-    post: {
-        id: string;
-        message: string;
-        user_id: string;
-        channel_id: string;
-        create_at?: number;
-    };
-}
-
-interface PostMessagePreviewProps {
-    metadata: PostPreviewMetadata;
-}
-
 const mockGetPost = jest.fn();
 const mockGetProfilesByIds = jest.fn();
 
@@ -42,13 +23,13 @@ jest.mock('react-redux', () => ({
     useDispatch: () => mockDispatch,
 }));
 
-const postMessagePreviewMock = jest.fn<null, [PostMessagePreviewProps]>(() => null);
+const postMessagePreviewMock = jest.fn<null, [{metadata: {post: {create_at?: number}}}]>(() => null);
 
 jest.mock('@/mm_webapp', () => ({
-    PostMessagePreview: (props: PostMessagePreviewProps) => postMessagePreviewMock(props),
+    PostMessagePreview: (props: {metadata: {post: {create_at?: number}}}) => postMessagePreviewMock(props),
 }));
 
-const baseState = {
+const baseState = (posts: Record<string, {id: string; create_at: number}>) => ({
     entities: {
         channels: {
             channels: {
@@ -60,26 +41,57 @@ const baseState = {
                 team_1: {id: 'team_1', name: 'team-name'},
             },
         },
+        posts: {
+            posts,
+        },
     },
-};
+});
 
 beforeEach(() => {
     jest.clearAllMocks();
-    mockUseSelector.mockImplementation((selector) => selector(baseState));
+    mockGetPost.mockResolvedValue({id: 'post_1', user_id: 'user_1', channel_id: 'channel_1', message: 'hello', create_at: 1700000000000});
+    mockGetProfilesByIds.mockResolvedValue([{id: 'user_1', username: 'someone'}]);
 });
 
 describe('PostPreview', () => {
-    test('passes the source post create_at into PostMessagePreview metadata', async () => {
-        const sourcePost = {
-            id: 'post_1',
-            user_id: 'user_1',
-            channel_id: 'channel_1',
-            message: 'hello world',
-            create_at: 1700000000000,
-        };
+    test('forwards the stored post create_at into PostMessagePreview metadata', async () => {
+        mockUseSelector.mockImplementation((selector) => selector(baseState({post_1: {id: 'post_1', create_at: 1700000000000}})));
 
-        mockGetPost.mockResolvedValue(sourcePost);
-        mockGetProfilesByIds.mockResolvedValue([{id: 'user_1', username: 'someone'}]);
+        await act(async () => {
+            render(
+                <PostPreview
+                    postId='post_1'
+                    userId='user_1'
+                    channelId='channel_1'
+                    content='hello world'
+                />,
+            );
+        });
+
+        const props = postMessagePreviewMock.mock.calls.at(-1)?.[0];
+        expect(props?.metadata.post.create_at).toBe(1700000000000);
+    });
+
+    test('renders without create_at until the fetched post is in the store', async () => {
+        mockUseSelector.mockImplementation((selector) => selector(baseState({})));
+
+        await act(async () => {
+            render(
+                <PostPreview
+                    postId='post_1'
+                    userId='user_1'
+                    channelId='channel_1'
+                    content='hello world'
+                />,
+            );
+        });
+
+        const props = postMessagePreviewMock.mock.calls.at(-1)?.[0];
+        expect(props?.metadata.post.create_at).toBeUndefined();
+    });
+
+    test('dispatches RECEIVED_POST and RECEIVED_PROFILES after fetching', async () => {
+        mockUseSelector.mockImplementation((selector) => selector(baseState({})));
 
         await act(async () => {
             render(
@@ -93,139 +105,8 @@ describe('PostPreview', () => {
         });
 
         await waitFor(() => {
-            expect(mockGetPost).toHaveBeenCalledWith('post_1');
+            expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({type: 'RECEIVED_POST'}));
+            expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({type: 'RECEIVED_PROFILES'}));
         });
-
-        await waitFor(() => {
-            const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0];
-            expect(lastCall?.metadata.post.create_at).toBe(1700000000000);
-        });
-
-        const lastProps = postMessagePreviewMock.mock.calls.at(-1)?.[0];
-        expect(lastProps?.metadata.post_id).toBe('post_1');
-        expect(lastProps?.metadata.channel_id).toBe('channel_1');
-        expect(lastProps?.metadata.team_name).toBe('team-name');
-        expect(lastProps?.metadata.post.message).toBe('hello world');
-        expect(lastProps?.metadata.post.user_id).toBe('user_1');
-        expect(lastProps?.metadata.post.id).toBe('post_1');
-    });
-
-    test('clears create_at when navigating to a post without a timestamp', async () => {
-        mockGetPost.mockResolvedValueOnce({
-            id: 'post_1',
-            user_id: 'user_1',
-            channel_id: 'channel_1',
-            message: 'first',
-            create_at: 1700000000000,
-        });
-        mockGetProfilesByIds.mockResolvedValue([{id: 'user_1', username: 'someone'}]);
-
-        let rerender: ReturnType<typeof render>['rerender'] | undefined;
-        await act(async () => {
-            const result = render(
-                <PostPreview
-                    postId='post_1'
-                    userId='user_1'
-                    channelId='channel_1'
-                    content='first'
-                />,
-            );
-            rerender = result.rerender;
-        });
-
-        await waitFor(() => {
-            const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0];
-            expect(lastCall?.metadata.post.create_at).toBe(1700000000000);
-        });
-
-        // Simulate a follow-up post that has no create_at on the response.
-        mockGetPost.mockResolvedValueOnce({
-            id: 'post_2',
-            user_id: 'user_1',
-            channel_id: 'channel_1',
-            message: 'second',
-        });
-
-        await act(async () => {
-            rerender?.(
-                <PostPreview
-                    postId='post_2'
-                    userId='user_1'
-                    channelId='channel_1'
-                    content='second'
-                />,
-            );
-        });
-
-        await waitFor(() => {
-            expect(mockGetPost).toHaveBeenCalledWith('post_2');
-        });
-
-        await waitFor(() => {
-            const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0];
-            expect(lastCall?.metadata.post_id).toBe('post_2');
-            expect(lastCall?.metadata.post.create_at).toBeUndefined();
-        });
-    });
-
-    test('does not retain stale create_at when the fetch fails', async () => {
-        mockGetPost.mockResolvedValueOnce({
-            id: 'post_1',
-            user_id: 'user_1',
-            channel_id: 'channel_1',
-            message: 'first',
-            create_at: 1700000000000,
-        });
-        mockGetProfilesByIds.mockResolvedValue([{id: 'user_1', username: 'someone'}]);
-
-        let rerender: ReturnType<typeof render>['rerender'] | undefined;
-        await act(async () => {
-            const result = render(
-                <PostPreview
-                    postId='post_1'
-                    userId='user_1'
-                    channelId='channel_1'
-                    content='first'
-                />,
-            );
-            rerender = result.rerender;
-        });
-
-        await waitFor(() => {
-            const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0];
-            expect(lastCall?.metadata.post.create_at).toBe(1700000000000);
-        });
-
-        // Suppress expected error log emitted by the catch handler.
-        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {
-            // no-op
-        });
-
-        try {
-            mockGetPost.mockRejectedValueOnce(new Error('boom'));
-
-            await act(async () => {
-                rerender?.(
-                    <PostPreview
-                        postId='post_2'
-                        userId='user_1'
-                        channelId='channel_1'
-                        content='second'
-                    />,
-                );
-            });
-
-            await waitFor(() => {
-                expect(mockGetPost).toHaveBeenCalledWith('post_2');
-            });
-
-            await waitFor(() => {
-                const lastCall = postMessagePreviewMock.mock.calls.at(-1)?.[0];
-                expect(lastCall?.metadata.post_id).toBe('post_2');
-                expect(lastCall?.metadata.post.create_at).toBeUndefined();
-            });
-        } finally {
-            consoleError.mockRestore();
-        }
     });
 });

--- a/webapp/src/components/post_preview.tsx
+++ b/webapp/src/components/post_preview.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
 import styled from 'styled-components';
 
@@ -27,6 +27,7 @@ export const PostPreview: React.FC<Props> = ({postId, userId, channelId, content
     const channel = useSelector((state: GlobalState) => state.entities.channels.channels[channelId]);
     const team = useSelector((state: GlobalState) => state.entities.teams.teams[channel?.team_id || '']);
     const teamName = team?.name || '';
+    const [createAt, setCreateAt] = useState<number | undefined>();
 
     useEffect(() => {
         async function fetchData() {
@@ -34,6 +35,13 @@ export const PostPreview: React.FC<Props> = ({postId, userId, channelId, content
                 getPost(postId),
                 getProfilesByIds([userId]),
             ]);
+
+            // Capture the source post's creation timestamp so the preview's
+            // header renders the correct relative time instead of defaulting
+            // to "now" (a missing/0 create_at is rendered as "now").
+            if (post?.create_at) {
+                setCreateAt(post.create_at);
+            }
 
             // Store post in Redux
             dispatch({
@@ -66,8 +74,11 @@ export const PostPreview: React.FC<Props> = ({postId, userId, channelId, content
                     post_id: postId,
                     team_name: teamName,
                     post: {
+                        id: postId,
                         message: content,
                         user_id: userId,
+                        channel_id: channelId,
+                        create_at: createAt,
                     },
                 }}
             />

--- a/webapp/src/components/post_preview.tsx
+++ b/webapp/src/components/post_preview.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
 import styled from 'styled-components';
 
@@ -27,24 +27,15 @@ export const PostPreview: React.FC<Props> = ({postId, userId, channelId, content
     const channel = useSelector((state: GlobalState) => state.entities.channels.channels[channelId]);
     const team = useSelector((state: GlobalState) => state.entities.teams.teams[channel?.team_id || '']);
     const teamName = team?.name || '';
-    const [createAt, setCreateAt] = useState<number | undefined>();
+    const storedPost = useSelector((state: GlobalState) => state.entities.posts.posts[postId]);
 
     useEffect(() => {
-        // Clear any timestamp left over from a previous postId so a missing
-        // create_at on the new post does not render the prior post's time.
-        setCreateAt(undefined); // eslint-disable-line no-undefined
-
         async function fetchData() {
             try {
                 const [post, profiles] = await Promise.all([
                     getPost(postId),
                     getProfilesByIds([userId]),
                 ]);
-
-                // Capture the source post's creation timestamp so the preview's
-                // header renders the correct relative time instead of defaulting
-                // to "now" (a missing/0 create_at is rendered as "now").
-                setCreateAt(post?.create_at ?? undefined); // eslint-disable-line no-undefined
 
                 dispatch({
                     type: 'RECEIVED_POST',
@@ -61,10 +52,6 @@ export const PostPreview: React.FC<Props> = ({postId, userId, channelId, content
                     data: profilesById,
                 });
             } catch (err) {
-                // Avoid leaving a stale timestamp on the preview if the fetch
-                // fails; the embedded preview will fall back to its
-                // post-not-loaded rendering.
-                setCreateAt(undefined); // eslint-disable-line no-undefined
                 // eslint-disable-next-line no-console
                 console.error('PostPreview: failed to fetch source post or profile', err);
             }
@@ -87,7 +74,7 @@ export const PostPreview: React.FC<Props> = ({postId, userId, channelId, content
                         message: content,
                         user_id: userId,
                         channel_id: channelId,
-                        create_at: createAt,
+                        create_at: storedPost?.create_at,
                     },
                 }}
             />

--- a/webapp/src/components/post_preview.tsx
+++ b/webapp/src/components/post_preview.tsx
@@ -30,35 +30,44 @@ export const PostPreview: React.FC<Props> = ({postId, userId, channelId, content
     const [createAt, setCreateAt] = useState<number | undefined>();
 
     useEffect(() => {
+        // Clear any timestamp left over from a previous postId so a missing
+        // create_at on the new post does not render the prior post's time.
+        setCreateAt(undefined); // eslint-disable-line no-undefined
+
         async function fetchData() {
-            const [post, profiles] = await Promise.all([
-                getPost(postId),
-                getProfilesByIds([userId]),
-            ]);
+            try {
+                const [post, profiles] = await Promise.all([
+                    getPost(postId),
+                    getProfilesByIds([userId]),
+                ]);
 
-            // Capture the source post's creation timestamp so the preview's
-            // header renders the correct relative time instead of defaulting
-            // to "now" (a missing/0 create_at is rendered as "now").
-            if (post?.create_at) {
-                setCreateAt(post.create_at);
+                // Capture the source post's creation timestamp so the preview's
+                // header renders the correct relative time instead of defaulting
+                // to "now" (a missing/0 create_at is rendered as "now").
+                setCreateAt(post?.create_at ?? undefined); // eslint-disable-line no-undefined
+
+                dispatch({
+                    type: 'RECEIVED_POST',
+                    data: post,
+                });
+
+                const profilesById = profiles.reduce<Record<string, any>>((acc, profile) => {
+                    acc[profile.id] = profile;
+                    return acc;
+                }, {});
+
+                dispatch({
+                    type: 'RECEIVED_PROFILES',
+                    data: profilesById,
+                });
+            } catch (err) {
+                // Avoid leaving a stale timestamp on the preview if the fetch
+                // fails; the embedded preview will fall back to its
+                // post-not-loaded rendering.
+                setCreateAt(undefined); // eslint-disable-line no-undefined
+                // eslint-disable-next-line no-console
+                console.error('PostPreview: failed to fetch source post or profile', err);
             }
-
-            // Store post in Redux
-            dispatch({
-                type: 'RECEIVED_POST',
-                data: post,
-            });
-
-            // Store profiles in Redux
-            const profilesById = profiles.reduce<Record<string, any>>((acc, profile) => {
-                acc[profile.id] = profile;
-                return acc;
-            }, {});
-
-            dispatch({
-                type: 'RECEIVED_PROFILES',
-                data: profilesById,
-            });
         }
 
         fetchData();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
The Sources panel in AI Enhanced Search renders every result's header timestamp as `now`, regardless of how old the source post actually is.

Root cause: `PostPreview` (used by `SearchSources`) constructs the `metadata.post` object passed to Mattermost's `PostMessagePreview` manually with only `message` and `user_id`. Mattermost's `PostMessagePreview` renders the header timestamp from `previewPost.create_at`. Because `create_at` was missing/`0`, the `Timestamp` formatter chose its smallest unit (`now`) for every preview.

Fix: When the source post is fetched, capture its `create_at` and pass it through `metadata.post` (along with `id` and `channel_id`) so the preview header renders the correct relative time.

The fix is small and isolated to `webapp/src/components/post_preview.tsx`. Added a unit test (`webapp/src/components/post_preview.test.tsx`) that verifies the source post's `create_at` is propagated to `PostMessagePreview`. The test was confirmed to fail without the fix and pass with the fix.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-68437

#### Release Note
```release-note
Fixed the Sources panel in AI Enhanced Search showing every source post's timestamp as "now" by passing the source post's create_at timestamp through to the post preview.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb469584-e553-4036-923a-05af4e5302b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb469584-e553-4036-923a-05af4e5302b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Post previews now reliably display the original post creation time and avoid showing current/stale timestamps.
  * Fetch failures are handled gracefully to prevent errors from affecting the UI.

* **New Features**
  * Post preview metadata now includes post and channel identifiers for more accurate context.

* **Tests**
  * Added tests verifying preview metadata propagation, behaviour when posts are absent, and correct handling of fetch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->