### PR TITLE
Fix stuck MCP OAuth provider state

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -58,6 +58,7 @@ type MCPClientManager interface {
 	GetHTTPClient() *http.Client
 	ProcessOAuthCallback(ctx context.Context, loggedInUserID, state, code string) (*mcp.OAuthSession, error)
 	DisconnectUserOAuth(userID, serverName string) error
+	MarkOAuthNeeded(userID, serverName, authURL string) error
 	GetEmbeddedServer() mcp.EmbeddedMCPServer
 	EnsureMCPSessionID(userID string) (string, error)
 	GetToolsForUser(userID string) ([]llm.Tool, *mcp.Errors)

--- a/api/api.go
+++ b/api/api.go
@@ -106,6 +106,11 @@ type ClusterAgentNotifier interface {
 	PublishAgentUpdate() error
 }
 
+// MCPOAuthClusterNotifier broadcasts MCP OAuth updates to other cluster nodes.
+type MCPOAuthClusterNotifier interface {
+	PublishMCPOAuthUpdate(userID string) error
+}
+
 // API represents the HTTP API functionality for the plugin
 type API struct {
 	bots                  *bots.MMBots
@@ -132,6 +137,7 @@ type API struct {
 	configUpdater         ConfigUpdater
 	clusterNotifier       ClusterNotifier
 	clusterAgentNotifier  ClusterAgentNotifier
+	mcpOAuthNotifier      MCPOAuthClusterNotifier
 	conversationStore     ConversationStore
 	convService           *conversation.Service
 	getSearchInitError    func() string
@@ -163,6 +169,7 @@ func New(
 	configUpdater ConfigUpdater,
 	clusterNotifier ClusterNotifier,
 	clusterAgentNotifier ClusterAgentNotifier,
+	mcpOAuthNotifier MCPOAuthClusterNotifier,
 	conversationStore ConversationStore,
 	getSearchInitError func() string,
 	customPromptsStore *customprompts.Store,
@@ -192,6 +199,7 @@ func New(
 		configUpdater:         configUpdater,
 		clusterNotifier:       clusterNotifier,
 		clusterAgentNotifier:  clusterAgentNotifier,
+		mcpOAuthNotifier:      mcpOAuthNotifier,
 		conversationStore:     conversationStore,
 		getSearchInitError:    getSearchInitError,
 		customPromptsStore:    customPromptsStore,

--- a/api/api_admin_test.go
+++ b/api/api_admin_test.go
@@ -36,7 +36,7 @@ func setupAdminTestEnvironment(t *testing.T) (*API, *plugintest.API) {
 	cfg := &testConfigImpl{}
 	noopMetrics := &metrics.NoopMetrics{}
 
-	api := New(nil, nil, nil, nil, nil, client, noopMetrics, nil, cfg, nil, nil, nil, nil, nil, nil, &mockMCPClientManager{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	api := New(nil, nil, nil, nil, nil, client, noopMetrics, nil, cfg, nil, nil, nil, nil, nil, nil, &mockMCPClientManager{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	return api, mockAPI
 }

--- a/api/api_mcp.go
+++ b/api/api_mcp.go
@@ -166,11 +166,12 @@ func buildUserMCPServerInfo(
 		NeedsOAuth:    needsOAuth,
 		Tools:         toolInfos,
 	}
-	if hasAuthError && !info.Authenticated {
+	switch {
+	case hasAuthError && !info.Authenticated:
 		info.AuthURL = authError.AuthURL
-	} else if hasPersistedAuthNeeded && !info.Authenticated {
+	case hasPersistedAuthNeeded && !info.Authenticated:
 		info.AuthURL = authNeededState.AuthURL
-	} else if !info.Authenticated && oauthManager != nil && staticOAuthConfigured {
+	case !info.Authenticated && oauthManager != nil && staticOAuthConfigured:
 		info.AuthURL = oauthManager.StartURL(serverConfig.Name)
 	}
 	return info

--- a/api/api_mcp.go
+++ b/api/api_mcp.go
@@ -167,7 +167,7 @@ func buildUserMCPServerInfo(
 		Tools:         toolInfos,
 	}
 	switch {
-	case hasAuthError && !info.Authenticated:
+	case hasAuthError && !info.Authenticated && authError.AuthURL != "":
 		info.AuthURL = authError.AuthURL
 	case hasPersistedAuthNeeded && !info.Authenticated:
 		info.AuthURL = authNeededState.AuthURL
@@ -258,6 +258,7 @@ func (a *API) handleDeleteUserMCPOAuth(c *gin.Context) {
 		return
 	}
 
+	a.publishMCPOAuthClusterInvalidation(userID)
 	a.publishMCPDisconnected(userID, serverName)
 	c.Status(http.StatusOK)
 }

--- a/api/api_mcp.go
+++ b/api/api_mcp.go
@@ -142,9 +142,22 @@ func buildUserMCPServerInfo(
 		}
 	}
 
-	authenticated := isUserMCPServerAuthenticated(serverConfig, len(originTools) > 0, hasAuthError, hasStoredToken)
+	var authNeededState *mcp.OAuthNeededState
+	if oauthManager != nil {
+		var err error
+		authNeededState, err = oauthManager.LoadAuthNeededState(userID, serverConfig.Name)
+		if err != nil {
+			authNeededState = nil
+			if api != nil {
+				api.pluginAPI.Log.Debug("Failed to load MCP OAuth-needed state", "userID", userID, "serverName", serverConfig.Name, "serverOrigin", serverConfig.BaseURL, "error", err)
+			}
+		}
+	}
+	hasPersistedAuthNeeded := authNeededState != nil && authNeededState.AuthURL != ""
+
+	authenticated := isUserMCPServerAuthenticated(serverConfig, len(originTools) > 0, hasAuthError, hasStoredToken, hasPersistedAuthNeeded)
 	staticOAuthConfigured := serverConfig.ClientID != ""
-	needsOAuth := hasAuthError || hasStoredToken || (!authenticated && staticOAuthConfigured)
+	needsOAuth := hasAuthError || hasStoredToken || hasPersistedAuthNeeded || (!authenticated && staticOAuthConfigured)
 
 	info := UserMCPServerInfo{
 		Name:          serverConfig.Name,
@@ -155,6 +168,8 @@ func buildUserMCPServerInfo(
 	}
 	if hasAuthError && !info.Authenticated {
 		info.AuthURL = authError.AuthURL
+	} else if hasPersistedAuthNeeded && !info.Authenticated {
+		info.AuthURL = authNeededState.AuthURL
 	} else if !info.Authenticated && oauthManager != nil && staticOAuthConfigured {
 		info.AuthURL = oauthManager.StartURL(serverConfig.Name)
 	}
@@ -166,17 +181,18 @@ func isUserMCPServerAuthenticated(
 	hasDiscoveredTools bool,
 	hasAuthError bool,
 	hasStoredToken bool,
+	hasPersistedAuthNeeded bool,
 ) bool {
 	if serverConfig.BaseURL == mcp.EmbeddedClientKey {
 		return true
 	}
 
-	if hasDiscoveredTools {
-		return true
+	if hasAuthError || hasPersistedAuthNeeded {
+		return false
 	}
 
-	if hasAuthError {
-		return false
+	if hasDiscoveredTools {
+		return true
 	}
 
 	return hasStoredToken

--- a/api/api_mcp_test.go
+++ b/api/api_mcp_test.go
@@ -264,6 +264,68 @@ func TestHandleGetUserMCPToolsAuthErrorsOverrideStoredTokensForZeroToolServers(t
 	require.Equal(t, "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/OAuth%20Server/start", response.Servers[0].AuthURL)
 }
 
+func TestHandleGetUserMCPToolsAuthErrorWithoutURLFallsBackToPersistedAuthNeededState(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	server := mcp.ServerConfig{
+		Name:    "OAuth Server",
+		Enabled: true,
+		BaseURL: "https://oauth.example.com",
+	}
+	e.config.mcpConfig = mcp.Config{
+		Enabled: true,
+		Servers: []mcp.ServerConfig{server},
+	}
+
+	mmClient := mmapimocks.NewMockClient(t)
+	mmClient.On("KVGet", "mcp_oauth_token_v1_"+testUserID+"_"+server.Name, mock.AnythingOfType("*oauth2.Token")).
+		Run(func(args mock.Arguments) {
+			token := args.Get(1).(*oauth2.Token)
+			*token = oauth2.Token{}
+		}).
+		Return(nil)
+	mmClient.On("KVGet", "mcp_oauth_needed_v1_"+testUserID+"_"+server.Name, mock.AnythingOfType("*mcp.OAuthNeededState")).
+		Run(func(args mock.Arguments) {
+			state := args.Get(1).(*mcp.OAuthNeededState)
+			*state = mcp.OAuthNeededState{
+				AuthURL: "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/OAuth%20Server/start?resource_metadata=https%3A%2F%2Foauth.example.com%2Fmetadata",
+			}
+		}).
+		Return(nil)
+
+	oauthManager := mcp.NewOAuthManager(mmClient, "https://mattermost.example.com/plugins/mattermost-ai/oauth/callback", &http.Client{}, func(serverID string) (mcp.ServerConfig, bool) {
+		if serverID == server.Name {
+			return server, true
+		}
+		return mcp.ServerConfig{}, false
+	})
+
+	e.api.mcpClientManager = &mockMCPClientManager{
+		oauthManager: oauthManager,
+		mcpErrors: &mcp.Errors{
+			ToolAuthErrors: []llm.ToolAuthError{
+				{
+					ServerName:   server.Name,
+					ServerOrigin: server.BaseURL,
+					Error:        errors.New("oauth needed"),
+				},
+			},
+		},
+	}
+
+	response := getUserMCPToolsResponse(t, e.api)
+
+	require.Len(t, response.Servers, 1)
+	require.Equal(t, server.Name, response.Servers[0].Name)
+	require.False(t, response.Servers[0].Authenticated)
+	require.True(t, response.Servers[0].NeedsOAuth)
+	require.Equal(t, "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/OAuth%20Server/start?resource_metadata=https%3A%2F%2Foauth.example.com%2Fmetadata", response.Servers[0].AuthURL)
+}
+
 func TestHandleGetUserMCPToolsIncludesEmbeddedZeroToolServer(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DefaultWriter = io.Discard
@@ -378,6 +440,8 @@ func TestHandleDeleteUserMCPOAuth(t *testing.T) {
 
 	mcpMock := &mockMCPClientManager{}
 	e.api.mcpClientManager = mcpMock
+	clusterNotifier := &fakeMCPOAuthClusterNotifier{}
+	e.api.mcpOAuthNotifier = clusterNotifier
 
 	const testServerOrigin = "https://mcp.test/"
 	e.config.mcpConfig = mcp.Config{
@@ -406,12 +470,57 @@ func TestHandleDeleteUserMCPOAuth(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
 	require.Equal(t, []mcpDisconnectCall{{userID: testUserID, serverName: "TestServer"}}, mcpMock.disconnectCalls)
+	require.Equal(t, []string{testUserID}, clusterNotifier.calls)
 	require.Equal(t, WebsocketEventMCPConnectionUpdated, gotEvent)
 	require.Equal(t, "disconnected", gotPayload["status"])
 	require.Equal(t, "TestServer", gotPayload["serverName"])
 	require.Equal(t, testServerOrigin, gotPayload["serverOrigin"])
 	require.NotNil(t, gotBroadcast)
 	require.Equal(t, testUserID, gotBroadcast.UserId)
+}
+
+func TestHandleDeleteUserMCPOAuthClusterPublishFailureStillSucceeds(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	e.api.mcpClientManager = &mockMCPClientManager{}
+	clusterNotifier := &fakeMCPOAuthClusterNotifier{err: errors.New("cluster publish failed")}
+	e.api.mcpOAuthNotifier = clusterNotifier
+	e.mockAPI.On("LogWarn", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+
+	request := httptest.NewRequest(http.MethodDelete, "/mcp/oauth/TestServer", nil)
+	request.Header.Add("Mattermost-User-Id", testUserID)
+
+	recorder := httptest.NewRecorder()
+	e.api.ServeHTTP(nil, recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
+	require.Equal(t, []string{testUserID}, clusterNotifier.calls)
+}
+
+func TestHandleDeleteUserMCPOAuthDoesNotNotifyOnDisconnectFailure(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	e.api.mcpClientManager = &mockMCPClientManager{disconnectErr: errors.New("delete token failed")}
+	clusterNotifier := &fakeMCPOAuthClusterNotifier{}
+	e.api.mcpOAuthNotifier = clusterNotifier
+	e.mockAPI.On("LogError", mock.Anything).Return().Maybe()
+
+	request := httptest.NewRequest(http.MethodDelete, "/mcp/oauth/TestServer", nil)
+	request.Header.Add("Mattermost-User-Id", testUserID)
+
+	recorder := httptest.NewRecorder()
+	e.api.ServeHTTP(nil, recorder, request)
+
+	require.Equal(t, http.StatusInternalServerError, recorder.Result().StatusCode)
+	require.Empty(t, clusterNotifier.calls)
 }
 
 func TestHandleDeleteUserMCPOAuthMissingServerName(t *testing.T) {
@@ -422,6 +531,8 @@ func TestHandleDeleteUserMCPOAuthMissingServerName(t *testing.T) {
 	defer e.Cleanup(t)
 
 	e.api.mcpClientManager = &mockMCPClientManager{}
+	clusterNotifier := &fakeMCPOAuthClusterNotifier{}
+	e.api.mcpOAuthNotifier = clusterNotifier
 
 	request := httptest.NewRequest(http.MethodDelete, "/mcp/oauth/", nil)
 	request.Header.Add("Mattermost-User-Id", testUserID)
@@ -430,6 +541,7 @@ func TestHandleDeleteUserMCPOAuthMissingServerName(t *testing.T) {
 	e.api.ServeHTTP(nil, recorder, request)
 
 	require.Equal(t, http.StatusNotFound, recorder.Result().StatusCode)
+	require.Empty(t, clusterNotifier.calls)
 }
 
 func TestHandleOAuthStartRedirectsToProviderAuthorizeURL(t *testing.T) {
@@ -602,6 +714,50 @@ func TestPublishMCPConnectionUpdatedNoOpWhenMMClientMissing(t *testing.T) {
 		ServerURL: "https://test.example.com",
 	}
 	e.api.publishMCPConnectionUpdated(testUserID, session)
+}
+
+func TestHandleOAuthCallbackPublishesClusterInvalidationAndWebsocket(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	session := &mcp.OAuthSession{
+		UserID:    testUserID,
+		ServerID:  "AtlassianMCP",
+		ServerURL: "https://mcp.atlassian.com/v1/sse",
+	}
+	e.api.mcpClientManager = &mockMCPClientManager{processOAuthSession: session}
+	clusterNotifier := &fakeMCPOAuthClusterNotifier{}
+	e.api.mcpOAuthNotifier = clusterNotifier
+
+	mmClient := mmapimocks.NewMockClient(t)
+	var gotEvent string
+	var gotPayload map[string]interface{}
+	var gotBroadcast *model.WebsocketBroadcast
+	mmClient.On("PublishWebSocketEvent", mock.AnythingOfType("string"), mock.AnythingOfType("map[string]interface {}"), mock.AnythingOfType("*model.WebsocketBroadcast")).
+		Run(func(args mock.Arguments) {
+			gotEvent = args.String(0)
+			gotPayload, _ = args.Get(1).(map[string]interface{})
+			gotBroadcast, _ = args.Get(2).(*model.WebsocketBroadcast)
+		}).Return()
+	e.api.mmClient = mmClient
+
+	request := httptest.NewRequest(http.MethodGet, "/oauth/callback?state=state&code=code", nil)
+	request.Header.Add("Mattermost-User-Id", testUserID)
+
+	recorder := httptest.NewRecorder()
+	e.api.ServeHTTP(nil, recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
+	require.Equal(t, []string{testUserID}, clusterNotifier.calls)
+	require.Equal(t, WebsocketEventMCPConnectionUpdated, gotEvent)
+	require.Equal(t, "connected", gotPayload["status"])
+	require.Equal(t, "AtlassianMCP", gotPayload["serverName"])
+	require.Equal(t, "https://mcp.atlassian.com/v1/sse", gotPayload["serverOrigin"])
+	require.NotNil(t, gotBroadcast)
+	require.Equal(t, testUserID, gotBroadcast.UserId)
 }
 
 func TestHandleOAuthStartAcceptsResourceMetadataMatchingOrigin(t *testing.T) {

--- a/api/api_mcp_test.go
+++ b/api/api_mcp_test.go
@@ -121,6 +121,12 @@ func TestHandleGetUserMCPToolsStaticOAuthCredentialsNeedOAuthWhenUnauthenticated
 			*token = oauth2.Token{}
 		}).
 		Return(nil)
+	mmClient.On("KVGet", "mcp_oauth_needed_v1_"+testUserID+"_"+server.Name, mock.AnythingOfType("*mcp.OAuthNeededState")).
+		Run(func(args mock.Arguments) {
+			state := args.Get(1).(*mcp.OAuthNeededState)
+			*state = mcp.OAuthNeededState{}
+		}).
+		Return(nil)
 
 	oauthManager := mcp.NewOAuthManager(mmClient, "https://mattermost.example.com/plugins/mattermost-ai/oauth/callback", &http.Client{}, func(serverID string) (mcp.ServerConfig, bool) {
 		if serverID == server.Name {
@@ -165,6 +171,12 @@ func TestHandleGetUserMCPToolsStoredTokenMarksZeroToolServerAuthenticated(t *tes
 		Run(func(args mock.Arguments) {
 			token := args.Get(1).(*oauth2.Token)
 			*token = oauth2.Token{AccessToken: "stored-token"}
+		}).
+		Return(nil)
+	mmClient.On("KVGet", "mcp_oauth_needed_v1_"+testUserID+"_"+server.Name, mock.AnythingOfType("*mcp.OAuthNeededState")).
+		Run(func(args mock.Arguments) {
+			state := args.Get(1).(*mcp.OAuthNeededState)
+			*state = mcp.OAuthNeededState{}
 		}).
 		Return(nil)
 
@@ -214,6 +226,12 @@ func TestHandleGetUserMCPToolsAuthErrorsOverrideStoredTokensForZeroToolServers(t
 		}).
 		Return(nil).
 		Maybe()
+	mmClient.On("KVGet", "mcp_oauth_needed_v1_"+testUserID+"_"+server.Name, mock.AnythingOfType("*mcp.OAuthNeededState")).
+		Run(func(args mock.Arguments) {
+			state := args.Get(1).(*mcp.OAuthNeededState)
+			*state = mcp.OAuthNeededState{}
+		}).
+		Return(nil)
 
 	oauthManager := mcp.NewOAuthManager(mmClient, "https://mattermost.example.com/plugins/mattermost-ai/oauth/callback", &http.Client{}, func(serverID string) (mcp.ServerConfig, bool) {
 		if serverID == server.Name {
@@ -272,6 +290,67 @@ func TestHandleGetUserMCPToolsIncludesEmbeddedZeroToolServer(t *testing.T) {
 	require.Empty(t, response.Servers[0].Tools)
 	require.False(t, response.Servers[0].NeedsOAuth)
 	require.Empty(t, response.Servers[0].AuthURL)
+}
+
+func TestHandleGetUserMCPToolsAuthNeededStateOverridesDiscoveredTools(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	server := mcp.ServerConfig{
+		Name:    "GitHub",
+		Enabled: true,
+		BaseURL: "https://api.githubcopilot.com/mcp",
+	}
+	e.config.mcpConfig = mcp.Config{
+		Enabled: true,
+		Servers: []mcp.ServerConfig{server},
+	}
+
+	mmClient := mmapimocks.NewMockClient(t)
+	mmClient.On("KVGet", "mcp_oauth_token_v1_"+testUserID+"_"+server.Name, mock.AnythingOfType("*oauth2.Token")).
+		Run(func(args mock.Arguments) {
+			token := args.Get(1).(*oauth2.Token)
+			*token = oauth2.Token{}
+		}).
+		Return(nil)
+	mmClient.On("KVGet", "mcp_oauth_needed_v1_"+testUserID+"_"+server.Name, mock.AnythingOfType("*mcp.OAuthNeededState")).
+		Run(func(args mock.Arguments) {
+			state := args.Get(1).(*mcp.OAuthNeededState)
+			*state = mcp.OAuthNeededState{
+				AuthURL: "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/GitHub/start?resource_metadata=https%3A%2F%2Fapi.githubcopilot.com%2F.well-known%2Foauth-protected-resource%2Fmcp",
+			}
+		}).
+		Return(nil)
+
+	oauthManager := mcp.NewOAuthManager(mmClient, "https://mattermost.example.com/plugins/mattermost-ai/oauth/callback", &http.Client{}, func(serverID string) (mcp.ServerConfig, bool) {
+		if serverID == server.Name {
+			return server, true
+		}
+		return mcp.ServerConfig{}, false
+	})
+
+	e.api.mcpClientManager = &mockMCPClientManager{
+		oauthManager: oauthManager,
+		tools: []llm.Tool{
+			{
+				Name:         "get_me",
+				Description:  "Get current user",
+				ServerOrigin: server.BaseURL,
+			},
+		},
+	}
+
+	response := getUserMCPToolsResponse(t, e.api)
+
+	require.Len(t, response.Servers, 1)
+	require.Equal(t, server.Name, response.Servers[0].Name)
+	require.False(t, response.Servers[0].Authenticated)
+	require.True(t, response.Servers[0].NeedsOAuth)
+	require.Equal(t, "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/GitHub/start?resource_metadata=https%3A%2F%2Fapi.githubcopilot.com%2F.well-known%2Foauth-protected-resource%2Fmcp", response.Servers[0].AuthURL)
+	require.Len(t, response.Servers[0].Tools, 1)
 }
 
 func getUserMCPToolsResponse(t *testing.T, api *API) UserMCPToolsResponse {

--- a/api/api_oauth.go
+++ b/api/api_oauth.go
@@ -87,8 +87,22 @@ func (a *API) handleOAuthCallback(c *gin.Context) {
 		return
 	}
 
+	a.publishMCPOAuthClusterInvalidation(userID)
 	a.publishMCPConnectionUpdated(userID, session)
 	a.renderOAuthWindowClosePage(c, http.StatusOK, "Authorization Successful")
+}
+
+// publishMCPOAuthClusterInvalidation notifies peer nodes to drop stale per-user MCP clients.
+func (a *API) publishMCPOAuthClusterInvalidation(userID string) {
+	if a.mcpOAuthNotifier == nil || userID == "" {
+		return
+	}
+
+	if err := a.mcpOAuthNotifier.PublishMCPOAuthUpdate(userID); err != nil {
+		if a.pluginAPI != nil {
+			a.pluginAPI.Log.Warn("Failed to publish MCP OAuth cluster invalidation", "userID", userID, "error", err)
+		}
+	}
 }
 
 // publishMCPConnectionUpdated notifies the webapp that the user connected an MCP server (OAuth callback).

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -87,13 +87,16 @@ type mcpDisconnectCall struct {
 
 // mockMCPClientManager is a minimal implementation of MCPClientManager for testing
 type mockMCPClientManager struct {
-	oauthManager     *mcp.OAuthManager
-	tools            []llm.Tool
-	mcpErrors        *mcp.Errors
-	config           mcp.Config
-	embeddedServer   mcp.EmbeddedMCPServer
-	disconnectCalls  []mcpDisconnectCall
-	oauthNeededCalls []mcpDisconnectCall
+	oauthManager        *mcp.OAuthManager
+	tools               []llm.Tool
+	mcpErrors           *mcp.Errors
+	config              mcp.Config
+	embeddedServer      mcp.EmbeddedMCPServer
+	processOAuthSession *mcp.OAuthSession
+	processOAuthErr     error
+	disconnectErr       error
+	disconnectCalls     []mcpDisconnectCall
+	oauthNeededCalls    []mcpDisconnectCall
 }
 
 func (m *mockMCPClientManager) GetOAuthManager() *mcp.OAuthManager {
@@ -105,7 +108,7 @@ func (m *mockMCPClientManager) GetToolsCache() *mcp.ToolsCache {
 }
 
 func (m *mockMCPClientManager) ProcessOAuthCallback(ctx context.Context, loggedInUserID, state, code string) (*mcp.OAuthSession, error) {
-	return nil, nil
+	return m.processOAuthSession, m.processOAuthErr
 }
 
 func (m *mockMCPClientManager) DisconnectUserOAuth(userID, serverName string) error {
@@ -113,7 +116,7 @@ func (m *mockMCPClientManager) DisconnectUserOAuth(userID, serverName string) er
 		userID:     userID,
 		serverName: serverName,
 	})
-	return nil
+	return m.disconnectErr
 }
 
 func (m *mockMCPClientManager) MarkOAuthNeeded(userID, serverName, authURL string) error {
@@ -142,6 +145,16 @@ func (m *mockMCPClientManager) GetToolsForUser(userID string) ([]llm.Tool, *mcp.
 
 func (m *mockMCPClientManager) GetConfig() mcp.Config {
 	return m.config
+}
+
+type fakeMCPOAuthClusterNotifier struct {
+	calls []string
+	err   error
+}
+
+func (f *fakeMCPOAuthClusterNotifier) PublishMCPOAuthUpdate(userID string) error {
+	f.calls = append(f.calls, userID)
+	return f.err
 }
 
 // mockConversationStore is a simple in-memory implementation of ConversationStore for API-layer tests.
@@ -392,7 +405,7 @@ func SetupTestEnvironment(t *testing.T) *TestEnvironment {
 	mockConvStore := newMockConversationStore()
 	agentStore := newMockAgentStore()
 
-	api := New(testBots, conversationsService, nil, nil, nil, client, noopMetrics, nil, cfg, nil, nil, nil, nil, nil, nil, &mockMCPClientManager{}, nil, nil, nil, agentStore, nil, nil, nil, mockConvStore, nil, nil)
+	api := New(testBots, conversationsService, nil, nil, nil, client, noopMetrics, nil, cfg, nil, nil, nil, nil, nil, nil, &mockMCPClientManager{}, nil, nil, nil, agentStore, nil, nil, nil, nil, mockConvStore, nil, nil)
 
 	return &TestEnvironment{
 		api:               api,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -87,12 +87,13 @@ type mcpDisconnectCall struct {
 
 // mockMCPClientManager is a minimal implementation of MCPClientManager for testing
 type mockMCPClientManager struct {
-	oauthManager    *mcp.OAuthManager
-	tools           []llm.Tool
-	mcpErrors       *mcp.Errors
-	config          mcp.Config
-	embeddedServer  mcp.EmbeddedMCPServer
-	disconnectCalls []mcpDisconnectCall
+	oauthManager     *mcp.OAuthManager
+	tools            []llm.Tool
+	mcpErrors        *mcp.Errors
+	config           mcp.Config
+	embeddedServer   mcp.EmbeddedMCPServer
+	disconnectCalls  []mcpDisconnectCall
+	oauthNeededCalls []mcpDisconnectCall
 }
 
 func (m *mockMCPClientManager) GetOAuthManager() *mcp.OAuthManager {
@@ -109,6 +110,14 @@ func (m *mockMCPClientManager) ProcessOAuthCallback(ctx context.Context, loggedI
 
 func (m *mockMCPClientManager) DisconnectUserOAuth(userID, serverName string) error {
 	m.disconnectCalls = append(m.disconnectCalls, mcpDisconnectCall{
+		userID:     userID,
+		serverName: serverName,
+	})
+	return nil
+}
+
+func (m *mockMCPClientManager) MarkOAuthNeeded(userID, serverName, authURL string) error {
+	m.oauthNeededCalls = append(m.oauthNeededCalls, mcpDisconnectCall{
 		userID:     userID,
 		serverName: serverName,
 	})

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -63,6 +63,7 @@ func (m *ClientManager) cleanupInactiveClients() {
 					m.log.Debug("Closing inactive MCP client", "userID", userID)
 					client.Close()
 					delete(m.clients, userID)
+					delete(m.activity, userID)
 				}
 			}
 			m.clientsMu.Unlock()
@@ -121,6 +122,7 @@ func (m *ClientManager) Close() {
 
 	// Clear the clients map
 	m.clients = make(map[string]*UserClients)
+	m.activity = make(map[string]time.Time)
 }
 
 // createAndStoreUserClient creates a new UserClients instance and stores it in the manager
@@ -144,19 +146,21 @@ func (m *ClientManager) createAndStoreUserClient(userID string) (*UserClients, *
 	// Store the client even if some servers failed to connect
 	// This allows partial success - user gets tools from working servers
 	m.clients[userID] = userClients
+	m.activity[userID] = time.Now()
 
 	return userClients, mcpErrors
 }
 
 // getClientForUser gets or creates an MCP client for a specific user
 func (m *ClientManager) getClientForUser(userID string) (*UserClients, *Errors) {
-	m.clientsMu.RLock()
+	m.clientsMu.Lock()
 	client, exists := m.clients[userID]
-	m.clientsMu.RUnlock()
 	if exists {
 		m.activity[userID] = time.Now()
+		m.clientsMu.Unlock()
 		return client, client.initialRemoteConnectErrors
 	}
+	m.clientsMu.Unlock()
 
 	return m.createAndStoreUserClient(userID)
 }

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -233,12 +233,10 @@ func (m *ClientManager) DisconnectUserOAuth(userID, serverName string) error {
 // MarkOAuthNeeded stores the latest upstream OAuth-needed state for a user/server
 // and drops any cached client so subsequent tool discovery reflects the reconnectable state.
 func (m *ClientManager) MarkOAuthNeeded(userID, serverName, authURL string) error {
-	if m.oauthManager == nil {
-		return nil
-	}
-
-	if err := m.oauthManager.StoreAuthNeededState(userID, serverName, authURL); err != nil {
-		return err
+	if m.oauthManager != nil {
+		if err := m.oauthManager.StoreAuthNeededState(userID, serverName, authURL); err != nil {
+			return err
+		}
 	}
 
 	m.InvalidateUserClients(userID)

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -233,15 +233,14 @@ func (m *ClientManager) DisconnectUserOAuth(userID, serverName string) error {
 // MarkOAuthNeeded stores the latest upstream OAuth-needed state for a user/server
 // and drops any cached client so subsequent tool discovery reflects the reconnectable state.
 func (m *ClientManager) MarkOAuthNeeded(userID, serverName, authURL string) error {
+	var storeErr error
 	if m.oauthManager != nil {
-		if err := m.oauthManager.StoreAuthNeededState(userID, serverName, authURL); err != nil {
-			return err
-		}
+		storeErr = m.oauthManager.StoreAuthNeededState(userID, serverName, authURL)
 	}
 
 	m.InvalidateUserClients(userID)
 
-	return nil
+	return storeErr
 }
 
 // GetOAuthManager returns the OAuth manager instance

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sort"
 	"sync"
@@ -13,6 +14,8 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 )
+
+var ErrOAuthNotConfigured = errors.New("oauth is not configured for this plugin")
 
 // ClientManager manages MCP clients for multiple users
 type ClientManager struct {
@@ -206,6 +209,10 @@ func (m *ClientManager) InvalidateUserClients(userID string) {
 
 // ProcessOAuthCallback processes the OAuth callback for a user
 func (m *ClientManager) ProcessOAuthCallback(ctx context.Context, userID, state, code string) (*OAuthSession, error) {
+	if m.oauthManager == nil {
+		return nil, ErrOAuthNotConfigured
+	}
+
 	session, err := m.oauthManager.ProcessCallback(ctx, userID, state, code)
 	if err != nil {
 		return nil, err
@@ -221,6 +228,10 @@ func (m *ClientManager) ProcessOAuthCallback(ctx context.Context, userID, state,
 // and invalidates the cached MCP client so a fresh connection is established
 // on the next request.
 func (m *ClientManager) DisconnectUserOAuth(userID, serverName string) error {
+	if m.oauthManager == nil {
+		return ErrOAuthNotConfigured
+	}
+
 	if err := m.oauthManager.DeleteUserToken(userID, serverName); err != nil {
 		return err
 	}

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -184,6 +184,22 @@ func (m *ClientManager) GetToolsForUser(userID string) ([]llm.Tool, *Errors) {
 	return filtered, mcpErrors
 }
 
+// InvalidateUserClients closes and removes cached MCP clients for a user.
+func (m *ClientManager) InvalidateUserClients(userID string) {
+	if userID == "" {
+		return
+	}
+
+	m.clientsMu.Lock()
+	defer m.clientsMu.Unlock()
+
+	if uc, ok := m.clients[userID]; ok {
+		uc.Close()
+		delete(m.clients, userID)
+	}
+	delete(m.activity, userID)
+}
+
 // ProcessOAuthCallback processes the OAuth callback for a user
 func (m *ClientManager) ProcessOAuthCallback(ctx context.Context, userID, state, code string) (*OAuthSession, error) {
 	session, err := m.oauthManager.ProcessCallback(ctx, userID, state, code)
@@ -191,22 +207,8 @@ func (m *ClientManager) ProcessOAuthCallback(ctx context.Context, userID, state,
 		return nil, err
 	}
 
-	if m.oauthManager != nil && session != nil {
-		if clearErr := m.oauthManager.DeleteAuthNeededState(userID, session.ServerID); clearErr != nil {
-			m.log.Warn("Failed to clear MCP OAuth-needed state after successful callback",
-				"userID", userID,
-				"serverID", session.ServerID,
-				"error", clearErr)
-		}
-	}
-
 	// Delete the client to force a re-creation (close first, like DisconnectUserOAuth).
-	m.clientsMu.Lock()
-	if uc, ok := m.clients[userID]; ok {
-		uc.Close()
-		delete(m.clients, userID)
-	}
-	m.clientsMu.Unlock()
+	m.InvalidateUserClients(userID)
 
 	return session, nil
 }
@@ -219,12 +221,7 @@ func (m *ClientManager) DisconnectUserOAuth(userID, serverName string) error {
 		return err
 	}
 
-	m.clientsMu.Lock()
-	if uc, ok := m.clients[userID]; ok {
-		uc.Close()
-		delete(m.clients, userID)
-	}
-	m.clientsMu.Unlock()
+	m.InvalidateUserClients(userID)
 
 	return nil
 }
@@ -240,12 +237,7 @@ func (m *ClientManager) MarkOAuthNeeded(userID, serverName, authURL string) erro
 		return err
 	}
 
-	m.clientsMu.Lock()
-	if uc, ok := m.clients[userID]; ok {
-		uc.Close()
-		delete(m.clients, userID)
-	}
-	m.clientsMu.Unlock()
+	m.InvalidateUserClients(userID)
 
 	return nil
 }

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -191,6 +191,15 @@ func (m *ClientManager) ProcessOAuthCallback(ctx context.Context, userID, state,
 		return nil, err
 	}
 
+	if m.oauthManager != nil && session != nil {
+		if clearErr := m.oauthManager.DeleteAuthNeededState(userID, session.ServerID); clearErr != nil {
+			m.log.Warn("Failed to clear MCP OAuth-needed state after successful callback",
+				"userID", userID,
+				"serverID", session.ServerID,
+				"error", clearErr)
+		}
+	}
+
 	// Delete the client to force a re-creation (close first, like DisconnectUserOAuth).
 	m.clientsMu.Lock()
 	if uc, ok := m.clients[userID]; ok {
@@ -207,6 +216,27 @@ func (m *ClientManager) ProcessOAuthCallback(ctx context.Context, userID, state,
 // on the next request.
 func (m *ClientManager) DisconnectUserOAuth(userID, serverName string) error {
 	if err := m.oauthManager.DeleteUserToken(userID, serverName); err != nil {
+		return err
+	}
+
+	m.clientsMu.Lock()
+	if uc, ok := m.clients[userID]; ok {
+		uc.Close()
+		delete(m.clients, userID)
+	}
+	m.clientsMu.Unlock()
+
+	return nil
+}
+
+// MarkOAuthNeeded stores the latest upstream OAuth-needed state for a user/server
+// and drops any cached client so subsequent tool discovery reflects the reconnectable state.
+func (m *ClientManager) MarkOAuthNeeded(userID, serverName, authURL string) error {
+	if m.oauthManager == nil {
+		return nil
+	}
+
+	if err := m.oauthManager.StoreAuthNeededState(userID, serverName, authURL); err != nil {
 		return err
 	}
 

--- a/mcp/client_manager_test.go
+++ b/mcp/client_manager_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,4 +52,24 @@ func TestClientManagerReInitIdleTimeoutDefaulting(t *testing.T) {
 			require.Equal(t, tc.expectedTimeout, manager.clientTimeout)
 		})
 	}
+}
+
+func TestClientManagerMarkOAuthNeededInvalidatesUserClient(t *testing.T) {
+	manager := &ClientManager{}
+	manager.clients = map[string]*UserClients{
+		"user-1": {
+			clients: map[string]*Client{},
+		},
+	}
+	manager.activity = map[string]time.Time{
+		"user-1": time.Now(),
+	}
+
+	mockClient := mocks.NewMockClient(t)
+	mockClient.On("KVSetWithExpiry", "mcp_oauth_needed_v1_user-1_GitHub", mock.AnythingOfType("*mcp.OAuthNeededState"), oauthNeededStateTTL).Return(nil)
+	manager.oauthManager = NewOAuthManager(mockClient, "https://mattermost.example.com/plugins/mattermost-ai/oauth/callback", nil, nil)
+
+	err := manager.MarkOAuthNeeded("user-1", "GitHub", "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/GitHub/start")
+	require.NoError(t, err)
+	require.Empty(t, manager.clients)
 }

--- a/mcp/client_manager_test.go
+++ b/mcp/client_manager_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -83,6 +85,31 @@ func TestClientManagerInvalidateUserClients(t *testing.T) {
 
 	require.Contains(t, manager.clients, "user-2")
 	require.Equal(t, now.Add(time.Minute), manager.activity["user-2"])
+}
+
+func TestClientManagerCreateAndStoreUserClientSetsInitialActivity(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	mockAPI.On("LogDebug", mock.Anything, mock.Anything, mock.Anything).Maybe()
+	client := pluginapi.NewClient(mockAPI, nil)
+	manager := &ClientManager{
+		config:   Config{},
+		log:      client.Log,
+		clients:  make(map[string]*UserClients),
+		activity: make(map[string]time.Time),
+	}
+
+	before := time.Now()
+	userClients, mcpErrors := manager.createAndStoreUserClient("user-1")
+	after := time.Now()
+
+	require.NotNil(t, userClients)
+	require.Nil(t, mcpErrors)
+	require.Contains(t, manager.clients, "user-1")
+
+	lastActivity, ok := manager.activity["user-1"]
+	require.True(t, ok)
+	require.False(t, lastActivity.Before(before))
+	require.False(t, lastActivity.After(after))
 }
 
 func TestClientManagerMarkOAuthNeededInvalidatesUserClient(t *testing.T) {

--- a/mcp/client_manager_test.go
+++ b/mcp/client_manager_test.go
@@ -7,12 +7,25 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
+	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type recordKVSetWithExpiryClient struct {
+	mmapi.Client
+	key   string
+	value any
+	ttl   time.Duration
+}
+
+func (c *recordKVSetWithExpiryClient) KVSetWithExpiry(key string, value interface{}, ttl time.Duration) error {
+	c.key = key
+	c.value = value
+	c.ttl = ttl
+	return nil
+}
 
 func TestClientManagerReInitIdleTimeoutDefaulting(t *testing.T) {
 	testCases := []struct {
@@ -58,38 +71,67 @@ func TestClientManagerReInitIdleTimeoutDefaulting(t *testing.T) {
 
 func TestClientManagerInvalidateUserClients(t *testing.T) {
 	now := time.Now()
-	manager := &ClientManager{
-		clients: map[string]*UserClients{
-			"user-1": {
-				clients: map[string]*Client{},
-			},
-			"user-2": {
-				clients: map[string]*Client{},
-			},
+	testCases := []struct {
+		name                 string
+		userID               string
+		expectedClientKeys   []string
+		expectedActivityKeys []string
+	}{
+		{
+			name:                 "removes existing user",
+			userID:               "user-1",
+			expectedClientKeys:   []string{"user-2"},
+			expectedActivityKeys: []string{"user-2"},
 		},
-		activity: map[string]time.Time{
-			"user-1": now,
-			"user-2": now.Add(time.Minute),
+		{
+			name:                 "ignores missing user",
+			userID:               "missing-user",
+			expectedClientKeys:   []string{"user-1", "user-2"},
+			expectedActivityKeys: []string{"user-1", "user-2"},
+		},
+		{
+			name:                 "ignores empty user",
+			userID:               "",
+			expectedClientKeys:   []string{"user-1", "user-2"},
+			expectedActivityKeys: []string{"user-1", "user-2"},
 		},
 	}
 
-	manager.InvalidateUserClients("user-1")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := &ClientManager{
+				clients: map[string]*UserClients{
+					"user-1": {
+						clients: map[string]*Client{},
+					},
+					"user-2": {
+						clients: map[string]*Client{},
+					},
+				},
+				activity: map[string]time.Time{
+					"user-1": now,
+					"user-2": now.Add(time.Minute),
+				},
+			}
 
-	require.NotContains(t, manager.clients, "user-1")
-	require.NotContains(t, manager.activity, "user-1")
-	require.Contains(t, manager.clients, "user-2")
-	require.Equal(t, now.Add(time.Minute), manager.activity["user-2"])
+			manager.InvalidateUserClients(tc.userID)
 
-	manager.InvalidateUserClients("missing-user")
-	manager.InvalidateUserClients("")
-
-	require.Contains(t, manager.clients, "user-2")
-	require.Equal(t, now.Add(time.Minute), manager.activity["user-2"])
+			require.Len(t, manager.clients, len(tc.expectedClientKeys))
+			for _, key := range tc.expectedClientKeys {
+				require.Contains(t, manager.clients, key)
+			}
+			require.Len(t, manager.activity, len(tc.expectedActivityKeys))
+			for _, key := range tc.expectedActivityKeys {
+				require.Contains(t, manager.activity, key)
+			}
+			require.Equal(t, now.Add(time.Minute), manager.activity["user-2"])
+		})
+	}
 }
 
 func TestClientManagerCreateAndStoreUserClientSetsInitialActivity(t *testing.T) {
 	mockAPI := &plugintest.API{}
-	mockAPI.On("LogDebug", mock.Anything, mock.Anything, mock.Anything).Maybe()
+	mockAPI.On("LogDebug", "No remote MCP servers provided for user", "userID", "user-1").Return().Maybe()
 	client := pluginapi.NewClient(mockAPI, nil)
 	manager := &ClientManager{
 		config:   Config{},
@@ -113,22 +155,66 @@ func TestClientManagerCreateAndStoreUserClientSetsInitialActivity(t *testing.T) 
 }
 
 func TestClientManagerMarkOAuthNeededInvalidatesUserClient(t *testing.T) {
-	manager := &ClientManager{}
-	manager.clients = map[string]*UserClients{
-		"user-1": {
-			clients: map[string]*Client{},
+	testCases := []struct {
+		name                     string
+		manager                  *ClientManager
+		expectedStoredKey        string
+		expectedStoredAuthURL    string
+		expectedStoredTTL        time.Duration
+		expectPersistenceAttempt bool
+	}{
+		{
+			name: "persists state when oauth manager exists",
+			manager: func() *ClientManager {
+				storeClient := &recordKVSetWithExpiryClient{}
+				manager := &ClientManager{
+					clients: map[string]*UserClients{
+						"user-1": {clients: map[string]*Client{}},
+					},
+					activity: map[string]time.Time{
+						"user-1": time.Now(),
+					},
+				}
+				manager.oauthManager = NewOAuthManager(storeClient, "https://mattermost.example.com/plugins/mattermost-ai/oauth/callback", nil, nil)
+				return manager
+			}(),
+			expectedStoredKey:        "mcp_oauth_needed_v1_user-1_GitHub",
+			expectedStoredAuthURL:    "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/GitHub/start",
+			expectedStoredTTL:        oauthNeededStateTTL,
+			expectPersistenceAttempt: true,
+		},
+		{
+			name: "still invalidates without oauth manager",
+			manager: &ClientManager{
+				clients: map[string]*UserClients{
+					"user-1": {clients: map[string]*Client{}},
+				},
+				activity: map[string]time.Time{
+					"user-1": time.Now(),
+				},
+			},
 		},
 	}
-	manager.activity = map[string]time.Time{
-		"user-1": time.Now(),
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.manager.MarkOAuthNeeded("user-1", "GitHub", "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/GitHub/start")
+			require.NoError(t, err)
+			require.Empty(t, tc.manager.clients)
+			require.Empty(t, tc.manager.activity)
+
+			if !tc.expectPersistenceAttempt {
+				return
+			}
+
+			storeClient, ok := tc.manager.oauthManager.pluginAPI.(*recordKVSetWithExpiryClient)
+			require.True(t, ok)
+			require.Equal(t, tc.expectedStoredKey, storeClient.key)
+			require.Equal(t, tc.expectedStoredTTL, storeClient.ttl)
+
+			state, ok := storeClient.value.(*OAuthNeededState)
+			require.True(t, ok)
+			require.Equal(t, tc.expectedStoredAuthURL, state.AuthURL)
+		})
 	}
-
-	mockClient := mocks.NewMockClient(t)
-	mockClient.On("KVSetWithExpiry", "mcp_oauth_needed_v1_user-1_GitHub", mock.AnythingOfType("*mcp.OAuthNeededState"), oauthNeededStateTTL).Return(nil)
-	manager.oauthManager = NewOAuthManager(mockClient, "https://mattermost.example.com/plugins/mattermost-ai/oauth/callback", nil, nil)
-
-	err := manager.MarkOAuthNeeded("user-1", "GitHub", "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/GitHub/start")
-	require.NoError(t, err)
-	require.Empty(t, manager.clients)
-	require.Empty(t, manager.activity)
 }

--- a/mcp/client_manager_test.go
+++ b/mcp/client_manager_test.go
@@ -54,6 +54,37 @@ func TestClientManagerReInitIdleTimeoutDefaulting(t *testing.T) {
 	}
 }
 
+func TestClientManagerInvalidateUserClients(t *testing.T) {
+	now := time.Now()
+	manager := &ClientManager{
+		clients: map[string]*UserClients{
+			"user-1": {
+				clients: map[string]*Client{},
+			},
+			"user-2": {
+				clients: map[string]*Client{},
+			},
+		},
+		activity: map[string]time.Time{
+			"user-1": now,
+			"user-2": now.Add(time.Minute),
+		},
+	}
+
+	manager.InvalidateUserClients("user-1")
+
+	require.NotContains(t, manager.clients, "user-1")
+	require.NotContains(t, manager.activity, "user-1")
+	require.Contains(t, manager.clients, "user-2")
+	require.Equal(t, now.Add(time.Minute), manager.activity["user-2"])
+
+	manager.InvalidateUserClients("missing-user")
+	manager.InvalidateUserClients("")
+
+	require.Contains(t, manager.clients, "user-2")
+	require.Equal(t, now.Add(time.Minute), manager.activity["user-2"])
+}
+
 func TestClientManagerMarkOAuthNeededInvalidatesUserClient(t *testing.T) {
 	manager := &ClientManager{}
 	manager.clients = map[string]*UserClients{
@@ -72,4 +103,5 @@ func TestClientManagerMarkOAuthNeededInvalidatesUserClient(t *testing.T) {
 	err := manager.MarkOAuthNeeded("user-1", "GitHub", "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/GitHub/start")
 	require.NoError(t, err)
 	require.Empty(t, manager.clients)
+	require.Empty(t, manager.activity)
 }

--- a/mcp/client_manager_test.go
+++ b/mcp/client_manager_test.go
@@ -251,3 +251,20 @@ func TestClientManagerMarkOAuthNeededInvalidatesUserClient(t *testing.T) {
 		})
 	}
 }
+
+func TestClientManagerProcessOAuthCallbackRequiresOAuthManager(t *testing.T) {
+	manager := &ClientManager{}
+
+	session, err := manager.ProcessOAuthCallback(t.Context(), "user-1", "state", "code")
+
+	require.Nil(t, session)
+	require.ErrorIs(t, err, ErrOAuthNotConfigured)
+}
+
+func TestClientManagerDisconnectUserOAuthRequiresOAuthManager(t *testing.T) {
+	manager := &ClientManager{}
+
+	err := manager.DisconnectUserOAuth("user-1", "GitHub")
+
+	require.ErrorIs(t, err, ErrOAuthNotConfigured)
+}

--- a/mcp/client_manager_test.go
+++ b/mcp/client_manager_test.go
@@ -4,10 +4,12 @@
 package mcp
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/mattermost/mattermost-plugin-agents/mmapi"
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/stretchr/testify/require"
@@ -15,16 +17,17 @@ import (
 
 type recordKVSetWithExpiryClient struct {
 	mmapi.Client
-	key   string
-	value any
-	ttl   time.Duration
+	key    string
+	value  any
+	ttl    time.Duration
+	setErr error
 }
 
 func (c *recordKVSetWithExpiryClient) KVSetWithExpiry(key string, value interface{}, ttl time.Duration) error {
 	c.key = key
 	c.value = value
 	c.ttl = ttl
-	return nil
+	return c.setErr
 }
 
 func TestClientManagerReInitIdleTimeoutDefaulting(t *testing.T) {
@@ -158,6 +161,7 @@ func TestClientManagerMarkOAuthNeededInvalidatesUserClient(t *testing.T) {
 	testCases := []struct {
 		name                     string
 		manager                  *ClientManager
+		expectedErr              string
 		expectedStoredKey        string
 		expectedStoredAuthURL    string
 		expectedStoredTTL        time.Duration
@@ -184,6 +188,29 @@ func TestClientManagerMarkOAuthNeededInvalidatesUserClient(t *testing.T) {
 			expectPersistenceAttempt: true,
 		},
 		{
+			name: "returns persistence error but still invalidates",
+			manager: func() *ClientManager {
+				storeClient := &recordKVSetWithExpiryClient{
+					setErr: model.NewAppError("test", "oauth_needed_store_failed", nil, "persist failed", http.StatusInternalServerError),
+				}
+				manager := &ClientManager{
+					clients: map[string]*UserClients{
+						"user-1": {clients: map[string]*Client{}},
+					},
+					activity: map[string]time.Time{
+						"user-1": time.Now(),
+					},
+				}
+				manager.oauthManager = NewOAuthManager(storeClient, "https://mattermost.example.com/plugins/mattermost-ai/oauth/callback", nil, nil)
+				return manager
+			}(),
+			expectedErr:              "failed to store OAuth-needed state",
+			expectedStoredKey:        "mcp_oauth_needed_v1_user-1_GitHub",
+			expectedStoredAuthURL:    "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/GitHub/start",
+			expectedStoredTTL:        oauthNeededStateTTL,
+			expectPersistenceAttempt: true,
+		},
+		{
 			name: "still invalidates without oauth manager",
 			manager: &ClientManager{
 				clients: map[string]*UserClients{
@@ -199,7 +226,13 @@ func TestClientManagerMarkOAuthNeededInvalidatesUserClient(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.manager.MarkOAuthNeeded("user-1", "GitHub", "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/GitHub/start")
-			require.NoError(t, err)
+
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+			}
 			require.Empty(t, tc.manager.clients)
 			require.Empty(t, tc.manager.activity)
 

--- a/mcp/oauth_manager.go
+++ b/mcp/oauth_manager.go
@@ -310,7 +310,10 @@ func (m *OAuthManager) ProcessCallback(ctx context.Context, loggedInUserID, stat
 		return nil, fmt.Errorf("failed to save token: %w", err)
 	}
 	if err := m.DeleteAuthNeededState(loggedInUserID, session.ServerID); err != nil {
-		return nil, fmt.Errorf("failed to clear oauth-needed state: %w", err)
+		m.pluginAPI.LogWarn("Failed to clear OAuth-needed state after successful callback",
+			"userID", loggedInUserID,
+			"serverID", session.ServerID,
+			"error", err)
 	}
 
 	return session, nil

--- a/mcp/oauth_manager.go
+++ b/mcp/oauth_manager.go
@@ -309,6 +309,9 @@ func (m *OAuthManager) ProcessCallback(ctx context.Context, loggedInUserID, stat
 	if err := m.storeToken(loggedInUserID, session.ServerID, token); err != nil {
 		return nil, fmt.Errorf("failed to save token: %w", err)
 	}
+	if err := m.DeleteAuthNeededState(loggedInUserID, session.ServerID); err != nil {
+		return nil, fmt.Errorf("failed to clear oauth-needed state: %w", err)
+	}
 
 	return session, nil
 }

--- a/mcp/oauth_manager_test.go
+++ b/mcp/oauth_manager_test.go
@@ -361,42 +361,65 @@ func TestOAuthNeededStateLifecycle(t *testing.T) {
 	require.NoError(t, manager.DeleteAuthNeededState(userID, serverID))
 }
 
-func TestDeleteUserTokenAttemptsAuthNeededCleanupWhenTokenDeleteFails(t *testing.T) {
-	manager, mockClient := setupTestOAuthManager(t)
-
+func TestDeleteUserTokenCleanup(t *testing.T) {
 	const userID = "user123"
 	const serverID = "GitHub"
+
 	tokenErr := model.NewAppError("test", "token_delete_failed", nil, "token delete failed", http.StatusInternalServerError)
-
-	mockClient.On("KVDelete", buildTokenKey(userID, serverID)).
-		Return(tokenErr).
-		Once()
-	mockClient.On("KVDelete", buildAuthNeededKey(userID, serverID)).
-		Return(nil).
-		Once()
-
-	err := manager.DeleteUserToken(userID, serverID)
-
-	require.ErrorIs(t, err, tokenErr)
-}
-
-func TestDeleteUserTokenReturnsAuthNeededCleanupError(t *testing.T) {
-	manager, mockClient := setupTestOAuthManager(t)
-
-	const userID = "user123"
-	const serverID = "GitHub"
 	authNeededErr := model.NewAppError("test", "auth_needed_delete_failed", nil, "auth-needed delete failed", http.StatusInternalServerError)
 
-	mockClient.On("KVDelete", buildTokenKey(userID, serverID)).
-		Return(nil).
-		Once()
-	mockClient.On("KVDelete", buildAuthNeededKey(userID, serverID)).
-		Return(authNeededErr).
-		Once()
+	testCases := []struct {
+		name                string
+		tokenDeleteErr      error
+		authNeededDeleteErr error
+		expectedErr         error
+	}{
+		{
+			name:           "returns token delete error after auth-needed cleanup",
+			tokenDeleteErr: tokenErr,
+			expectedErr:    tokenErr,
+		},
+		{
+			name:                "returns auth-needed cleanup error",
+			authNeededDeleteErr: authNeededErr,
+			expectedErr:         authNeededErr,
+		},
+		{
+			name:                "joins both cleanup errors",
+			tokenDeleteErr:      tokenErr,
+			authNeededDeleteErr: authNeededErr,
+			expectedErr:         tokenErr,
+		},
+		{
+			name:        "succeeds when both deletes succeed",
+			expectedErr: nil,
+		},
+	}
 
-	err := manager.DeleteUserToken(userID, serverID)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, mockClient := setupTestOAuthManager(t)
 
-	require.ErrorIs(t, err, authNeededErr)
+			mockClient.On("KVDelete", buildTokenKey(userID, serverID)).
+				Return(tc.tokenDeleteErr).
+				Once()
+			mockClient.On("KVDelete", buildAuthNeededKey(userID, serverID)).
+				Return(tc.authNeededDeleteErr).
+				Once()
+
+			err := manager.DeleteUserToken(userID, serverID)
+
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorIs(t, err, tc.expectedErr)
+			if tc.authNeededDeleteErr != nil {
+				require.ErrorIs(t, err, tc.authNeededDeleteErr)
+			}
+		})
+	}
 }
 
 func TestProcessCallback_InvalidSession(t *testing.T) {

--- a/mcp/oauth_manager_test.go
+++ b/mcp/oauth_manager_test.go
@@ -320,6 +320,47 @@ func TestStaticCredsHelpers(t *testing.T) {
 	}
 }
 
+func TestOAuthNeededStateLifecycle(t *testing.T) {
+	manager, mockClient := setupTestOAuthManager(t)
+
+	const userID = "user123"
+	const serverID = "GitHub"
+	const authURL = "https://mattermost.example.com/plugins/mattermost-ai/mcp/oauth/GitHub/start?resource_metadata=https%3A%2F%2Fapi.githubcopilot.com%2F.well-known%2Foauth-protected-resource%2Fmcp"
+
+	mockClient.On("KVSetWithExpiry", buildAuthNeededKey(userID, serverID), mock.AnythingOfType("*mcp.OAuthNeededState"), oauthNeededStateTTL).
+		Run(func(args mock.Arguments) {
+			state := args.Get(1).(*OAuthNeededState)
+			require.Equal(t, authURL, state.AuthURL)
+			require.False(t, state.SeenAt.IsZero())
+		}).
+		Return(nil).
+		Once()
+
+	require.NoError(t, manager.StoreAuthNeededState(userID, serverID, authURL))
+
+	mockClient.On("KVGet", buildAuthNeededKey(userID, serverID), mock.AnythingOfType("*mcp.OAuthNeededState")).
+		Run(func(args mock.Arguments) {
+			state := args.Get(1).(*OAuthNeededState)
+			*state = OAuthNeededState{
+				AuthURL: authURL,
+				SeenAt:  time.Now(),
+			}
+		}).
+		Return(nil).
+		Once()
+
+	state, err := manager.LoadAuthNeededState(userID, serverID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, authURL, state.AuthURL)
+
+	mockClient.On("KVDelete", buildAuthNeededKey(userID, serverID)).
+		Return(nil).
+		Once()
+
+	require.NoError(t, manager.DeleteAuthNeededState(userID, serverID))
+}
+
 func TestProcessCallback_InvalidSession(t *testing.T) {
 	manager, mockClient := setupTestOAuthManager(t)
 

--- a/mcp/oauth_manager_test.go
+++ b/mcp/oauth_manager_test.go
@@ -361,6 +361,44 @@ func TestOAuthNeededStateLifecycle(t *testing.T) {
 	require.NoError(t, manager.DeleteAuthNeededState(userID, serverID))
 }
 
+func TestDeleteUserTokenAttemptsAuthNeededCleanupWhenTokenDeleteFails(t *testing.T) {
+	manager, mockClient := setupTestOAuthManager(t)
+
+	const userID = "user123"
+	const serverID = "GitHub"
+	tokenErr := model.NewAppError("test", "token_delete_failed", nil, "token delete failed", http.StatusInternalServerError)
+
+	mockClient.On("KVDelete", buildTokenKey(userID, serverID)).
+		Return(tokenErr).
+		Once()
+	mockClient.On("KVDelete", buildAuthNeededKey(userID, serverID)).
+		Return(nil).
+		Once()
+
+	err := manager.DeleteUserToken(userID, serverID)
+
+	require.ErrorIs(t, err, tokenErr)
+}
+
+func TestDeleteUserTokenReturnsAuthNeededCleanupError(t *testing.T) {
+	manager, mockClient := setupTestOAuthManager(t)
+
+	const userID = "user123"
+	const serverID = "GitHub"
+	authNeededErr := model.NewAppError("test", "auth_needed_delete_failed", nil, "auth-needed delete failed", http.StatusInternalServerError)
+
+	mockClient.On("KVDelete", buildTokenKey(userID, serverID)).
+		Return(nil).
+		Once()
+	mockClient.On("KVDelete", buildAuthNeededKey(userID, serverID)).
+		Return(authNeededErr).
+		Once()
+
+	err := manager.DeleteUserToken(userID, serverID)
+
+	require.ErrorIs(t, err, authNeededErr)
+}
+
 func TestProcessCallback_InvalidSession(t *testing.T) {
 	manager, mockClient := setupTestOAuthManager(t)
 
@@ -450,6 +488,87 @@ func TestProcessCallback_UserIDValidation(t *testing.T) {
 	require.Contains(t, err.Error(), correctUserID)
 	require.Contains(t, err.Error(), wrongUserID)
 	mockClient.AssertCalled(t, "KVDelete", mock.AnythingOfType("string"))
+}
+
+func TestProcessCallbackReturnsSessionWhenAuthNeededCleanupFails(t *testing.T) {
+	userID := "user123"
+	serverID := "server456"
+	state := "test-state"
+	code := "auth-code"
+
+	var authServer *httptest.Server
+	authServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource":
+			http.NotFound(w, r)
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+				Issuer:                authServer.URL,
+				AuthorizationEndpoint: authServer.URL + "/authorize",
+				TokenEndpoint:         authServer.URL + "/token",
+			}))
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer authServer.Close()
+
+	lookup := func(id string) (ServerConfig, bool) {
+		if id == serverID {
+			return ServerConfig{
+				Name:         serverID,
+				BaseURL:      authServer.URL,
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			}, true
+		}
+		return ServerConfig{}, false
+	}
+	manager, mockClient := setupTestOAuthManagerFull(t, lookup, authServer.Client())
+
+	session := &OAuthSession{
+		UserID:         userID,
+		ServerID:       serverID,
+		ServerURL:      authServer.URL,
+		CodeVerifier:   "test-verifier",
+		State:          state,
+		StaticClientID: "client-id",
+		CreatedAt:      time.Now(),
+	}
+	clearErr := model.NewAppError("test", "auth_needed_delete_failed", nil, "auth-needed delete failed", http.StatusInternalServerError)
+
+	mockClient.On("KVGet", buildSessionKey(userID, state), mock.AnythingOfType("*mcp.OAuthSession")).
+		Run(func(args mock.Arguments) {
+			sess := args.Get(1).(*OAuthSession)
+			*sess = *session
+		}).
+		Return(nil).
+		Once()
+	mockClient.On("KVSet", buildTokenKey(userID, serverID), mock.Anything).
+		Return(nil).
+		Once()
+	mockClient.On("KVDelete", buildAuthNeededKey(userID, serverID)).
+		Return(clearErr).
+		Once()
+	mockClient.On("KVDelete", buildSessionKey(userID, state)).
+		Return(nil).
+		Once()
+	mockClient.On("LogWarn", "Failed to clear OAuth-needed state after successful callback", mock.Anything).
+		Return().
+		Once()
+
+	gotSession, err := manager.ProcessCallback(context.Background(), userID, state, code)
+
+	require.NoError(t, err)
+	require.Equal(t, session, gotSession)
 }
 
 func TestProcessCallback_RederivesStaticCredsFromConfig(t *testing.T) {

--- a/mcp/oauth_store.go
+++ b/mcp/oauth_store.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -136,13 +137,9 @@ func (m *OAuthManager) deleteToken(userID, serverID string) error {
 // DeleteUserToken removes the stored OAuth token for a user and server,
 // effectively disconnecting the user from that MCP server.
 func (m *OAuthManager) DeleteUserToken(userID, serverID string) error {
-	if err := m.deleteToken(userID, serverID); err != nil {
-		return err
-	}
-	if err := m.DeleteAuthNeededState(userID, serverID); err != nil {
-		return err
-	}
-	return nil
+	tokenErr := m.deleteToken(userID, serverID)
+	authNeededErr := m.DeleteAuthNeededState(userID, serverID)
+	return errors.Join(tokenErr, authNeededErr)
 }
 
 type ClientCredentials struct {

--- a/mcp/oauth_store.go
+++ b/mcp/oauth_store.go
@@ -31,6 +31,16 @@ func buildTokenKey(userID, serverID string) string {
 	return fmt.Sprintf("%s_%s_%s", prefix, userID, serverID)
 }
 
+func buildAuthNeededKey(userID, serverID string) string {
+	prefix := "mcp_oauth_needed_v1"
+	return fmt.Sprintf("%s_%s_%s", prefix, userID, serverID)
+}
+
+type OAuthNeededState struct {
+	AuthURL string    `json:"authURL"`
+	SeenAt  time.Time `json:"seenAt"`
+}
+
 // loadToken retrieves the OAuth token for a user and server from the KV store
 // If no token is found, it returns nil to indicate no token exists
 func (m *OAuthManager) loadToken(userID, serverID string) (*oauth2.Token, error) {
@@ -65,6 +75,46 @@ func (m *OAuthManager) HasStoredToken(userID, serverID string) (bool, error) {
 	return true, nil
 }
 
+const oauthNeededStateTTL = 24 * time.Hour
+
+func (m *OAuthManager) LoadAuthNeededState(userID, serverID string) (*OAuthNeededState, error) {
+	authNeededKey := buildAuthNeededKey(userID, serverID)
+
+	var state OAuthNeededState
+	err := m.pluginAPI.KVGet(authNeededKey, &state)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve OAuth-needed state from KV store: %w", err)
+	}
+
+	if state.AuthURL == "" {
+		return nil, nil
+	}
+
+	return &state, nil
+}
+
+func (m *OAuthManager) StoreAuthNeededState(userID, serverID, authURL string) error {
+	authNeededKey := buildAuthNeededKey(userID, serverID)
+	state := &OAuthNeededState{
+		AuthURL: authURL,
+		SeenAt:  time.Now(),
+	}
+
+	if err := m.pluginAPI.KVSetWithExpiry(authNeededKey, state, oauthNeededStateTTL); err != nil {
+		return fmt.Errorf("failed to store OAuth-needed state: %w", err)
+	}
+
+	return nil
+}
+
+func (m *OAuthManager) DeleteAuthNeededState(userID, serverID string) error {
+	authNeededKey := buildAuthNeededKey(userID, serverID)
+	if err := m.pluginAPI.KVDelete(authNeededKey); err != nil {
+		return fmt.Errorf("failed to delete OAuth-needed state: %w", err)
+	}
+	return nil
+}
+
 func (m *OAuthManager) storeToken(userID, serverID string, token *oauth2.Token) error {
 	tokenKey := buildTokenKey(userID, serverID)
 
@@ -86,7 +136,13 @@ func (m *OAuthManager) deleteToken(userID, serverID string) error {
 // DeleteUserToken removes the stored OAuth token for a user and server,
 // effectively disconnecting the user from that MCP server.
 func (m *OAuthManager) DeleteUserToken(userID, serverID string) error {
-	return m.deleteToken(userID, serverID)
+	if err := m.deleteToken(userID, serverID); err != nil {
+		return err
+	}
+	if err := m.DeleteAuthNeededState(userID, serverID); err != nil {
+		return err
+	}
+	return nil
 }
 
 type ClientCredentials struct {

--- a/mcp/user_clients.go
+++ b/mcp/user_clients.go
@@ -261,7 +261,7 @@ func (c *UserClients) createToolResolver(client *Client, toolName string) func(l
 		result, err := client.CallToolWithMetadata(context.Background(), toolName, args, metadata)
 		if err != nil {
 			c.rememberOAuthNeededForToolCall(client, err)
-			return "", err
+			return result, err
 		}
 
 		c.clearOAuthNeededForServer(client)

--- a/mcp/user_clients.go
+++ b/mcp/user_clients.go
@@ -204,6 +204,49 @@ func (c *UserClients) prepareToolCallMetadata(client *Client, llmContext *llm.Co
 	return metadata
 }
 
+func (c *UserClients) clearOAuthNeededForServer(client *Client) {
+	if c.oauthManager == nil || client == nil || client.config.Name == "" {
+		return
+	}
+	if err := c.oauthManager.DeleteAuthNeededState(c.userID, client.config.Name); err != nil {
+		c.log.Debug("Failed to clear MCP OAuth-needed state after successful tool call",
+			"userID", c.userID,
+			"serverID", client.config.Name,
+			"error", err)
+	}
+}
+
+func (c *UserClients) rememberOAuthNeededForToolCall(client *Client, err error) {
+	if c.oauthManager == nil || client == nil || client.config.Name == "" || err == nil {
+		return
+	}
+
+	oauthErr := client.oauthNeededError(err)
+	if oauthErr == nil {
+		return
+	}
+
+	var needed *OAuthNeededError
+	if !errors.As(oauthErr, &needed) {
+		return
+	}
+
+	authURL := needed.AuthURL()
+	if authURL == "" {
+		authURL = c.oauthManager.StartURL(client.config.Name)
+	}
+	if authURL == "" {
+		return
+	}
+
+	if storeErr := c.oauthManager.StoreAuthNeededState(c.userID, client.config.Name, authURL); storeErr != nil {
+		c.log.Warn("Failed to persist MCP OAuth-needed state after tool call",
+			"userID", c.userID,
+			"serverID", client.config.Name,
+			"error", storeErr)
+	}
+}
+
 // createToolResolver creates a resolver function for the given tool
 func (c *UserClients) createToolResolver(client *Client, toolName string) func(llmContext *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
 	return func(llmContext *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
@@ -215,6 +258,13 @@ func (c *UserClients) createToolResolver(client *Client, toolName string) func(l
 		// Prepare metadata for the tool call
 		metadata := c.prepareToolCallMetadata(client, llmContext)
 
-		return client.CallToolWithMetadata(context.Background(), toolName, args, metadata)
+		result, err := client.CallToolWithMetadata(context.Background(), toolName, args, metadata)
+		if err != nil {
+			c.rememberOAuthNeededForToolCall(client, err)
+			return "", err
+		}
+
+		c.clearOAuthNeededForServer(client)
+		return result, nil
 	}
 }

--- a/server/cluster_events.go
+++ b/server/cluster_events.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"encoding/json"
+
 	"github.com/mattermost/mattermost-plugin-agents/api"
 	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -12,6 +14,11 @@ import (
 
 const clusterEventConfigUpdate = "config_update"
 const clusterEventAgentUpdate = "agent_update"
+const clusterEventMCPOAuthUserInvalidate = "mcp_oauth_user_invalidate"
+
+type mcpOAuthUserInvalidateClusterPayload struct {
+	UserID string `json:"userID"`
+}
 
 func (p *Plugin) publishClusterEvent(eventID string) error {
 	ev := model.PluginClusterEvent{Id: eventID}
@@ -35,6 +42,27 @@ func (p *Plugin) PublishAgentUpdate() error {
 	return p.publishClusterEvent(clusterEventAgentUpdate)
 }
 
+// PublishMCPOAuthUpdate broadcasts a per-user MCP OAuth cache invalidation to all other nodes.
+func (p *Plugin) PublishMCPOAuthUpdate(userID string) error {
+	payload, err := json.Marshal(mcpOAuthUserInvalidateClusterPayload{UserID: userID})
+	if err != nil {
+		return err
+	}
+
+	ev := model.PluginClusterEvent{
+		Id:   clusterEventMCPOAuthUserInvalidate,
+		Data: payload,
+	}
+	opts := model.PluginClusterEventSendOptions{
+		SendType: model.PluginClusterEventSendTypeReliable,
+	}
+	if err := p.API.PublishPluginClusterEvent(ev, opts); err != nil {
+		p.pluginAPI.Log.Error("Failed to publish cluster event", "event", clusterEventMCPOAuthUserInvalidate, "error", err.Error())
+		return err
+	}
+	return nil
+}
+
 // OnPluginClusterEvent handles cluster events from other nodes.
 func (p *Plugin) OnPluginClusterEvent(_ *plugin.Context, ev model.PluginClusterEvent) {
 	switch ev.Id {
@@ -56,5 +84,19 @@ func (p *Plugin) OnPluginClusterEvent(_ *plugin.Context, ev model.PluginClusterE
 		}
 		// Clients connected to this node need the same RHS cache invalidation as on the originating node.
 		mmapi.NewClient(p.pluginAPI).PublishWebSocketEvent(api.WebsocketEventBotsInvalidate, map[string]interface{}{}, &model.WebsocketBroadcast{})
+
+	case clusterEventMCPOAuthUserInvalidate:
+		var payload mcpOAuthUserInvalidateClusterPayload
+		if err := json.Unmarshal(ev.Data, &payload); err != nil {
+			p.pluginAPI.Log.Error("Failed to unmarshal MCP OAuth cluster invalidation payload", "error", err.Error())
+			return
+		}
+		if payload.UserID == "" {
+			p.pluginAPI.Log.Error("Received MCP OAuth cluster invalidation with empty userID")
+			return
+		}
+		if p.mcpClientManager != nil {
+			p.mcpClientManager.InvalidateUserClients(payload.UserID)
+		}
 	}
 }

--- a/server/cluster_events.go
+++ b/server/cluster_events.go
@@ -44,6 +44,10 @@ func (p *Plugin) PublishAgentUpdate() error {
 
 // PublishMCPOAuthUpdate broadcasts a per-user MCP OAuth cache invalidation to all other nodes.
 func (p *Plugin) PublishMCPOAuthUpdate(userID string) error {
+	if userID == "" {
+		return nil
+	}
+
 	payload, err := json.Marshal(mcpOAuthUserInvalidateClusterPayload{UserID: userID})
 	if err != nil {
 		return err

--- a/server/main.go
+++ b/server/main.go
@@ -502,6 +502,7 @@ func (p *Plugin) OnActivate() error {
 		&p.configuration,
 		p,
 		p,
+		p,
 		p.store,
 		getSearchInitError,
 		customPromptsStore,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
This change fixes MCP providers getting stuck in a toggle-only state after tools were discovered or cached even though the upstream server later required OAuth for tool calls. The backend now persists call-time OAuth-needed state, invalidates cached per-user clients when that happens, and makes `GET /mcp/tools` prefer that reconnect-required state over stale discovered tools so the webapp can show **Connect** again.

It also clears that persisted state after a successful OAuth callback, a successful tool call, or an explicit disconnect.

This PR also fixes HA behavior for MCP OAuth connection changes. OAuth tokens and OAuth-needed state are shared through plugin KV, but each app node keeps its own in-memory MCP client cache. Successful OAuth callbacks and explicit disconnects now publish a reliable cluster event so peer nodes invalidate the affected user's cached MCP clients and rebuild from KV on the next request. That keeps the MCP settings UI, tool provider popover, and chat tool loading from flip-flopping between connected and disconnected depending on which node handles the request.

#### Ticket Link
NONE

#### Screenshots
NONE

#### Release Note
```release-note
Fixed MCP provider connection state so servers that expose tools but later require OAuth no longer get stuck in a toggle-only state, and fixed HA OAuth state propagation so MCP connection changes are reflected consistently across cluster nodes.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1870b03f-5f79-4c04-b2f4-5ae049175f51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1870b03f-5f79-4c04-b2f4-5ae049175f51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent per-user/per-server tracking when MCP servers require OAuth, with cluster-wide invalidation notifications to keep nodes in sync.
  * API now emits per-user MCP OAuth invalidation updates on disconnects and callback completion.

* **Bug Fixes**
  * Auth URL and "Needs OAuth" responses now consider persisted OAuth-needed state and prefer persisted URLs when appropriate.
  * OAuth-needed state cleared after successful callback; cleanup failures log warnings without breaking flow.
  * Improved client-cache invalidation and activity tracking for more reliable tool discovery.

* **Tests**
  * Expanded tests for OAuth-needed lifecycle, notifications, cache invalidation, callback flows, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->