### PR TITLE
Fix dropped image and file attachments in LLM requests

### DIFF
--- a/bots/bots.go
+++ b/bots/bots.go
@@ -554,10 +554,8 @@ func (b *MMBots) GetBotByID(botID string) *Bot {
 	return nil
 }
 
-// GetBotConfigByID returns the EnableVision and MaxFileSize attachment-handling
-// settings for the given bot ID, with ok=false when no bot has that ID. This
-// is used by the conversation service to lazy-resolve image and file content
-// blocks at LLM-request build time.
+// GetBotConfigByID returns the bot's EnableVision and MaxFileSize. ok is
+// false when botID is unknown.
 func (b *MMBots) GetBotConfigByID(botID string) (bool, int64, bool) {
 	bot := b.GetBotByID(botID)
 	if bot == nil {

--- a/bots/bots.go
+++ b/bots/bots.go
@@ -554,6 +554,19 @@ func (b *MMBots) GetBotByID(botID string) *Bot {
 	return nil
 }
 
+// GetBotConfigByID returns the EnableVision and MaxFileSize attachment-handling
+// settings for the given bot ID, with ok=false when no bot has that ID. This
+// is used by the conversation service to lazy-resolve image and file content
+// blocks at LLM-request build time.
+func (b *MMBots) GetBotConfigByID(botID string) (bool, int64, bool) {
+	bot := b.GetBotByID(botID)
+	if bot == nil {
+		return false, 0, false
+	}
+	cfg := bot.GetConfig()
+	return cfg.EnableVision, cfg.MaxFileSize, true
+}
+
 // GetBotForDMChannel returns the bot for the given DM channel.
 func (b *MMBots) GetBotForDMChannel(channel *model.Channel) *Bot {
 	b.botsLock.RLock()

--- a/channels/analysis_conversation_test.go
+++ b/channels/analysis_conversation_test.go
@@ -131,6 +131,10 @@ func (b *testBotLookup) IsAnyBot(userID string) bool {
 	return b.botUserIDs[userID]
 }
 
+func (b *testBotLookup) GetBotConfigByID(string) (bool, int64, bool) {
+	return false, 0, false
+}
+
 // fakeLLM implements llm.LanguageModel for tests. It returns a sequence of
 // pre-configured streams, one per call to ChatCompletion.
 type fakeLLM struct {

--- a/channels/channels_eval_test.go
+++ b/channels/channels_eval_test.go
@@ -217,6 +217,10 @@ func (b *evalBotLookup) IsAnyBot(userID string) bool {
 	return b.botUserIDs[userID]
 }
 
+func (b *evalBotLookup) GetBotConfigByID(string) (bool, int64, bool) {
+	return false, 0, false
+}
+
 func setupChannelMocksFromThreadData(mmClient *mocks.MockClient, threadData *evals.ThreadExport) {
 	// Mock posts retrieval - return the thread data as channel posts
 	mmClient.On("GetPostsSince", threadData.Channel.Id, fixedStart).Return(threadData.PostList, nil)

--- a/conversation/convert.go
+++ b/conversation/convert.go
@@ -12,9 +12,6 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 )
 
-// DefaultMaxFileSize is the fallback cap for text-content reads when a bot's
-// MaxFileSize config is unset or non-positive. Matches the pre-refactor
-// constant from conversations/conversations.go.
 const DefaultMaxFileSize = int64(5 * 1024 * 1024)
 
 // UnsharedToolResultRedaction replaces tool_result content the requester has
@@ -32,12 +29,6 @@ var unsharedToolUseArgumentsRedaction = json.RawMessage("{}")
 // true is replaced with UnsharedToolResultRedaction, and tool_use arguments
 // whose Shared flag is not true are replaced with an empty JSON object so the
 // LLM cannot paraphrase private tool parameters into a channel-visible reply.
-//
-// mmClient is used to lazily resolve image and file blocks back into
-// llm.Post.Files / llm.Post.Message at request-build time. enableVision gates
-// whether image blocks are sent at all. maxFileSize caps text-content reads
-// (DefaultMaxFileSize when <= 0). mmClient may be nil only when blocks contain
-// no file or image entries.
 func BlocksToPost(
 	blocks []ContentBlock,
 	role string,

--- a/conversation/convert.go
+++ b/conversation/convert.go
@@ -5,10 +5,17 @@ package conversation
 
 import (
 	"encoding/json"
+	"io"
 	"strings"
 
 	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 )
+
+// DefaultMaxFileSize is the fallback cap for text-content reads when a bot's
+// MaxFileSize config is unset or non-positive. Matches the pre-refactor
+// constant from conversations/conversations.go.
+const DefaultMaxFileSize = int64(5 * 1024 * 1024)
 
 // UnsharedToolResultRedaction replaces tool_result content the requester has
 // not shared, preserving the tool_use/tool_result pairing required by LLM
@@ -25,12 +32,31 @@ var unsharedToolUseArgumentsRedaction = json.RawMessage("{}")
 // true is replaced with UnsharedToolResultRedaction, and tool_use arguments
 // whose Shared flag is not true are replaced with an empty JSON object so the
 // LLM cannot paraphrase private tool parameters into a channel-visible reply.
-func BlocksToPost(blocks []ContentBlock, role string, redactUnshared bool) llm.Post {
+//
+// mmClient is used to lazily resolve image and file blocks back into
+// llm.Post.Files / llm.Post.Message at request-build time. enableVision gates
+// whether image blocks are sent at all. maxFileSize caps text-content reads
+// (DefaultMaxFileSize when <= 0). mmClient may be nil only when blocks contain
+// no file or image entries.
+func BlocksToPost(
+	blocks []ContentBlock,
+	role string,
+	redactUnshared bool,
+	mmClient mmapi.Client,
+	enableVision bool,
+	maxFileSize int64,
+) llm.Post {
 	post := llm.Post{
 		Role: RoleFromString(role),
 	}
 
+	effectiveMax := maxFileSize
+	if effectiveMax <= 0 {
+		effectiveMax = DefaultMaxFileSize
+	}
+
 	var textParts []string
+	var fileContents []string
 
 	for _, block := range blocks {
 		switch block.Type {
@@ -76,13 +102,76 @@ func BlocksToPost(blocks []ContentBlock, role string, redactUnshared bool) llm.P
 				})
 			}
 
-		case BlockTypeFile, BlockTypeImage, BlockTypeAnnotations:
+		case BlockTypeImage:
+			if !enableVision {
+				continue
+			}
+			if mmClient == nil {
+				continue
+			}
+			fileInfo, err := mmClient.GetFileInfo(block.FileID)
+			if err != nil {
+				mmClient.LogError("failed to get file info for image attachment", "error", err)
+				continue
+			}
+			reader, err := mmClient.GetFile(block.FileID)
+			if err != nil {
+				mmClient.LogError("failed to get file for image attachment", "error", err)
+				continue
+			}
+			post.Files = append(post.Files, llm.File{
+				MimeType: fileInfo.MimeType,
+				Size:     fileInfo.Size,
+				Reader:   reader,
+			})
+
+		case BlockTypeFile:
+			if mmClient == nil {
+				continue
+			}
+			fileInfo, err := mmClient.GetFileInfo(block.FileID)
+			if err != nil {
+				mmClient.LogError("failed to get file info for file attachment", "error", err)
+				continue
+			}
+
+			var content string
+			if trimmed := strings.TrimSpace(fileInfo.Content); trimmed != "" {
+				if int64(len(trimmed)) >= effectiveMax {
+					trimmed = trimmed[:effectiveMax] + "\n... (content truncated due to size limit)"
+				}
+				content = trimmed
+			} else if strings.HasPrefix(fileInfo.MimeType, "text/") {
+				reader, err := mmClient.GetFile(block.FileID)
+				if err != nil {
+					mmClient.LogError("failed to get file for file attachment", "error", err)
+					continue
+				}
+				body, err := io.ReadAll(io.LimitReader(reader, effectiveMax))
+				if err != nil {
+					mmClient.LogError("failed to read file content", "error", err)
+					continue
+				}
+				content = string(body)
+				if int64(len(body)) >= effectiveMax {
+					content += "\n... (content truncated due to size limit)"
+				}
+			} else {
+				continue
+			}
+
+			fileContents = append(fileContents, "File Name: "+fileInfo.Name+"\nContent: "+content)
+
+		case BlockTypeAnnotations:
 			// Not mapped to llm.Post
 		}
 	}
 
 	if len(textParts) > 0 {
 		post.Message = strings.Join(textParts, "\n")
+	}
+	if len(fileContents) > 0 {
+		post.Message += "\nAttached File Contents:\n" + strings.Join(fileContents, "\n\n")
 	}
 
 	return post

--- a/conversation/convert_test.go
+++ b/conversation/convert_test.go
@@ -5,10 +5,16 @@ package conversation
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost-plugin-agents/llm"
+	mmapimocks "github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,19 +104,11 @@ func TestBlocksToPost(t *testing.T) {
 				ReasoningSignature: "sig2",
 			},
 		},
-		{
-			name: "file and image blocks are skipped",
-			blocks: []ContentBlock{
-				{Type: BlockTypeText, Text: "message"},
-				{Type: BlockTypeFile, Filename: "f.txt", Content: "data"},
-				{Type: BlockTypeImage, FileID: "img1", MimeType: "image/png"},
-			},
-			role: "user",
-			expected: llm.Post{
-				Role:    llm.PostRoleUser,
-				Message: "message",
-			},
-		},
+		// File and image blocks are no longer "skipped"; they lazy-resolve
+		// through mmClient. See TestBlocksToPost_LazyResolvesAttachments
+		// for the new behavior. This case is deliberately removed because
+		// its old expectation (no Files entry) only held while attachments
+		// were broken.
 		{
 			name: "annotations blocks are skipped",
 			blocks: []ContentBlock{
@@ -171,7 +169,7 @@ func TestBlocksToPost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := BlocksToPost(tt.blocks, tt.role, false)
+			result := BlocksToPost(tt.blocks, tt.role, false, nil, false, 0)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -188,7 +186,7 @@ func TestBlocksToPost_RedactUnshared(t *testing.T) {
 	}
 
 	t.Run("redactUnshared=false", func(t *testing.T) {
-		got := BlocksToPost(blocks, "assistant", false)
+		got := BlocksToPost(blocks, "assistant", false, nil, false, 0)
 		require.Len(t, got.ToolUse, 3)
 		results := map[string]string{}
 		args := map[string]string{}
@@ -205,7 +203,7 @@ func TestBlocksToPost_RedactUnshared(t *testing.T) {
 	})
 
 	t.Run("redactUnshared=true", func(t *testing.T) {
-		got := BlocksToPost(blocks, "assistant", true)
+		got := BlocksToPost(blocks, "assistant", true, nil, false, 0)
 		require.Len(t, got.ToolUse, 3)
 		results := map[string]string{}
 		args := map[string]string{}
@@ -445,7 +443,7 @@ func TestPostToBlocksToPostRoundTrip(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			blocks := PostToBlocks(tt.post, tt.shared)
 			role := RoleToString(tt.post.Role)
-			roundTripped := BlocksToPost(blocks, role, false)
+			roundTripped := BlocksToPost(blocks, role, false, nil, false, 0)
 
 			assert.Equal(t, tt.post.Role, roundTripped.Role)
 			assert.Equal(t, tt.post.Message, roundTripped.Message)
@@ -462,4 +460,406 @@ func TestPostToBlocksToPostRoundTrip(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeReadCloser wraps a strings.Reader as io.ReadCloser so the mock GetFile
+// return type matches mmapi.Client.GetFile.
+type fakeReadCloser struct {
+	io.Reader
+}
+
+func (fakeReadCloser) Close() error { return nil }
+
+func newFakeReadCloser(s string) io.ReadCloser {
+	return fakeReadCloser{Reader: strings.NewReader(s)}
+}
+
+// TestBlocksToPost_LazyResolvesAttachments encodes the new desired behavior:
+// file and image content blocks are lazy-resolved through mmClient at the
+// moment we build the LLM request, instead of being inlined when the user
+// turn was first written.
+func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
+	t.Run("image block with EnableVision=true populates Files", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
+			Id:       "img1",
+			Name:     "shot.png",
+			MimeType: "image/png",
+			Size:     1234,
+		}, nil)
+		mmClient.On("GetFile", "img1").Return(newFakeReadCloser("PNGDATA"), nil)
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeImage, FileID: "img1", Filename: "shot.png", MimeType: "image/png"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		require.Len(t, post.Files, 1, "an image block with vision enabled must produce exactly one entry in Post.Files")
+		assert.Equal(t, "image/png", post.Files[0].MimeType)
+		assert.Equal(t, int64(1234), post.Files[0].Size)
+		require.NotNil(t, post.Files[0].Reader)
+
+		// Read the bytes back and pin them to what the mock returned.
+		// Catches a wrong-FileID-resolution bug (e.g. iterating wrong
+		// FileID, returning a stale reader, etc.).
+		bytesBack, readErr := io.ReadAll(post.Files[0].Reader)
+		require.NoError(t, readErr)
+		assert.Equal(t, "PNGDATA", string(bytesBack),
+			"the Reader bound to Post.Files must yield the bytes that mmClient.GetFile returned for that exact FileID")
+	})
+
+	t.Run("image block with EnableVision=false is skipped", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		// No expectations: GetFile/GetFileInfo must NOT be called when
+		// vision is off. mockery will fail the test if either runs.
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeImage, FileID: "img1", Filename: "shot.png", MimeType: "image/png"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, false, 0)
+
+		assert.Empty(t, post.Files, "image block must be silently dropped when vision is disabled")
+	})
+
+	t.Run("text/plain file block reads content via GetFile and appends Attached File Contents", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id:       "doc1",
+			Name:     "foo.txt",
+			MimeType: "text/plain",
+			Size:     11,
+		}, nil)
+		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser("hello world"), nil)
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeText, Text: "look at this"},
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "foo.txt", MimeType: "text/plain"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		assert.Empty(t, post.Files, "non-image text file must NOT go through Post.Files")
+		assert.Contains(t, post.Message, "look at this")
+		assert.Contains(t, post.Message, "\nAttached File Contents:\nFile Name: foo.txt\nContent: hello world")
+	})
+
+	t.Run("file block uses pre-extracted FileInfo.Content without GetFile", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id:       "doc1",
+			Name:     "doc.pdf",
+			MimeType: "application/pdf",
+			Content:  "pre-extracted content",
+		}, nil)
+		// No GetFile expectation — mockery fails if it is called.
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "doc.pdf", MimeType: "application/pdf"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		assert.Contains(t, post.Message, "File Name: doc.pdf")
+		assert.Contains(t, post.Message, "Content: pre-extracted content")
+	})
+
+	t.Run("text/plain file at exactly maxFileSize gets truncation marker", func(t *testing.T) {
+		const cap = int64(8)
+		body := "ABCDEFGH" // exactly 8 bytes
+
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id:       "doc1",
+			Name:     "big.txt",
+			MimeType: "text/plain",
+			Size:     int64(len(body)),
+		}, nil)
+		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser(body), nil)
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "big.txt", MimeType: "text/plain"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, cap)
+
+		assert.Contains(t, post.Message, "... (content truncated due to size limit)",
+			"reading exactly maxFileSize bytes must append the truncation marker so the LLM knows the content was cut")
+	})
+
+	t.Run("non-text non-image MIME with empty Content is skipped without GetFile", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id:       "doc1",
+			Name:     "binary.pdf",
+			MimeType: "application/pdf",
+		}, nil)
+		// No GetFile expectation — mockery fails if it is called.
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeText, Text: "see attached"},
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "binary.pdf", MimeType: "application/pdf"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		assert.Equal(t, "see attached", post.Message,
+			"non-text non-image attachments without pre-extracted Content must be silently skipped")
+	})
+
+	t.Run("multiple mixed blocks: text + image + text/plain file", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
+			Id:       "img1",
+			Name:     "shot.png",
+			MimeType: "image/png",
+			Size:     500,
+		}, nil)
+		mmClient.On("GetFile", "img1").Return(newFakeReadCloser("PNGDATA"), nil)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id:       "doc1",
+			Name:     "foo.txt",
+			MimeType: "text/plain",
+			Size:     5,
+		}, nil)
+		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser("hello"), nil)
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeText, Text: "the text"},
+			{Type: BlockTypeImage, FileID: "img1", Filename: "shot.png", MimeType: "image/png"},
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "foo.txt", MimeType: "text/plain"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		require.Len(t, post.Files, 1, "exactly the image attachment should populate Post.Files")
+		assert.Equal(t, "image/png", post.Files[0].MimeType)
+		assert.Contains(t, post.Message, "the text")
+		assert.Contains(t, post.Message, "Attached File Contents:")
+		assert.Contains(t, post.Message, "File Name: foo.txt")
+		assert.Contains(t, post.Message, "Content: hello")
+
+		// Ordering contract: original user text precedes the
+		// "Attached File Contents:" suffix. Without this ordering,
+		// the LLM would see file content inserted before the user's
+		// own message.
+		idxText := strings.Index(post.Message, "the text")
+		idxAttach := strings.Index(post.Message, "Attached File Contents:")
+		require.NotEqual(t, -1, idxText)
+		require.NotEqual(t, -1, idxAttach)
+		assert.Less(t, idxText, idxAttach,
+			"user text must appear in the message before the Attached File Contents suffix")
+	})
+
+	t.Run("multiple text/plain files appear in input order in the message", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc-a").Return(&model.FileInfo{
+			Id: "doc-a", Name: "a.txt", MimeType: "text/plain", Size: 5,
+		}, nil)
+		mmClient.On("GetFile", "doc-a").Return(newFakeReadCloser("AAAAA"), nil)
+		mmClient.On("GetFileInfo", "doc-b").Return(&model.FileInfo{
+			Id: "doc-b", Name: "b.txt", MimeType: "text/plain", Size: 5,
+		}, nil)
+		mmClient.On("GetFile", "doc-b").Return(newFakeReadCloser("BBBBB"), nil)
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeText, Text: "two attachments"},
+			{Type: BlockTypeFile, FileID: "doc-a", Filename: "a.txt", MimeType: "text/plain"},
+			{Type: BlockTypeFile, FileID: "doc-b", Filename: "b.txt", MimeType: "text/plain"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		idxA := strings.Index(post.Message, "File Name: a.txt")
+		idxB := strings.Index(post.Message, "File Name: b.txt")
+		require.NotEqual(t, -1, idxA, "a.txt must appear in the message")
+		require.NotEqual(t, -1, idxB, "b.txt must appear in the message")
+		assert.Less(t, idxA, idxB,
+			"file blocks must appear in input order in the Attached File Contents suffix")
+	})
+
+	t.Run("GetFile error on image is logged and skipped, conversation continues", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
+			Id:       "img1",
+			Name:     "broken.png",
+			MimeType: "image/png",
+		}, nil)
+		mmClient.On("GetFile", "img1").Return(nil, errors.New("file store offline"))
+		// LogError must actually be invoked — without .Maybe() this fails
+		// if production silently swallows the error (the broken behavior).
+		mmClient.On("LogError", mock.Anything, mock.Anything).Return()
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeText, Text: "still here"},
+			{Type: BlockTypeImage, FileID: "img1", Filename: "broken.png", MimeType: "image/png"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		// Pin that GetFile was actually attempted — production simply
+		// dropping the image without trying to fetch it would still leave
+		// post.Files empty, so the previous broken behavior would pass
+		// without this AssertCalled.
+		mmClient.AssertCalled(t, "GetFile", "img1")
+		assert.Empty(t, post.Files, "GetFile errors must drop the entry, not abort the request")
+		assert.Equal(t, "still here", post.Message,
+			"text content must still appear when an image attachment fails to load")
+	})
+
+	// The maxFileSize=0 → DefaultMaxFileSize boundary trio. We pin the
+	// constant by name so this test has to be updated alongside any change
+	// to DefaultMaxFileSize.
+	t.Run("maxFileSize=0 default: payload of DefaultMaxFileSize-1 bytes has no truncation marker", func(t *testing.T) {
+		body := strings.Repeat("A", int(DefaultMaxFileSize-1))
+
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id: "doc1", Name: "under.txt", MimeType: "text/plain", Size: int64(len(body)),
+		}, nil)
+		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser(body), nil)
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "under.txt", MimeType: "text/plain"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		assert.Contains(t, post.Message, "File Name: under.txt")
+		assert.NotContains(t, post.Message, "content truncated",
+			"a payload of DefaultMaxFileSize-1 bytes must NOT be marked truncated")
+	})
+
+	t.Run("maxFileSize=0 default: payload of exactly DefaultMaxFileSize bytes gets truncation marker", func(t *testing.T) {
+		body := strings.Repeat("A", int(DefaultMaxFileSize))
+
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id: "doc1", Name: "boundary.txt", MimeType: "text/plain", Size: int64(len(body)),
+		}, nil)
+		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser(body), nil)
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "boundary.txt", MimeType: "text/plain"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		assert.Contains(t, post.Message, "... (content truncated due to size limit)",
+			"reading exactly DefaultMaxFileSize bytes must append the truncation marker (LimitReader saw the cap)")
+	})
+
+	t.Run("maxFileSize=0 default: payload of DefaultMaxFileSize+1 bytes gets truncation marker", func(t *testing.T) {
+		body := strings.Repeat("A", int(DefaultMaxFileSize+1))
+
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id: "doc1", Name: "over.txt", MimeType: "text/plain", Size: int64(len(body)),
+		}, nil)
+		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser(body), nil)
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "over.txt", MimeType: "text/plain"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		assert.Contains(t, post.Message, "... (content truncated due to size limit)",
+			"a payload above DefaultMaxFileSize must be truncated with the marker")
+	})
+
+	t.Run("nil mmClient is safe when no file or image blocks are present", func(t *testing.T) {
+		// Documents the zero-config safety guarantee: a turn with only
+		// text/thinking/tool blocks must not panic when mmClient is nil.
+		blocks := []ContentBlock{
+			{Type: BlockTypeText, Text: "hello"},
+			{Type: BlockTypeThinking, Text: "reason", Signature: "sig"},
+			{Type: BlockTypeToolUse, ID: "tc1", Name: "search", Input: json.RawMessage(`{}`), Status: StatusSuccess, Shared: BoolPtr(true)},
+		}
+
+		require.NotPanics(t, func() {
+			post := BlocksToPost(blocks, "assistant", false, nil, false, 0)
+			assert.Equal(t, "hello", post.Message)
+			assert.Equal(t, "reason", post.Reasoning)
+			require.Len(t, post.ToolUse, 1)
+			assert.Equal(t, "tc1", post.ToolUse[0].ID)
+		})
+	})
+
+	t.Run("BlockTypeFile with image/* MIME goes through file path, not image path", func(t *testing.T) {
+		// Dispatch must be by block.Type, not by MimeType — a malformed
+		// block (Type=file but MimeType=image/png) must not be sent to
+		// the LLM as an image. With empty FileInfo.Content and a
+		// non-text MIME, the file-text path skips the block, so GetFile
+		// must NOT be called.
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id: "doc1", Name: "weird.png", MimeType: "image/png",
+		}, nil)
+		// No GetFile expectation — mockery fails the test if production
+		// fetches bytes anyway (which would happen if dispatch went by
+		// MimeType into the image branch).
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeText, Text: "see attached"},
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "weird.png", MimeType: "image/png"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		mmClient.AssertNotCalled(t, "GetFile", "doc1")
+		assert.Empty(t, post.Files,
+			"a BlockTypeFile must never populate Post.Files even when its MimeType says image/*")
+		assert.Equal(t, "see attached", post.Message,
+			"a non-text non-image file block with empty Content must be silently skipped")
+	})
+
+	t.Run("FileInfo.Content non-empty wins over GetFile (explicit AssertNotCalled)", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id: "doc1", Name: "extracted.pdf", MimeType: "application/pdf",
+			Content: "server-extracted text",
+		}, nil)
+		// No GetFile expectation: when fileInfo.Content is non-empty,
+		// the byte fetch must be skipped entirely.
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "extracted.pdf", MimeType: "application/pdf"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		mmClient.AssertNotCalled(t, "GetFile", "doc1",
+			"pre-extracted FileInfo.Content must short-circuit GetFile to avoid a redundant blob read")
+		assert.Contains(t, post.Message, "Content: server-extracted text")
+	})
+
+	t.Run("pre-extracted FileInfo.Content larger than maxFileSize gets truncation marker", func(t *testing.T) {
+		// Mattermost's server-side text extraction is itself bounded, but
+		// a per-bot MaxFileSize lower than the server's cap could be
+		// silently violated by the pre-extracted-content shortcut. Cap it
+		// the same way the GetFile branch does.
+		const cap = int64(8)
+		oversized := strings.Repeat("X", int(cap)+1) // 9 bytes vs cap=8
+
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id: "doc1", Name: "huge.pdf", MimeType: "application/pdf",
+			Content: oversized,
+		}, nil)
+		// GetFile must NOT be called — pre-extracted content path still
+		// short-circuits the byte fetch even when the cap clips it.
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "huge.pdf", MimeType: "application/pdf"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, cap)
+
+		mmClient.AssertNotCalled(t, "GetFile", "doc1",
+			"the pre-extracted-content cap must not trigger a GetFile fetch")
+		assert.Contains(t, post.Message, "... (content truncated due to size limit)",
+			"FileInfo.Content longer than effectiveMax must be truncated with the marker")
+	})
 }

