### PR TITLE
Fix Agents RHS drag-and-drop isolation

### DIFF
--- a/webapp/src/components/rhs/rhs_new_tab.tsx
+++ b/webapp/src/components/rhs/rhs_new_tab.tsx
@@ -112,22 +112,7 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
                 <FormattedMessage defaultMessage='Setting up chat channel...'/>
             </div>
         );
-    } else if (AdvancedTextEditor) {
-        editorComponent = (
-            <AdvancedTextEditor
-                channelId={botChannelId}
-                placeholder={intl.formatMessage({defaultMessage: 'Ask Agents anything...'})}
-                isThreadView={true}
-                location={'RHS_COMMENT'}
-                afterSubmit={(result: {created?: {id: string}}) => {
-                    if (result.created?.id) {
-                        selectPost(result.created?.id);
-                        setCurrentTab('thread');
-                    }
-                }}
-            />
-        );
-    } else {
+    } else if (CreatePost) {
         editorComponent = (
             <CreatePost
                 channelId={botChannelId}
@@ -166,6 +151,27 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
                 }}
             />
         );
+    } else if (AdvancedTextEditor) {
+        // Prefer the plugin-scoped CreatePost wrapper when available. The generic
+        // AdvancedTextEditor registers file drop handlers as a center-post composer
+        // when no real rootId exists, which causes uploads dropped into the center
+        // channel to also attach to the Agents RHS draft.
+        editorComponent = (
+            <AdvancedTextEditor
+                channelId={botChannelId}
+                placeholder={intl.formatMessage({defaultMessage: 'Ask Agents anything...'})}
+                isThreadView={true}
+                location={'RHS_COMMENT'}
+                afterSubmit={(result: {created?: {id: string}}) => {
+                    if (result.created?.id) {
+                        selectPost(result.created?.id);
+                        setCurrentTab('thread');
+                    }
+                }}
+            />
+        );
+    } else {
+        editorComponent = null;
     }
 
     return (

--- a/webapp/src/components/rhs/rhs_new_tab.tsx
+++ b/webapp/src/components/rhs/rhs_new_tab.tsx
@@ -46,6 +46,7 @@ type Props = {
 }
 
 const EMPTY_BOTS: LLMBot[] = [];
+const EMPTY_RHS_DRAFT = {message: '', fileInfos: [], uploadsInProgress: []};
 
 const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
     const intl = useIntl();
@@ -61,6 +62,7 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
 
     // State for error handling
     const [channelError, setChannelError] = useState(false);
+    const [submitError, setSubmitError] = useState('');
 
     // If botChannelId is empty, we need to create a direct channel
     useEffect(() => {
@@ -119,24 +121,32 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
                 placeholder={intl.formatMessage({defaultMessage: 'Ask Agents anything...'})}
                 rootId={'ai_agents'}
                 onSubmit={async (p: any) => {
-                    const post = {...p};
-                    post.channel_id = botChannelId || '';
-                    post.props = {};
-                    post.uploadsInProgress = [];
-                    post.file_ids = p.fileInfos.map((f: any) => f.id);
-                    const created = await createPost(post);
-                    selectPost(created.id);
-                    setCurrentTab('thread');
-                    dispatch({
-                        type: 'SET_GLOBAL_ITEM',
-                        data: {
-                            name: 'comment_draft_ai_agents',
-                            value: {message: '', fileInfos: [], uploadsInProgress: []},
-                        },
-                    });
+                    try {
+                        const post = {...p};
+                        post.channel_id = botChannelId || '';
+                        post.props = {};
+                        post.uploadsInProgress = [];
+                        post.file_ids = p.fileInfos.map((f: any) => f.id);
+                        const created = await createPost(post);
+                        setSubmitError('');
+                        updateDraft(EMPTY_RHS_DRAFT);
+                        selectPost(created.id);
+                        setCurrentTab('thread');
+                        dispatch({
+                            type: 'SET_GLOBAL_ITEM',
+                            data: {
+                                name: 'comment_draft_ai_agents',
+                                value: EMPTY_RHS_DRAFT,
+                            },
+                        });
+                    } catch (e) {
+                        console.error('Failed to create Agents RHS post:', e); // eslint-disable-line no-console
+                        setSubmitError(intl.formatMessage({defaultMessage: 'Failed to send message. Please try again.'}));
+                    }
                 }}
                 draft={draft}
                 onUpdateCommentDraft={(newDraft: any) => {
+                    setSubmitError('');
                     updateDraft(newDraft);
                     const timestamp = new Date().getTime();
                     newDraft.updateAt = timestamp;
@@ -186,6 +196,11 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
                         selectPost={selectPost}
                         setCurrentTab={setCurrentTab}
                     />
+                )}
+                {submitError && (
+                    <div style={{textAlign: 'center', padding: '0 0 12px', color: 'var(--error-text)'}}>
+                        {submitError}
+                    </div>
                 )}
                 <CreatePostContainer
                     data-testid='rhs-new-tab-create-post'

--- a/webapp/src/components/rhs/rhs_new_tab.tsx
+++ b/webapp/src/components/rhs/rhs_new_tab.tsx
@@ -39,19 +39,43 @@ const ReverseScroll = styled.div`
 	justify-content: flex-end;
 `;
 
+const SubmitErrorBanner = styled.div`
+    text-align: center;
+    padding: 0 0 12px;
+    color: var(--error-text);
+`;
+
 type Props = {
     selectPost: (postId: string) => void
     setCurrentTab: (tab: string) => void
     activeBot: LLMBot | null
 }
 
+type RHSDraftFileInfo = {
+    id: string;
+}
+
+type RHSDraft = {
+    message: string;
+    fileInfos: RHSDraftFileInfo[];
+    uploadsInProgress: string[];
+    updateAt?: number;
+    createAt?: number;
+}
+
+type RHSSubmitPost = RHSDraft & {
+    channel_id: string;
+    props: Record<string, unknown>;
+    file_ids: string[];
+}
+
 const EMPTY_BOTS: LLMBot[] = [];
-const EMPTY_RHS_DRAFT = {message: '', fileInfos: [], uploadsInProgress: []};
+const EMPTY_RHS_DRAFT: RHSDraft = {message: '', fileInfos: [], uploadsInProgress: []};
 
 const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
     const intl = useIntl();
     const dispatch = useDispatch();
-    const [draft, updateDraft] = useState<any>(null);
+    const [draft, updateDraft] = useState<RHSDraft | null>(null);
     const [creatingChannel, setCreatingChannel] = useState(false);
     const currentUserId = useSelector((state: any) => state.entities.users.currentUserId);
     const botChannelId = activeBot?.dmChannelID || '';
@@ -120,13 +144,19 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
                 channelId={botChannelId}
                 placeholder={intl.formatMessage({defaultMessage: 'Ask Agents anything...'})}
                 rootId={'ai_agents'}
-                onSubmit={async (p: any) => {
+                onSubmit={async (p: RHSDraft) => {
                     try {
-                        const post = {...p};
+                        const fileInfos = Array.isArray(p.fileInfos) ? p.fileInfos : [];
+                        const post: RHSSubmitPost = {
+                            ...p,
+                            channel_id: botChannelId || '',
+                            props: {},
+                            file_ids: [],
+                        };
                         post.channel_id = botChannelId || '';
                         post.props = {};
                         post.uploadsInProgress = [];
-                        post.file_ids = p.fileInfos.map((f: any) => f.id);
+                        post.file_ids = fileInfos.map((f) => f.id);
                         const created = await createPost(post);
                         setSubmitError('');
                         updateDraft(EMPTY_RHS_DRAFT);
@@ -145,7 +175,7 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
                     }
                 }}
                 draft={draft}
-                onUpdateCommentDraft={(newDraft: any) => {
+                onUpdateCommentDraft={(newDraft: RHSDraft) => {
                     setSubmitError('');
                     updateDraft(newDraft);
                     const timestamp = new Date().getTime();
@@ -198,9 +228,9 @@ const RHSNewTab = ({selectPost, setCurrentTab, activeBot}: Props) => {
                     />
                 )}
                 {submitError && (
-                    <div style={{textAlign: 'center', padding: '0 0 12px', color: 'var(--error-text)'}}>
+                    <SubmitErrorBanner>
                         {submitError}
-                    </div>
+                    </SubmitErrorBanner>
                 )}
                 <CreatePostContainer
                     data-testid='rhs-new-tab-create-post'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Fixes the Agents RHS composer to prefer Mattermost's plugin-scoped `CreatePost` wrapper so file drag-and-drop stays isolated from the center channel composer. Also clears the local controlled draft after successful submit, surfaces a retryable inline error if custom RHS post creation fails, and tightens the RHS draft typing/submit guarding so missing `fileInfos` cannot crash submit.

#### Ticket Link
NONE

#### Screenshots
A real desktop drag-and-drop walkthrough was attempted in the local Mattermost environment, but the available desktop automation could not complete a reliable cross-window OS drag gesture, so no user-facing artifact was attached.

#### Release Note
```release-note
Fixed a bug where dragging a file into the center channel while the Agents RHS was open could also attach that file to the Agents composer.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f72a895-0ab9-42de-a0e8-cab1245f4d62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f72a895-0ab9-42de-a0e8-cab1245f4d62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Prioritised the newer post editor and improved fallback to the legacy editor or no-editor state for a more consistent experience.
  * Improved draft handling to persist updates reliably and reset drafts after successful submission.

* **Bug Fixes**
  * Added a visible submit error banner and clearer error clearing to reduce confusion after failed submissions.
  * Ensured posts are selected and the thread view is opened after successful submissions; handled file and upload state correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->