### PR TITLE
Fix native citation UTF-16 offsets

### DIFF
--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -1542,8 +1542,8 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 
 	// Annotation buffer and text position tracking
 	var annotations []llm.Annotation
-	var textLen int       // cumulative byte length of all streamed text
-	var blockStartPos int // byte position where current text block started
+	var textLen int       // cumulative UTF-16 code units of all streamed text
+	var blockStartPos int // UTF-16 position where current text block started
 
 	// Watchdog timer for streaming timeout
 	watchdog := make(chan struct{})
@@ -1611,7 +1611,7 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 						Type:  llm.EventTypeText,
 						Value: *resp.Delta,
 					}
-					textLen += len(*resp.Delta)
+					textLen = advanceStreamingTextPosition(textLen, *resp.Delta)
 				}
 
 			case schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta:
@@ -1644,12 +1644,7 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 						// Bifrost doesn't provide output-text positions during Anthropic streaming.
 						// Compute them from tracked block boundaries, matching the approach used by
 						// the old Anthropic SDK implementation (extractAnnotations).
-						if resp.Annotation.StartIndex == nil {
-							ann.StartIndex = blockStartPos
-						}
-						if resp.Annotation.EndIndex == nil {
-							ann.EndIndex = textLen
-						}
+						fillMissingAnnotationIndices(ann, resp.Annotation, blockStartPos, textLen)
 						annotations = append(annotations, *ann)
 					}
 				}
@@ -1874,4 +1869,17 @@ func convertBifrostAnnotation(ann *schemas.ResponsesOutputMessageContentTextAnno
 	}
 
 	return result
+}
+
+func advanceStreamingTextPosition(current int, delta string) int {
+	return current + llm.UTF16CodeUnitCount(delta)
+}
+
+func fillMissingAnnotationIndices(ann *llm.Annotation, source *schemas.ResponsesOutputMessageContentTextAnnotation, blockStartPos int, textLen int) {
+	if source.StartIndex == nil {
+		ann.StartIndex = blockStartPos
+	}
+	if source.EndIndex == nil {
+		ann.EndIndex = textLen
+	}
 }