--- a/conversation/convert_test.go
+++ b/conversation/convert_test.go
@@ -566,7 +566,7 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 	})
 
 	t.Run("text/plain file at exactly maxFileSize gets truncation marker", func(t *testing.T) {
-		const cap = int64(8)
+		const maxBytes = int64(8)
 		body := "ABCDEFGH" // exactly 8 bytes
 
 		mmClient := mmapimocks.NewMockClient(t)
@@ -582,7 +582,7 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 			{Type: BlockTypeFile, FileID: "doc1", Filename: "big.txt", MimeType: "text/plain"},
 		}
 
-		post := BlocksToPost(blocks, "user", false, mmClient, true, cap)
+		post := BlocksToPost(blocks, "user", false, mmClient, true, maxBytes)
 
 		assert.Contains(t, post.Message, "... (content truncated due to size limit)",
 			"reading exactly maxFileSize bytes must append the truncation marker so the LLM knows the content was cut")
@@ -840,8 +840,8 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 		// a per-bot MaxFileSize lower than the server's cap could be
 		// silently violated by the pre-extracted-content shortcut. Cap it
 		// the same way the GetFile branch does.
-		const cap = int64(8)
-		oversized := strings.Repeat("X", int(cap)+1) // 9 bytes vs cap=8
+		const maxBytes = int64(8)
+		oversized := strings.Repeat("X", int(maxBytes)+1) // 9 bytes vs maxBytes=8
 
 		mmClient := mmapimocks.NewMockClient(t)
 		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
@@ -855,7 +855,7 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 			{Type: BlockTypeFile, FileID: "doc1", Filename: "huge.pdf", MimeType: "application/pdf"},
 		}
 
