### PR TITLE
Revert "MM-67913: Stop toggling app__body on Agents product page"

### DIFF
--- a/webapp/src/components/agents/agents_page.tsx
+++ b/webapp/src/components/agents/agents_page.tsx
@@ -15,13 +15,19 @@ export const AGENTS_ROUTE = `/plug/${manifest.id}/agents`;
 // No URL-matching or overlay needed; Mattermost's product routing handles it.
 const AgentsPage = () => {
     useEffect(() => {
-        // The host webapp owns `app__body` on document.body (see MM-67913 / Boards #188).
-        // ChannelController normally sets `channel-view` on #root, but it's not loaded in
-        // product views. Without it the global header loses its themed colors.
+        // ChannelController normally sets these classes, but it's not loaded in
+        // product views. Without them the global header loses its themed colors.
+        // Playbooks and Boards do the same thing in their top-level components.
+        document.body.classList.add('app__body');
+
         const root = document.getElementById('root');
         if (root && !root.classList.contains('channel-view')) {
             root.classList.add('channel-view');
         }
+
+        return () => {
+            document.body.classList.remove('app__body');
+        };
     }, []);
 
     return (


### PR DESCRIPTION
Reverts mattermost/mattermost-plugin-agents#683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header styling on the Agents page to ensure consistent theme appearance in product and plug views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->