### PR TITLE
Preserve thread post attachments for agent mentions

### DIFF
--- a/conversation/service.go
+++ b/conversation/service.go
@@ -582,11 +582,17 @@ func (s *Service) BuildChannelMentionRequest(
 	turnByPostID := make(map[string]store.Turn)
 	// Turns without post IDs (tool rounds, etc.) keyed by index.
 	var turnsWithoutPosts []store.Turn
+	latestPostLinkedSequence := 0
+	latestPostLinkedPostID := ""
 
 	for _, turn := range turns {
 		if turn.PostID != nil {
 			turnPostIDs[*turn.PostID] = true
 			turnByPostID[*turn.PostID] = turn
+			if turn.Sequence > latestPostLinkedSequence {
+				latestPostLinkedSequence = turn.Sequence
+				latestPostLinkedPostID = *turn.PostID
+			}
 		} else {
 			turnsWithoutPosts = append(turnsWithoutPosts, turn)
 		}
@@ -661,6 +667,9 @@ func (s *Service) BuildChannelMentionRequest(
 			}
 			blocks := userBlocksWithAttachments("@"+username+": "+format.PostBody(threadPost), threadPost.FileIds, s.mmClient)
 			posts = append(posts, BlocksToPost(blocks, "user", redactUnshared, s.mmClient, enableVision, maxFileSize))
+		}
+		if latestPostLinkedPostID != "" && threadPost.Id == latestPostLinkedPostID {
+			break
 		}
 	}
 

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -584,6 +584,7 @@ func (s *Service) BuildChannelMentionRequest(
 	var turnsWithoutPosts []store.Turn
 	latestPostLinkedSequence := 0
 	latestPostLinkedPostID := ""
+	latestPostLinkedRole := ""
 
 	for _, turn := range turns {
 		if turn.PostID != nil {
@@ -592,6 +593,7 @@ func (s *Service) BuildChannelMentionRequest(
 			if turn.Sequence > latestPostLinkedSequence {
 				latestPostLinkedSequence = turn.Sequence
 				latestPostLinkedPostID = *turn.PostID
+				latestPostLinkedRole = turn.Role
 			}
 		} else {
 			turnsWithoutPosts = append(turnsWithoutPosts, turn)
@@ -668,7 +670,7 @@ func (s *Service) BuildChannelMentionRequest(
 			blocks := userBlocksWithAttachments("@"+username+": "+format.PostBody(threadPost), threadPost.FileIds, s.mmClient)
 			posts = append(posts, BlocksToPost(blocks, "user", redactUnshared, s.mmClient, enableVision, maxFileSize))
 		}
-		if latestPostLinkedPostID != "" && threadPost.Id == latestPostLinkedPostID {
+		if latestPostLinkedRole == "user" && threadPost.Id == latestPostLinkedPostID {
 			break
 		}
 	}

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -653,15 +653,14 @@ func (s *Service) BuildChannelMentionRequest(
 			}
 			posts = append(posts, runPosts...)
 		} else {
-			// Render as plain text with @username prefix.
+			// Render as user content with @username prefix, preserving any
+			// uploaded files on thread posts that are not stored turns.
 			username := ""
 			if user, ok := threadData.UsersByID[threadPost.UserId]; ok {
 				username = user.Username
 			}
-			posts = append(posts, llm.Post{
-				Role:    llm.PostRoleUser,
-				Message: "@" + username + ": " + format.PostBody(threadPost),
-			})
+			blocks := userBlocksWithAttachments("@"+username+": "+format.PostBody(threadPost), threadPost.FileIds, s.mmClient)
+			posts = append(posts, BlocksToPost(blocks, "user", redactUnshared, s.mmClient, enableVision, maxFileSize))
 		}
 	}
 

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -667,7 +667,7 @@ func (s *Service) BuildChannelMentionRequest(
 			if user, ok := threadData.UsersByID[threadPost.UserId]; ok {
 				username = user.Username
 			}
-			blocks := userBlocksWithAttachments("@"+username+": "+format.PostBody(threadPost), threadPost.FileIds, s.mmClient)
+			blocks := userBlocksWithAttachments(format.AuthoredPost(threadPost, username), threadPost.FileIds, s.mmClient)
 			posts = append(posts, BlocksToPost(blocks, "user", redactUnshared, s.mmClient, enableVision, maxFileSize))
 		}
 		if latestPostLinkedRole == "user" && threadPost.Id == latestPostLinkedPostID {

--- a/conversation/service_test.go
+++ b/conversation/service_test.go
@@ -1343,6 +1343,55 @@ func TestBuildChannelMentionRequest_MixedThread(t *testing.T) {
 	assert.Contains(t, req.Posts[3].Message, "comment from B")
 }
 
+func TestBuildChannelMentionRequest_StopsAtCurrentUserTurn(t *testing.T) {
+	svc, s := setupTestService(t)
+
+	botID := model.NewId()
+	userID := model.NewId()
+	rootPostID := "trim_root"
+	currentPostID := "current_mention"
+
+	result, err := svc.CreateConversation(CreateConversationParams{
+		UserID:       userID,
+		BotID:        botID,
+		RootPostID:   &rootPostID,
+		Operation:    "conversation",
+		SystemPrompt: "system",
+		UserMessage:  "@aibot look at the earlier post",
+		UserPostID:   stringPtr(currentPostID),
+	})
+	require.NoError(t, err)
+
+	conv, err := s.GetConversation(result.ConversationID)
+	require.NoError(t, err)
+
+	threadData := &mmapi.ThreadData{
+		Posts: []*model.Post{
+			{Id: rootPostID, UserId: userID, CreateAt: 1000, Message: "earlier context"},
+			{Id: currentPostID, UserId: userID, CreateAt: 2000, Message: "@aibot look at the earlier post"},
+			{Id: "placeholder", UserId: botID, CreateAt: 3000, Message: "Thinking..."},
+			{Id: "later_reply", UserId: userID, CreateAt: 4000, Message: "this happened after the mention"},
+		},
+		UsersByID: map[string]*model.User{
+			userID: {Id: userID, Username: "alice"},
+			botID:  {Id: botID, Username: "aibot"},
+		},
+	}
+
+	svc.bots = &testBotLookup{botUserIDs: map[string]bool{botID: true}}
+
+	req, err := svc.BuildChannelMentionRequest(conv, &llm.Context{}, threadData)
+	require.NoError(t, err)
+
+	require.Len(t, req.Posts, 3, "system + earlier context + current mention")
+	assert.Contains(t, req.Posts[1].Message, "earlier context")
+	assert.Contains(t, req.Posts[2].Message, "@aibot look at the earlier post")
+	for _, post := range req.Posts {
+		assert.NotContains(t, post.Message, "Thinking...")
+		assert.NotContains(t, post.Message, "this happened after the mention")
+	}
+}
+
 func TestBuildChannelMentionRequest_MultiBotThread(t *testing.T) {
 	svc, s := setupTestService(t)
 

--- a/conversation/service_test.go
+++ b/conversation/service_test.go
@@ -2109,4 +2109,74 @@ func TestBuildChannelMentionRequest_AttachmentsResolveLazily(t *testing.T) {
 		assert.Contains(t, userPost.Message, "Content: hello",
 			"text-file content must still flow through to the LLM via the channel-mention path")
 	})
+
+	t.Run("image on root post is visible to later mention in same thread", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+
+		mmClient.On("GetFileInfo", "img-root").Return(&model.FileInfo{
+			Id: "img-root", Name: "screenshot.png", MimeType: "image/png", Size: 100,
+		}, nil)
+		mmClient.On("GetFile", "img-root").Return(io.NopCloser(strings.NewReader("PNGDATA")), nil)
+
+		botID := model.NewId()
+		userID := model.NewId()
+		rootPostID := "root_post_with_image"
+		mentionPostID := "later_mention_post"
+		bots := &testBotLookup{
+			botUserIDs: map[string]bool{botID: true},
+			configByID: map[string]testBotConfig{
+				botID: {enableVision: true, maxFileSize: 0},
+			},
+		}
+
+		svc, _ := setupTestServiceWithClient(t, mmClient, bots)
+
+		result, err := svc.CreateConversation(CreateConversationParams{
+			UserID:       userID,
+			BotID:        botID,
+			RootPostID:   stringPtr(rootPostID),
+			Operation:    "conversation",
+			SystemPrompt: "system",
+			UserMessage:  "@aibot what do you think?",
+			UserPostID:   stringPtr(mentionPostID),
+		})
+		require.NoError(t, err)
+
+		conv, err := svc.GetConversation(result.ConversationID)
+		require.NoError(t, err)
+
+		threadData := &mmapi.ThreadData{
+			Posts: []*model.Post{
+				{
+					Id:       rootPostID,
+					UserId:   userID,
+					CreateAt: 1000,
+					Message:  "I noticed this",
+					FileIds:  []string{"img-root"},
+				},
+				{
+					Id:       mentionPostID,
+					UserId:   userID,
+					CreateAt: 2000,
+					Message:  "@aibot what do you think?",
+				},
+			},
+			UsersByID: map[string]*model.User{
+				userID: {Id: userID, Username: "alice"},
+				botID:  {Id: botID, Username: "aibot"},
+			},
+		}
+
+		req, err := svc.BuildChannelMentionRequest(conv, &llm.Context{}, threadData)
+		require.NoError(t, err)
+
+		require.Len(t, req.Posts, 3, "system + root thread post + later mention turn")
+		rootPost := req.Posts[1]
+		require.Equal(t, llm.PostRoleUser, rootPost.Role)
+		require.Len(t, rootPost.Files, 1,
+			"image attachments on earlier thread posts must be visible when a later post mentions the agent")
+		assert.Equal(t, "image/png", rootPost.Files[0].MimeType)
+		assert.Contains(t, rootPost.Message, "@alice")
+		assert.Contains(t, rootPost.Message, "I noticed this")
+	})
 }

--- a/format/format.go
+++ b/format/format.go
@@ -71,6 +71,12 @@ func PostBody(post *model.Post) string {
 	return post.Message
 }
 
+// AuthoredPost formats a post body with the username of its author for LLM
+// consumption.
+func AuthoredPost(post *model.Post, username string) string {
+	return "@" + username + ": " + PostBody(post)
+}
+
 // PostEntry holds pre-resolved data for formatting a single post.
 // Used by MCP tools and other callers that need structured post output.
 type PostEntry struct {

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -241,6 +241,50 @@ Valid field: "Valid value"
 	}
 }
 