-		post := BlocksToPost(blocks, "user", false, mmClient, true, cap)
+		post := BlocksToPost(blocks, "user", false, mmClient, true, maxBytes)
 
 		mmClient.AssertNotCalled(t, "GetFile", "doc1",
 			"the pre-extracted-content cap must not trigger a GetFile fetch")

--- a/conversation/helpers.go
+++ b/conversation/helpers.go
@@ -21,10 +21,9 @@ func textBlocks(message string) []ContentBlock {
 	return []ContentBlock{{Type: BlockTypeText, Text: message}}
 }
 
-// userBlocksWithAttachments builds content blocks for a user turn: a text
-// block (if message is non-empty) followed by attachment blocks (image or
-// file) for each fileID. fileInfo lookups that error are logged and skipped
-// so a single missing/deleted file does not break the whole user turn.
+// userBlocksWithAttachments emits a text block followed by image/file blocks
+// for each fileID. A failed GetFileInfo is logged and the bad ID is skipped
+// so one deleted or unreadable attachment does not poison the whole turn.
 func userBlocksWithAttachments(message string, fileIDs []string, mmClient mmapi.Client) []ContentBlock {
 	blocks := textBlocks(message)
 	if mmClient == nil {

--- a/conversation/helpers.go
+++ b/conversation/helpers.go
@@ -5,8 +5,10 @@ package conversation
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 	"github.com/mattermost/mattermost-plugin-agents/toolrunner"
 	"github.com/mattermost/mattermost/server/public/model"
 )
@@ -17,6 +19,40 @@ func textBlocks(message string) []ContentBlock {
 		return nil
 	}
 	return []ContentBlock{{Type: BlockTypeText, Text: message}}
+}
+
+// userBlocksWithAttachments builds content blocks for a user turn: a text
+// block (if message is non-empty) followed by attachment blocks (image or
+// file) for each fileID. fileInfo lookups that error are logged and skipped
+// so a single missing/deleted file does not break the whole user turn.
+func userBlocksWithAttachments(message string, fileIDs []string, mmClient mmapi.Client) []ContentBlock {
+	blocks := textBlocks(message)
+	if mmClient == nil {
+		return blocks
+	}
+	for _, fileID := range fileIDs {
+		fileInfo, err := mmClient.GetFileInfo(fileID)
+		if err != nil {
+			mmClient.LogError("failed to get file info for user attachment", "error", err, "file_id", fileID)
+			continue
+		}
+		if strings.HasPrefix(fileInfo.MimeType, "image/") {
+			blocks = append(blocks, ContentBlock{
+				Type:     BlockTypeImage,
+				FileID:   fileID,
+				Filename: fileInfo.Name,
+				MimeType: fileInfo.MimeType,
+			})
+		} else {
+			blocks = append(blocks, ContentBlock{
+				Type:     BlockTypeFile,
+				FileID:   fileID,
+				Filename: fileInfo.Name,
+				MimeType: fileInfo.MimeType,
+			})
+		}
+	}
+	return blocks
 }
 
 // marshalBlocks serializes content blocks to JSON for store.Turn.Content.

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -32,9 +32,17 @@ type Store interface {
 	GetMaxSequenceForConversation(conversationID string) (int, error)
 }
 