--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -1657,6 +1657,7 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 				// Keep the annotation buffer so subsequent output_text_done events can include
 				// citations accumulated across the full response.
 				if len(annotations) > 0 {
+					normalizeMissingAnnotationPositions(annotations, textLen)
 					output <- llm.TextStreamEvent{
 						Type:  llm.EventTypeAnnotations,
 						Value: annotations,
@@ -1754,6 +1755,7 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 
 				// Emit any accumulated annotations
 				if len(annotations) > 0 {
+					normalizeMissingAnnotationPositions(annotations, textLen)
 					output <- llm.TextStreamEvent{
 						Type:  llm.EventTypeAnnotations,
 						Value: annotations,
@@ -1881,5 +1883,22 @@ func fillMissingAnnotationIndices(ann *llm.Annotation, source *schemas.Responses
 	}
 	if source.EndIndex == nil {
 		ann.EndIndex = textLen
+	}
+}
+
+func normalizeMissingAnnotationPositions(annotations []llm.Annotation, textLen int) {
+	fallbackPosition := textLen
+	for _, ann := range annotations {
+		if ann.EndIndex > 0 {
+			fallbackPosition = ann.EndIndex
+			break
+		}
+	}
+
+	for i := range annotations {
+		if annotations[i].StartIndex == 0 && annotations[i].EndIndex == 0 {
+			annotations[i].StartIndex = fallbackPosition
+			annotations[i].EndIndex = fallbackPosition
+		}
 	}
 }

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -847,6 +847,60 @@ func TestConvertBifrostAnnotation(t *testing.T) {
 	}
 }
 
+func TestFillMissingAnnotationIndicesUsesUTF16(t *testing.T) {
+	emDashPrefix := "Canvas released — a feature"
+	emojiPrefix := "Look 🔎 here"
+
+	assert.Equal(t, llm.UTF16CodeUnitCount(emDashPrefix), advanceStreamingTextPosition(0, emDashPrefix))
+	assert.NotEqual(t, len(emDashPrefix), advanceStreamingTextPosition(0, emDashPrefix))
+
+	tests := []struct {
+		name          string
+		ann           llm.Annotation
+		source        *schemas.ResponsesOutputMessageContentTextAnnotation
+		blockStartPos int
+		textLen       int
+		expectedStart int
+		expectedEnd   int
+	}{
+		{
+			name:          "fills missing Anthropic indices with UTF-16 text positions",
+			ann:           llm.Annotation{Type: llm.AnnotationTypeURLCitation},
+			source:        &schemas.ResponsesOutputMessageContentTextAnnotation{Type: "url_citation"},
+			blockStartPos: llm.UTF16CodeUnitCount(emDashPrefix),
+			textLen:       llm.UTF16CodeUnitCount(emDashPrefix + " directly inside Cursor"),
+			expectedStart: llm.UTF16CodeUnitCount(emDashPrefix),
+			expectedEnd:   llm.UTF16CodeUnitCount(emDashPrefix + " directly inside Cursor"),
+		},
+		{
+			name: "preserves provider-supplied indices",
+			ann: llm.Annotation{
+				Type:       llm.AnnotationTypeURLCitation,
+				StartIndex: 3,
+				EndIndex:   8,
+			},
+			source: &schemas.ResponsesOutputMessageContentTextAnnotation{
+				Type:       "url_citation",
+				StartIndex: intPtr(3),
+				EndIndex:   intPtr(8),
+			},
+			blockStartPos: llm.UTF16CodeUnitCount(emojiPrefix),
+			textLen:       llm.UTF16CodeUnitCount(emojiPrefix + " after"),
+			expectedStart: 3,
+			expectedEnd:   8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fillMissingAnnotationIndices(&tt.ann, tt.source, tt.blockStartPos, tt.textLen)
+
+			assert.Equal(t, tt.expectedStart, tt.ann.StartIndex)
+			assert.Equal(t, tt.expectedEnd, tt.ann.EndIndex)
+		})
+	}
+}
+
 type testStructuredOutput struct {
 	Name  string `json:"name"`
 	Score int    `json:"score"`

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -901,6 +901,26 @@ func TestFillMissingAnnotationIndicesUsesUTF16(t *testing.T) {
 	}
 }
 
+func TestNormalizeZeroWidthLeadingAnnotations(t *testing.T) {
+	annotations := []llm.Annotation{
+		{Type: llm.AnnotationTypeURLCitation, StartIndex: 0, EndIndex: 0, Index: 1},
+		{Type: llm.AnnotationTypeURLCitation, StartIndex: 0, EndIndex: 0, Index: 2},
+		{Type: llm.AnnotationTypeURLCitation, StartIndex: 109, EndIndex: 109, Index: 3},
+		{Type: llm.AnnotationTypeURLCitation, StartIndex: 242, EndIndex: 242, Index: 4},
+	}
+
+	normalizeMissingAnnotationPositions(annotations, 581)
+
+	assert.Equal(t, 109, annotations[0].StartIndex)
+	assert.Equal(t, 109, annotations[0].EndIndex)
+	assert.Equal(t, 109, annotations[1].StartIndex)
+	assert.Equal(t, 109, annotations[1].EndIndex)
+	assert.Equal(t, 109, annotations[2].StartIndex)
+	assert.Equal(t, 109, annotations[2].EndIndex)
+	assert.Equal(t, 242, annotations[3].StartIndex)
+	assert.Equal(t, 242, annotations[3].EndIndex)
+}
+
 type testStructuredOutput struct {
 	Name  string `json:"name"`
 	Score int    `json:"score"`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Fixes native web search citation placement for Anthropic/Bifrost streaming responses by tracking fallback offsets in JavaScript UTF-16 code units and normalizing provider-missing zero-width citation positions before emitting annotations.

Validation:
- `go test -v ./bifrost -run 'TestFillMissingAnnotationIndicesUsesUTF16|TestNormalizeMissingAnnotationPositions|TestConvertBifrostAnnotation'`
- `go test -v ./bifrost`
- Built and deployed the plugin locally with `make dist-ci` and `pluginctl deploy`.
- Configured an Anthropic native web search agent with `ANTHROPIC_API_KEY` and verified a real Mattermost response. Stored native annotation offsets for the final response were non-zero (`128`, `129`, `290`, `340`) and rendered citations were not inserted at the beginning or inside words.

#### Ticket Link

N/A

#### Screenshots

![Native citation final response](https://cursor.com/artifacts/c/art-ce034c80-2c6e-41f4-afec-c041185d2f00)

<a href="https://cursor.com/agents/bc-0e7b3fe4-b150-42a9-bbee-3919625e6b0a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnative_citation_final_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-e1adfe4b-e722-40a4-afb7-15b68df71033" alt="native_citation_final_walkthrough.mp4" /></a>

Final persisted offsets: `/opt/cursor/artifacts/native_citation_final_offsets.json`

#### Release Note

```release-note
Fixed native web search citation placement for Anthropic streaming responses containing non-ASCII text or provider-missing citation indices.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e7b3fe4-b150-42a9-bbee-3919625e6b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e7b3fe4-b150-42a9-bbee-3919625e6b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of text position tracking in streaming responses for emojis, special characters and mixed Unicode content.
  * Fixed annotation index completion so missing start/end positions are correctly determined during streaming.

* **Tests**
  * Added unit tests validating annotation position calculations across diverse character types, including emoji and punctuation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->