+func TestAuthoredPost(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		post     *model.Post
+		expected string
+	}{
+		{
+			name:     "post body with author username",
+			username: "alice",
+			post:     &model.Post{Message: "I noticed this"},
+			expected: "@alice: I noticed this",
+		},
+		{
+			name:     "post body with missing username",
+			username: "",
+			post:     &model.Post{Message: "orphaned context"},
+			expected: "@: orphaned context",
+		},
+		{
+			name:     "uses post body including attachments",
+			username: "bob",
+			post: &model.Post{
+				Message: "See attached",
+				Props: map[string]any{
+					"attachments": []any{
+						map[string]any{
+							"title": "Report",
+							"text":  "Q4 numbers",
+						},
+					},
+				},
+			},
+			expected: "@bob: See attached\nReport\nQ4 numbers\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, AuthoredPost(tt.post, tt.username))
+		})
+	}
+}
+
 func TestFormatPost(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Fixes channel mention request construction so earlier thread posts that are not persisted conversation turns still preserve uploaded file attachments. This lets an agent see an image uploaded on the thread root when a later reply mentions the agent.

Also limits live channel mention context to the latest user turn for the active conversation so response placeholders or later concurrent replies are not included in the LLM request, while preserving normal thread context after prior assistant turns.

Regression coverage added for:
- a root post with an image attachment followed by a separate mention post
- trimming live channel mention context at the current user mention turn

Verification:
- Reproduced pre-fix failure with `go test ./conversation -run 'TestBuildChannelMentionRequest_AttachmentsResolveLazily/image_on_root_post_is_visible_to_later_mention_in_same_thread' -count=1 -v` (`Files` length was 0)
- `go test ./conversation -run 'TestBuildChannelMentionRequest_AttachmentsResolveLazily' -count=1 -v`
- `go test ./conversation -run 'TestBuildChannelMentionRequest_(MixedThread|StopsAtCurrentUserTurn|BotTurnsOnly|MultiBotThread|ToolRoundsMerged)' -count=1 -v`
- `go test ./conversation ./conversations -count=1`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68653

#### Screenshots
<img width="539" height="940" alt="image" src="https://github.com/user-attachments/assets/2f85f513-41fd-4676-87ef-ce1949667193" />
<img width="507" height="846" alt="image" src="https://github.com/user-attachments/assets/fc4b311d-4e8b-4d37-8372-a68ac4172b4a" />
<img width="573" height="1196" alt="image" src="https://github.com/user-attachments/assets/bbc4d5e7-930c-42f6-8b75-7555d16753bf" />


#### Release Note
```release-note
Fixed image attachments on earlier thread posts not being visible to agents when the agent is mentioned from a later thread reply.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87d0b3ea-1ae5-462a-ad5c-f2be1e39d5c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87d0b3ea-1ae5-462a-ad5c-f2be1e39d5c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Threaded mentions now preserve earlier posts as proper user posts, retaining their attachments and file references so images/files remain visible in context.
  * Images referenced on earlier thread posts are resolved lazily when vision is enabled and included in the mention prompt as needed.
  * Thread context trimming: mention prompts now stop at the most recent linked user post to avoid pulling in unrelated conversation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->