-// BotLookup checks whether a user ID belongs to an AI bot.
+// BotLookup checks whether a user ID belongs to an AI bot, and exposes the
+// per-bot attachment-handling configuration that BlocksToPost needs to lazily
+// resolve image and file blocks back into llm.Post.Files / llm.Post.Message.
 type BotLookup interface {
 	IsAnyBot(userID string) bool
+
+	// GetBotConfigByID returns the EnableVision and MaxFileSize settings for
+	// the given bot ID. The ok return is false when no bot exists with that
+	// ID, in which case attachment resolution should fall back to safe
+	// defaults (vision off, default max file size).
+	GetBotConfigByID(botID string) (enableVision bool, maxFileSize int64, ok bool)
 }
 
 // Service manages conversation entities: creation, continuation,
@@ -71,6 +79,12 @@ type CreateConversationParams struct {
 	SystemPrompt string  // already-formatted system prompt text
 	UserMessage  string  // the first user message content
 	UserPostID   *string // nullable: post ID for the user turn, if a post exists
+
+	// FileIDs are the Mattermost file attachment IDs that accompany the
+	// initial user message. These are stored as references on the user
+	// turn (file/image content blocks) and lazy-resolved at LLM-request
+	// build time. Empty means the user turn has no attachments.
+	FileIDs []string
 }
 
 // CreateConversationResult is the return value of CreateConversation.
@@ -103,7 +117,7 @@ func (s *Service) CreateConversation(params CreateConversationParams) (*CreateCo
 	}
 
 	turnID := model.NewId()
-	content, err := marshalBlocks(textBlocks(params.UserMessage))
+	content, err := marshalBlocks(userBlocksWithAttachments(params.UserMessage, params.FileIDs, s.mmClient))
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal user message: %w", err)
 	}
@@ -174,6 +188,10 @@ type GetOrCreateParams struct {
 	SystemPrompt string  // formatted system prompt (used only if creating)
 	UserMessage  string  // new user message
 	UserPostID   *string // post ID for the new user turn
+
+	// FileIDs are the Mattermost file attachment IDs that accompany this
+	// user message. See CreateConversationParams.FileIDs for semantics.
+	FileIDs []string
 }
 
 // GetOrCreateResult is the return value of GetOrCreateConversation.
@@ -192,7 +210,7 @@ func (s *Service) GetOrCreateConversation(params GetOrCreateParams) (*GetOrCreat
 	}
 
 	if existing != nil {
-		turnID, appendErr := s.appendUserTurn(existing.ID, params.UserMessage, params.UserPostID)
+		turnID, appendErr := s.appendUserTurn(existing.ID, params.UserMessage, params.UserPostID, params.FileIDs)
 		if appendErr != nil {
 			return nil, appendErr
 		}
@@ -216,6 +234,7 @@ func (s *Service) GetOrCreateConversation(params GetOrCreateParams) (*GetOrCreat
 		SystemPrompt: params.SystemPrompt,
 		UserMessage:  params.UserMessage,
 		UserPostID:   params.UserPostID,
+		FileIDs:      params.FileIDs,
 	})
 	if errors.Is(err, store.ErrConversationConflict) {
 		// Another request created the conversation concurrently. Look it up and append the user turn.
@@ -226,7 +245,7 @@ func (s *Service) GetOrCreateConversation(params GetOrCreateParams) (*GetOrCreat
 		if raceConv == nil {
 			return nil, fmt.Errorf("conversation vanished after conflict")
 		}
-		turnID, appendErr := s.appendUserTurn(raceConv.ID, params.UserMessage, params.UserPostID)
+		turnID, appendErr := s.appendUserTurn(raceConv.ID, params.UserMessage, params.UserPostID, params.FileIDs)
 		if appendErr != nil {
 			return nil, appendErr
 		}
@@ -253,8 +272,8 @@ func (s *Service) GetOrCreateConversation(params GetOrCreateParams) (*GetOrCreat
 }
 
 // appendUserTurn creates a new user turn at the next available sequence number.
-func (s *Service) appendUserTurn(conversationID, message string, postID *string) (string, error) {
-	content, err := marshalBlocks(textBlocks(message))
+func (s *Service) appendUserTurn(conversationID, message string, postID *string, fileIDs []string) (string, error) {
+	content, err := marshalBlocks(userBlocksWithAttachments(message, fileIDs, s.mmClient))
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal user message: %w", err)
 	}
@@ -331,7 +350,8 @@ func (s *Service) BuildCompletionRequest(
 		Message: conv.SystemPrompt,
 	})
 
-	turnPosts, err := turnsToLLMPosts(turns, redactUnshared)
+	enableVision, maxFileSize := s.attachmentConfigForBot(conv.BotID)
+	turnPosts, err := turnsToLLMPosts(turns, redactUnshared, s.mmClient, enableVision, maxFileSize)
 	if err != nil {
 		return nil, err
 	}
@@ -344,13 +364,34 @@ func (s *Service) BuildCompletionRequest(
 	}, nil
 }
 
+// attachmentConfigForBot returns the EnableVision and MaxFileSize settings
+// that BlocksToPost needs to lazy-resolve image and file blocks for the given
+// bot. Falls back to safe defaults (vision off, default max file size) when
+// the bot lookup is unavailable or the bot is unknown.
+func (s *Service) attachmentConfigForBot(botID string) (bool, int64) {
+	if s.bots == nil {
+		return false, DefaultMaxFileSize
+	}
+	enableVision, maxFileSize, ok := s.bots.GetBotConfigByID(botID)
+	if !ok {
+		return false, DefaultMaxFileSize
+	}
+	return enableVision, maxFileSize
+}
+
 // turnsToLLMPosts converts a contiguous slice of turns into llm.Posts,
 // merging each tool_result turn into the preceding assistant turn so that
 // BlocksToPost can pair tool_result blocks with their tool_use entries in a
 // single llm.Post. Without this merge, tool_use entries go out with empty
 // Result fields and bifrost emits empty-content tool messages, which
 // Anthropic rejects with "text content blocks must be non-empty".
-func turnsToLLMPosts(turns []store.Turn, redactUnshared bool) ([]llm.Post, error) {
+func turnsToLLMPosts(
+	turns []store.Turn,
+	redactUnshared bool,
+	mmClient mmapi.Client,
+	enableVision bool,
+	maxFileSize int64,
+) ([]llm.Post, error) {
 	posts := make([]llm.Post, 0, len(turns))
 	for i := 0; i < len(turns); i++ {
 		turn := turns[i]
@@ -366,7 +407,7 @@ func turnsToLLMPosts(turns []store.Turn, redactUnshared bool) ([]llm.Post, error
 			blocks = append(blocks, nextBlocks...)
 			i++
 		}
-		posts = append(posts, BlocksToPost(blocks, turn.Role, redactUnshared))
+		posts = append(posts, BlocksToPost(blocks, turn.Role, redactUnshared, mmClient, enableVision, maxFileSize))
 	}
 	return posts, nil
 }
@@ -547,6 +588,8 @@ func (s *Service) BuildChannelMentionRequest(
 		return nil, fmt.Errorf("failed to get turns: %w", err)
 	}
 
+	enableVision, maxFileSize := s.attachmentConfigForBot(conv.BotID)
+
 	// Build a set of post IDs that belong to the bot's turns.
 	turnPostIDs := make(map[string]bool)
 	// Map from postID to the turn for quick lookup.
@@ -605,7 +648,7 @@ func (s *Service) BuildChannelMentionRequest(
 	// (precedingSeq = 0). Route through turnsToLLMPosts so tool_use and
 	// tool_result within the same tool round merge into a single llm.Post,
 	// matching BuildCompletionRequest's behavior.
-	leadingPosts, err := turnsToLLMPosts(turnsByPrecedingPost[0], redactUnshared)
+	leadingPosts, err := turnsToLLMPosts(turnsByPrecedingPost[0], redactUnshared, s.mmClient, enableVision, maxFileSize)
 	if err != nil {
 		return nil, err
 	}
@@ -618,7 +661,7 @@ func (s *Service) BuildChannelMentionRequest(
 			// preceding assistant turn's tool_use blocks.
 			turn := turnByPostID[threadPost.Id]
 			run := append([]store.Turn{turn}, turnsByPrecedingPost[turn.Sequence]...)
-			runPosts, err := turnsToLLMPosts(run, redactUnshared)
+			runPosts, err := turnsToLLMPosts(run, redactUnshared, s.mmClient, enableVision, maxFileSize)
 			if err != nil {
 				return nil, err
 			}

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -32,16 +32,12 @@ type Store interface {
 	GetMaxSequenceForConversation(conversationID string) (int, error)
 }
 
-// BotLookup checks whether a user ID belongs to an AI bot, and exposes the
-// per-bot attachment-handling configuration that BlocksToPost needs to lazily
-// resolve image and file blocks back into llm.Post.Files / llm.Post.Message.
+// BotLookup answers bot-membership and per-bot config queries.
 type BotLookup interface {
 	IsAnyBot(userID string) bool
 
-	// GetBotConfigByID returns the EnableVision and MaxFileSize settings for
-	// the given bot ID. The ok return is false when no bot exists with that
-	// ID, in which case attachment resolution should fall back to safe
-	// defaults (vision off, default max file size).
+	// GetBotConfigByID returns the bot's EnableVision and MaxFileSize.
+	// ok is false when botID is unknown.
 	GetBotConfigByID(botID string) (enableVision bool, maxFileSize int64, ok bool)
 }
 
@@ -79,12 +75,7 @@ type CreateConversationParams struct {
 	SystemPrompt string  // already-formatted system prompt text
 	UserMessage  string  // the first user message content
 	UserPostID   *string // nullable: post ID for the user turn, if a post exists
-
-	// FileIDs are the Mattermost file attachment IDs that accompany the
-	// initial user message. These are stored as references on the user
-	// turn (file/image content blocks) and lazy-resolved at LLM-request
-	// build time. Empty means the user turn has no attachments.
-	FileIDs []string
+	FileIDs      []string
 }
 
 // CreateConversationResult is the return value of CreateConversation.
@@ -188,10 +179,7 @@ type GetOrCreateParams struct {
 	SystemPrompt string  // formatted system prompt (used only if creating)
 	UserMessage  string  // new user message
 	UserPostID   *string // post ID for the new user turn
-
-	// FileIDs are the Mattermost file attachment IDs that accompany this
-	// user message. See CreateConversationParams.FileIDs for semantics.
-	FileIDs []string
+	FileIDs      []string
 }
 
 // GetOrCreateResult is the return value of GetOrCreateConversation.
@@ -364,10 +352,8 @@ func (s *Service) BuildCompletionRequest(
 	}, nil
 }
 
-// attachmentConfigForBot returns the EnableVision and MaxFileSize settings
-// that BlocksToPost needs to lazy-resolve image and file blocks for the given
-// bot. Falls back to safe defaults (vision off, default max file size) when
-// the bot lookup is unavailable or the bot is unknown.
+// attachmentConfigForBot returns the bot's EnableVision and MaxFileSize.
+// Falls back to vision-off + DefaultMaxFileSize when the bot is unknown.
 func (s *Service) attachmentConfigForBot(botID string) (bool, int64) {
 	if s.bots == nil {
 		return false, DefaultMaxFileSize

--- a/conversation/service_test.go
+++ b/conversation/service_test.go
@@ -6,8 +6,11 @@ package conversation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,10 +18,12 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/mmapi"
+	mmapimocks "github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
 	"github.com/mattermost/mattermost-plugin-agents/store"
 	"github.com/mattermost/mattermost-plugin-agents/toolrunner"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -60,10 +65,27 @@ func TestMain(m *testing.M) {
 // testBotLookup is a simple test double for BotLookup.
 type testBotLookup struct {
 	botUserIDs map[string]bool
+
+	// configByID is consulted by GetBotConfigByID. When nil/missing, the
+	// lookup returns ok=false so callers fall back to safe defaults.
+	configByID map[string]testBotConfig
+}
+
+type testBotConfig struct {
+	enableVision bool
+	maxFileSize  int64
 }
 
 func (t *testBotLookup) IsAnyBot(userID string) bool {
 	return t.botUserIDs[userID]
+}
+
+func (t *testBotLookup) GetBotConfigByID(botID string) (bool, int64, bool) {
+	cfg, ok := t.configByID[botID]
+	if !ok {
+		return false, 0, false
+	}
+	return cfg.enableVision, cfg.maxFileSize, true
 }
 
 // testLLM is a simple test double for llm.LanguageModel that returns a
@@ -1622,4 +1644,469 @@ func TestGetOrCreateConversation_RaceConflict(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, blocks, 1)
 	assert.Equal(t, "second message", blocks[0].Text)
+}
+
+// setupTestServiceWithClient is like setupTestService but also wires in an
+// mmapi.Client mock and a populated testBotLookup so attachment-handling
+// tests can drive lazy file/image resolution end-to-end.
+func setupTestServiceWithClient(
+	t *testing.T,
+	mmClient mmapi.Client,
+	bots *testBotLookup,
+) (*Service, *store.Store) {
+	t.Helper()
+
+	db, err := sqlx.Connect("postgres", testConnStr)
+	require.NoError(t, err)
+
+	schemaName := fmt.Sprintf("test_%d", time.Now().UnixNano())
+	_, err = db.Exec(fmt.Sprintf("CREATE SCHEMA %s", schemaName))
+	require.NoError(t, err)
+
+	_, err = db.Exec(fmt.Sprintf("SET search_path TO %s", schemaName))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.Exec(fmt.Sprintf("DROP SCHEMA %s CASCADE", schemaName))
+		db.Close()
+	})
+
+	s := store.New(db)
+	err = s.RunMigrations()
+	require.NoError(t, err)
+
+	if bots == nil {
+		bots = &testBotLookup{botUserIDs: map[string]bool{}}
+	}
+	svc := NewService(s, nil, mmClient, bots)
+	return svc, s
+}
+
+// TestCreateConversation_FileIDsPersistsAsContentBlocks pins the user-turn
+// schema for attachments. CreateConversation must store FileIDs as
+// BlockTypeImage / BlockTypeFile entries (lazy-load: NO inlined Content)
+// alongside the leading text block.
+func TestCreateConversation_FileIDsPersistsAsContentBlocks(t *testing.T) {
+	mmClient := mmapimocks.NewMockClient(t)
+	// No .Maybe(): GetFileInfo MUST be called for every FileID so the
+	// MIME type is read from the server (not inferred from the filename
+	// extension). Mockery fails the test if either expectation is unmet.
+	mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
+		Id: "img1", Name: "shot.png", MimeType: "image/png",
+	}, nil)
+	mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+		Id: "doc1", Name: "foo.txt", MimeType: "text/plain",
+	}, nil)
+
+	svc, s := setupTestServiceWithClient(t, mmClient, nil)
+
+	result, err := svc.CreateConversation(CreateConversationParams{
+		UserID:       model.NewId(),
+		BotID:        model.NewId(),
+		Operation:    "conversation",
+		SystemPrompt: "system",
+		UserMessage:  "look at these",
+		FileIDs:      []string{"img1", "doc1"},
+	})
+	require.NoError(t, err)
+
+	turns, err := s.GetTurnsForConversation(result.ConversationID)
+	require.NoError(t, err)
+	require.Len(t, turns, 1)
+
+	var blocks []ContentBlock
+	err = json.Unmarshal(turns[0].Content, &blocks)
+	require.NoError(t, err)
+
+	require.Len(t, blocks, 3, "expect [text, image, file] in this order")
+
+	assert.Equal(t, BlockTypeText, blocks[0].Type)
+	assert.Equal(t, "look at these", blocks[0].Text)
+
+	assert.Equal(t, BlockTypeImage, blocks[1].Type, "image attachment must persist as a BlockTypeImage")
+	assert.Equal(t, "img1", blocks[1].FileID)
+	assert.Equal(t, "image/png", blocks[1].MimeType)
+	assert.Empty(t, blocks[1].Content,
+		"image block must NOT inline content at user-turn write time; image bytes lazy-load via mmClient at request build time")
+
+	assert.Equal(t, BlockTypeFile, blocks[2].Type, "non-image attachment must persist as a BlockTypeFile")
+	assert.Equal(t, "doc1", blocks[2].FileID)
+	assert.Equal(t, "text/plain", blocks[2].MimeType)
+	assert.Empty(t, blocks[2].Content,
+		"file content must NOT be inlined at user-turn write time; it lazy-loads via mmClient at request build time")
+}
+
+// TestGetOrCreateConversation_AppendsFileIDs verifies the same shape applies
+// when appending a new user turn to an existing conversation.
+func TestGetOrCreateConversation_AppendsFileIDs(t *testing.T) {
+	mmClient := mmapimocks.NewMockClient(t)
+	// No .Maybe(): GetFileInfo for the appended attachment MUST run so
+	// MIME comes from the server, not the filename extension.
+	mmClient.On("GetFileInfo", "doc2").Return(&model.FileInfo{
+		Id: "doc2", Name: "notes.txt", MimeType: "text/plain",
+	}, nil)
+
+	svc, s := setupTestServiceWithClient(t, mmClient, nil)
+
+	botID := model.NewId()
+	userID := model.NewId()
+	rootPostID := "thread1"
+
+	// Seed an initial conversation.
+	_, err := svc.CreateConversation(CreateConversationParams{
+		UserID:       userID,
+		BotID:        botID,
+		RootPostID:   &rootPostID,
+		Operation:    "conversation",
+		SystemPrompt: "system",
+		UserMessage:  "first",
+	})
+	require.NoError(t, err)
+
+	res, err := svc.GetOrCreateConversation(GetOrCreateParams{
+		UserID:       userID,
+		BotID:        botID,
+		ChannelID:    "chan1",
+		RootPostID:   rootPostID,
+		Operation:    "conversation",
+		SystemPrompt: "ignored",
+		UserMessage:  "follow-up with attachment",
+		FileIDs:      []string{"doc2"},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsNew)
+
+	turns, err := s.GetTurnsForConversation(res.Conversation.ID)
+	require.NoError(t, err)
+	require.Len(t, turns, 2)
+
+	var blocks []ContentBlock
+	err = json.Unmarshal(turns[1].Content, &blocks)
+	require.NoError(t, err)
+
+	require.Len(t, blocks, 2)
+	assert.Equal(t, BlockTypeText, blocks[0].Type)
+	assert.Equal(t, "follow-up with attachment", blocks[0].Text)
+
+	assert.Equal(t, BlockTypeFile, blocks[1].Type)
+	assert.Equal(t, "doc2", blocks[1].FileID)
+	assert.Equal(t, "text/plain", blocks[1].MimeType)
+	assert.Empty(t, blocks[1].Content,
+		"appended file blocks must also leave Content empty (lazy-load model)")
+}
+
+// TestCreateConversation_EmptyFileIDsAndMessage keeps the existing behavior
+// for a message with no attachments and no body — empty content array.
+func TestCreateConversation_EmptyFileIDsAndMessage(t *testing.T) {
+	svc, s := setupTestServiceWithClient(t, nil, nil)
+
+	result, err := svc.CreateConversation(CreateConversationParams{
+		UserID:       model.NewId(),
+		BotID:        model.NewId(),
+		Operation:    "conversation",
+		SystemPrompt: "system",
+		UserMessage:  "",
+	})
+	require.NoError(t, err)
+
+	turns, err := s.GetTurnsForConversation(result.ConversationID)
+	require.NoError(t, err)
+	require.Len(t, turns, 1)
+
+	var blocks []ContentBlock
+	err = json.Unmarshal(turns[0].Content, &blocks)
+	require.NoError(t, err)
+	assert.Empty(t, blocks)
+}
+
+// TestCreateConversation_FileIDInfoErrorIsSkipped pins the resilience
+// contract. If GetFileInfo errors for one fileID, the user turn must still
+// be created with the rest. Mirrors the old PostToAIPost behavior.
+func TestCreateConversation_FileIDInfoErrorIsSkipped(t *testing.T) {
+	mmClient := mmapimocks.NewMockClient(t)
+	// Both GetFileInfo calls MUST happen — the bad one returns an error,
+	// but production must still attempt the fetch (otherwise an
+	// implementation that filtered FileIDs by some local rule would
+	// silently match this test). LogError must also actually fire so
+	// the error is observable to operators.
+	mmClient.On("GetFileInfo", "broken").Return(nil, errors.New("file gone"))
+	mmClient.On("GetFileInfo", "ok1").Return(&model.FileInfo{
+		Id: "ok1", Name: "good.txt", MimeType: "text/plain",
+	}, nil)
+	mmClient.On("LogError", mock.Anything, mock.Anything).Return()
+
+	svc, s := setupTestServiceWithClient(t, mmClient, nil)
+
+	result, err := svc.CreateConversation(CreateConversationParams{
+		UserID:       model.NewId(),
+		BotID:        model.NewId(),
+		Operation:    "conversation",
+		SystemPrompt: "system",
+		UserMessage:  "with mixed",
+		FileIDs:      []string{"broken", "ok1"},
+	})
+	require.NoError(t, err, "a single bad file must not break conversation creation")
+
+	turns, err := s.GetTurnsForConversation(result.ConversationID)
+	require.NoError(t, err)
+	require.Len(t, turns, 1)
+
+	var blocks []ContentBlock
+	err = json.Unmarshal(turns[0].Content, &blocks)
+	require.NoError(t, err)
+
+	// Expected layout: text + (skipped broken) + ok1 file block.
+	require.Len(t, blocks, 2)
+	assert.Equal(t, BlockTypeText, blocks[0].Type)
+	assert.Equal(t, BlockTypeFile, blocks[1].Type)
+	assert.Equal(t, "ok1", blocks[1].FileID)
+}
+
+// TestBuildCompletionRequest_AttachmentsResolveLazily wires the full path:
+// CreateConversation persists references → BuildCompletionRequest →
+// BlocksToPost re-fetches the file/image bytes via mmClient.
+func TestBuildCompletionRequest_AttachmentsResolveLazily(t *testing.T) {
+	t.Run("EnableVision=true populates Files and message gets file content", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+
+		// Used twice: once for user-turn creation (read MIME) and once at
+		// request build time (lazy resolve).
+		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
+			Id: "img1", Name: "pic.png", MimeType: "image/png", Size: 100,
+		}, nil)
+		mmClient.On("GetFile", "img1").Return(io.NopCloser(strings.NewReader("PNGDATA")), nil)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id: "doc1", Name: "notes.txt", MimeType: "text/plain", Size: 5,
+		}, nil)
+		mmClient.On("GetFile", "doc1").Return(io.NopCloser(strings.NewReader("hello")), nil)
+
+		botID := model.NewId()
+		bots := &testBotLookup{
+			botUserIDs: map[string]bool{},
+			configByID: map[string]testBotConfig{
+				botID: {enableVision: true, maxFileSize: 0},
+			},
+		}
+
+		svc, _ := setupTestServiceWithClient(t, mmClient, bots)
+
+		result, err := svc.CreateConversation(CreateConversationParams{
+			UserID:       model.NewId(),
+			BotID:        botID,
+			Operation:    "conversation",
+			SystemPrompt: "system",
+			UserMessage:  "the body",
+			FileIDs:      []string{"img1", "doc1"},
+		})
+		require.NoError(t, err)
+
+		conv, err := svc.GetConversation(result.ConversationID)
+		require.NoError(t, err)
+
+		req, err := svc.BuildCompletionRequest(conv, &llm.Context{})
+		require.NoError(t, err)
+
+		require.Len(t, req.Posts, 2, "system + user")
+		userPost := req.Posts[1]
+		assert.Equal(t, llm.PostRoleUser, userPost.Role)
+
+		require.Len(t, userPost.Files, 1, "image attachment must round-trip back into Post.Files")
+		assert.Equal(t, "image/png", userPost.Files[0].MimeType)
+
+		assert.Contains(t, userPost.Message, "the body")
+		assert.Contains(t, userPost.Message, "Attached File Contents:")
+		assert.Contains(t, userPost.Message, "File Name: notes.txt")
+		assert.Contains(t, userPost.Message, "Content: hello")
+	})
+
+	t.Run("EnableVision=false drops image but keeps file text content", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+
+		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
+			Id: "img1", Name: "pic.png", MimeType: "image/png", Size: 100,
+		}, nil)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id: "doc1", Name: "notes.txt", MimeType: "text/plain", Size: 5,
+		}, nil)
+		mmClient.On("GetFile", "doc1").Return(io.NopCloser(strings.NewReader("hello")), nil)
+		// NOTE: no GetFile(img1) expectation — vision is off so it must NOT be called.
+
+		botID := model.NewId()
+		bots := &testBotLookup{
+			botUserIDs: map[string]bool{},
+			configByID: map[string]testBotConfig{
+				botID: {enableVision: false, maxFileSize: 0},
+			},
+		}
+
+		svc, _ := setupTestServiceWithClient(t, mmClient, bots)
+
+		result, err := svc.CreateConversation(CreateConversationParams{
+			UserID:       model.NewId(),
+			BotID:        botID,
+			Operation:    "conversation",
+			SystemPrompt: "system",
+			UserMessage:  "no vision plz",
+			FileIDs:      []string{"img1", "doc1"},
+		})
+		require.NoError(t, err)
+
+		conv, err := svc.GetConversation(result.ConversationID)
+		require.NoError(t, err)
+
+		req, err := svc.BuildCompletionRequest(conv, &llm.Context{})
+		require.NoError(t, err)
+
+		require.Len(t, req.Posts, 2)
+		userPost := req.Posts[1]
+		// Explicit AssertNotCalled so the no-vision contract is
+		// readable in the test, not just implicit in mockery's strict
+		// mode. Production silently fetching the image bytes anyway
+		// would be a bug we'd want to surface here.
+		mmClient.AssertNotCalled(t, "GetFile", "img1")
+		assert.Empty(t, userPost.Files, "image attachments must be dropped entirely when vision is disabled")
+		assert.Contains(t, userPost.Message, "Content: hello",
+			"text-file content must still flow through to the LLM even when vision is off")
+	})
+}
+
+// TestBuildChannelMentionRequest_AttachmentsResolveLazily mirrors the
+// BuildCompletionRequest integration test for the channel-mention path.
+// Both builders run user turns through BlocksToPost, so attachments must
+// flow identically — a regression in only one path would leak otherwise.
+//
+// This test passes a non-nil threadData containing the user-turn's PostID so
+// BuildChannelMentionRequest takes its post-iteration branch (the long body
+// at service.go ~line 586+) and resolves the user turn's attachment blocks
+// via turnsToLLMPosts → BlocksToPost using the bot's vision/maxFileSize
+// config. With nil threadData the function short-circuits to
+// BuildCompletionRequest, which would not exercise this path.
+func TestBuildChannelMentionRequest_AttachmentsResolveLazily(t *testing.T) {
+	t.Run("EnableVision=true populates Files and message gets file content", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+
+		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
+			Id: "img1", Name: "pic.png", MimeType: "image/png", Size: 100,
+		}, nil)
+		mmClient.On("GetFile", "img1").Return(io.NopCloser(strings.NewReader("PNGDATA")), nil)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id: "doc1", Name: "notes.txt", MimeType: "text/plain", Size: 5,
+		}, nil)
+		mmClient.On("GetFile", "doc1").Return(io.NopCloser(strings.NewReader("hello")), nil)
+
+		botID := model.NewId()
+		userID := model.NewId()
+		userPostID := "post_user_1"
+		bots := &testBotLookup{
+			botUserIDs: map[string]bool{botID: true},
+			configByID: map[string]testBotConfig{
+				botID: {enableVision: true, maxFileSize: 0},
+			},
+		}
+
+		svc, _ := setupTestServiceWithClient(t, mmClient, bots)
+
+		result, err := svc.CreateConversation(CreateConversationParams{
+			UserID:       userID,
+			BotID:        botID,
+			Operation:    "conversation",
+			SystemPrompt: "system",
+			UserMessage:  "channel mention body",
+			UserPostID:   stringPtr(userPostID),
+			FileIDs:      []string{"img1", "doc1"},
+		})
+		require.NoError(t, err)
+
+		conv, err := svc.GetConversation(result.ConversationID)
+		require.NoError(t, err)
+
+		// Non-nil threadData with a post that matches the user turn's
+		// PostID — this drives the post-iteration branch so the user
+		// turn's attachment blocks flow through turnsToLLMPosts with the
+		// bot's vision/maxFileSize config.
+		threadData := &mmapi.ThreadData{
+			Posts: []*model.Post{
+				{Id: userPostID, UserId: userID, CreateAt: 1000, Message: "channel mention body"},
+			},
+			UsersByID: map[string]*model.User{
+				userID: {Id: userID, Username: "alice"},
+				botID:  {Id: botID, Username: "aibot"},
+			},
+		}
+
+		req, err := svc.BuildChannelMentionRequest(conv, &llm.Context{}, threadData)
+		require.NoError(t, err)
+
+		require.Len(t, req.Posts, 2, "system + user (resolved from the user turn)")
+		userPost := req.Posts[1]
+		require.Equal(t, llm.PostRoleUser, userPost.Role)
+		require.Len(t, userPost.Files, 1,
+			"BuildChannelMentionRequest must lazy-resolve image attachments just like BuildCompletionRequest")
+		assert.Equal(t, "image/png", userPost.Files[0].MimeType)
+		assert.Contains(t, userPost.Message, "channel mention body")
+		assert.Contains(t, userPost.Message, "Attached File Contents:")
+		assert.Contains(t, userPost.Message, "File Name: notes.txt")
+		assert.Contains(t, userPost.Message, "Content: hello")
+	})
+
+	t.Run("EnableVision=false drops image but keeps file text content", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+
+		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
+			Id: "img1", Name: "pic.png", MimeType: "image/png", Size: 100,
+		}, nil)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id: "doc1", Name: "notes.txt", MimeType: "text/plain", Size: 5,
+		}, nil)
+		mmClient.On("GetFile", "doc1").Return(io.NopCloser(strings.NewReader("hello")), nil)
+		// NOTE: no GetFile(img1) expectation — vision is off so the
+		// channel-mention path must NOT fetch the image bytes either.
+
+		botID := model.NewId()
+		userID := model.NewId()
+		userPostID := "post_user_2"
+		bots := &testBotLookup{
+			botUserIDs: map[string]bool{botID: true},
+			configByID: map[string]testBotConfig{
+				botID: {enableVision: false, maxFileSize: 0},
+			},
+		}
+
+		svc, _ := setupTestServiceWithClient(t, mmClient, bots)
+
+		result, err := svc.CreateConversation(CreateConversationParams{
+			UserID:       userID,
+			BotID:        botID,
+			Operation:    "conversation",
+			SystemPrompt: "system",
+			UserMessage:  "no vision channel mention",
+			UserPostID:   stringPtr(userPostID),
+			FileIDs:      []string{"img1", "doc1"},
+		})
+		require.NoError(t, err)
+
+		conv, err := svc.GetConversation(result.ConversationID)
+		require.NoError(t, err)
+
+		threadData := &mmapi.ThreadData{
+			Posts: []*model.Post{
+				{Id: userPostID, UserId: userID, CreateAt: 1000, Message: "no vision channel mention"},
+			},
+			UsersByID: map[string]*model.User{
+				userID: {Id: userID, Username: "alice"},
+				botID:  {Id: botID, Username: "aibot"},
+			},
+		}
+
+		req, err := svc.BuildChannelMentionRequest(conv, &llm.Context{}, threadData)
+		require.NoError(t, err)
+
+		require.Len(t, req.Posts, 2)
+		userPost := req.Posts[1]
+		mmClient.AssertNotCalled(t, "GetFile", "img1")
+		assert.Empty(t, userPost.Files,
+			"image attachments must be dropped on the channel-mention path when vision is disabled")
+		assert.Contains(t, userPost.Message, "Content: hello",
+			"text-file content must still flow through to the LLM via the channel-mention path")
+	})
 }

--- a/conversations/channel_mention_test.go
+++ b/conversations/channel_mention_test.go
@@ -66,6 +66,10 @@ func (b *channelMentionBotLookup) IsAnyBot(userID string) bool {
 	return b.botIDs[userID]
 }
 
+func (b *channelMentionBotLookup) GetBotConfigByID(botID string) (bool, int64, bool) {
+	return false, 0, false
+}
+
 func setupChannelMentionService(t *testing.T) (*conversation.Service, *store.Store) {
 	t.Helper()
 

--- a/conversations/conversations.go
+++ b/conversations/conversations.go
@@ -146,6 +146,7 @@ func (c *Conversations) CreateOrGetDMConversation(
 			SystemPrompt: systemPrompt,
 			UserMessage:  post.Message,
 			UserPostID:   &postID,
+			FileIDs:      post.FileIds,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create conversation: %w", err)
@@ -162,6 +163,7 @@ func (c *Conversations) CreateOrGetDMConversation(
 		SystemPrompt: systemPrompt,
 		UserMessage:  post.Message,
 		UserPostID:   &postID,
+		FileIDs:      post.FileIds,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get or create conversation: %w", err)

--- a/conversations/handle_messages.go
+++ b/conversations/handle_messages.go
@@ -209,6 +209,7 @@ func (c *Conversations) handleMentionViaConversation(
 		SystemPrompt: systemPrompt,
 		UserMessage:  post.Message,
 		UserPostID:   &userPostID,
+		FileIDs:      post.FileIds,
 	})
 	if convErr != nil {
 		return fmt.Errorf("failed to get or create conversation: %w", convErr)

--- a/search/search_conversation_test.go
+++ b/search/search_conversation_test.go
@@ -134,7 +134,8 @@ func (s *fakeConversationStore) UpdateConversationRootPostID(id string, rootPost
 // fakeBotLookup is a no-op implementation of conversation.BotLookup.
 type fakeBotLookup struct{}
 
-func (f *fakeBotLookup) IsAnyBot(string) bool { return false }
+func (f *fakeBotLookup) IsAnyBot(string) bool                        { return false }
+func (f *fakeBotLookup) GetBotConfigByID(string) (bool, int64, bool) { return false, 0, false }
 
 // makeSearchResult creates a single embeddings.SearchResult for testing.
 func makeSearchResult(postID, channelID, userID, content string, score float32) embeddings.SearchResult {

--- a/threads/analysis_conversation_test.go
+++ b/threads/analysis_conversation_test.go
@@ -71,6 +71,10 @@ func (t *testBotLookup) IsAnyBot(userID string) bool {
 	return t.botUserIDs[userID]
 }
 
+func (t *testBotLookup) GetBotConfigByID(string) (bool, int64, bool) {
+	return false, 0, false
+}
+
 // testSetup holds the objects needed for analysis conversation tests.
 type testSetup struct {
 	convService *conversation.Service


### PR DESCRIPTION
#### Summary

The "Conversation entities" refactor (#602) replaced the old `PostToAIPost` function but did not port over its file/image handling, so any attachment a user uploaded alongside a chat message was silently discarded before reaching the LLM. Two gaps caused this: `CreateConversationParams`/`GetOrCreateParams` only carried `UserMessage string` (no `FileIds`), and `BlocksToPost` had a no-op case for `BlockTypeFile`/`BlockTypeImage`.

This PR restores attachment handling using a lazy-load model:

- User turns persist only `FileID` references — no inlined binary or text content.
- `BlocksToPost` re-resolves attachments via `mmClient` on each completion: image blocks gated by per-bot `EnableVision` go to `llm.Post.Files`; text-file blocks (or files with server-pre-extracted `FileInfo.Content`) get inlined into the user message under `Attached File Contents:`, capped by per-bot `MaxFileSize` (default 5 MiB).
- Per-bot config plumbed via a new `MMBots.GetBotConfigByID` exposed through the `conversation.BotLookup` interface.
- Both `BuildCompletionRequest` and `BuildChannelMentionRequest` paths covered.
- Errors from `GetFileInfo`/`GetFile` are logged and the offending attachment is skipped — a single missing file does not break the conversation.

Built via Red-Green TDD: 17 new unit tests pinning lazy-load contract, vision gating, `MaxFileSize` boundary against `DefaultMaxFileSize`, multi-attachment ordering, error resilience, and end-to-end resolution through both completion-request builders. Reviewed in parallel by correctness, security, and test-quality agents.

#### Ticket Link
N/A

#### Release Note
\`\`\`release-note
Fixed image and text-file attachments being silently dropped from LLM requests after the conversation entities refactor.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-bot attachment settings: vision support toggle and per-bot file-size limits.
  * Conversations now persist file/image attachments and resolve them when building LLM requests.
  * Image bytes are included only when a bot’s vision is enabled; file text is embedded into prompts with size-based truncation and sensible defaults.

* **Tests**
  * Expanded tests cover lazy attachment resolution, truncation, error handling and bot-config fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->