### PR TITLE
Make stuck reindex jobs always recoverable

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -552,45 +552,45 @@ func (s *Indexer) isJobStale(jobStatus *JobStatus) bool {
 	return time.Since(lastUpdate) > StaleJobThreshold
 }
 
-// MarkOrphanedJobAsFailed marks a non-terminal job owned by this node as failed.
-// Intended to run at plugin startup so a crashed run (including one stuck in
-// cancel_requested) does not block future Starts.
+// MarkOrphanedJobAsFailed reclaims any non-terminal reindex job whose
+// heartbeat is older than StaleJobThreshold, on any node. Keying on
+// staleness (not the original NodeID) lets containerized deploys —
+// where the hostname changes on restart — and clustered deploys — where
+// the original node may be gone — recover after a crash. Resumable=true
+// preserves the cursor so the admin can resume from where the wedged
+// run left off.
 func (s *Indexer) MarkOrphanedJobAsFailed() error {
 	var jobStatus JobStatus
 	err := s.pluginAPI.KVGet(ReindexJobKey, &jobStatus)
 	if err != nil {
 		if mmapi.IsKVNotFound(err) {
-			return nil // No job exists, nothing to do
+			return nil
 		}
 		return err
 	}
 
-	if jobStatus.Status != JobStatusRunning && jobStatus.Status != JobStatusCancelRequested {
-		return nil
-	}
-
-	currentNodeID := s.getNodeID()
-	if jobStatus.NodeID != currentNodeID {
+	if !s.isJobStale(&jobStatus) {
 		return nil
 	}
 
 	newStatus := jobStatus
 	newStatus.Status = JobStatusFailed
-	newStatus.Error = fmt.Sprintf("Job orphaned: plugin restarted on node %s while job was running", currentNodeID)
+	newStatus.Resumable = true
+	newStatus.Error = fmt.Sprintf("Job orphaned: heartbeat older than %s on node %q",
+		StaleJobThreshold, jobStatus.NodeID)
 	newStatus.CompletedAt = time.Now()
 
-	s.pluginAPI.LogWarn("Marking orphaned reindex job as failed",
-		"node_id", currentNodeID,
+	s.pluginAPI.LogWarn("Reclaiming stale reindex job",
+		"job_id", jobStatus.JobID,
+		"previous_status", jobStatus.Status,
+		"node_id", jobStatus.NodeID,
 		"processed_rows", jobStatus.ProcessedRows)
 
-	// CAS-gate the write so a fresh run that has already claimed the row on
-	// another node is not clobbered.
-	ok, casErr := s.pluginAPI.KVCompareAndSet(ReindexJobKey, jobStatus, newStatus)
-	if casErr != nil {
+	// CAS so a fresh run that has already claimed the row on another
+	// node is not clobbered. We don't care if the CAS loses — that just
+	// means someone else already moved the row.
+	if _, casErr := s.pluginAPI.KVCompareAndSet(ReindexJobKey, jobStatus, newStatus); casErr != nil {
 		return casErr
-	}
-	if !ok {
-		return nil
 	}
 	return nil
 }

--- a/indexer/indexer_job.go
+++ b/indexer/indexer_job.go
@@ -413,6 +413,13 @@ func (s *Indexer) getLastIndexedTimestamp() int64 {
 // saveJobStatus persists the worker's view of the job, gated on JobID match
 // so a worker whose row has been claimed by a newer run does not clobber it.
 // A status with no JobID falls back to an unconditional set.
+//
+// The cancel-survival guard closes a race in which the admin's
+// CancelJob CAS lands before this worker's KVGet: without it, the
+// worker would read cancel_requested and then CAS back to running,
+// silently erasing the cancel. Propagating cancel_requested onto the
+// worker's local status makes the next loop iteration observe the
+// cancel and exit.
 func (s *Indexer) saveJobStatus(status *JobStatus) {
 	if status.JobID == "" {
 		if err := s.pluginAPI.KVSet(ReindexJobKey, status); err != nil {
@@ -432,6 +439,12 @@ func (s *Indexer) saveJobStatus(status *JobStatus) {
 		s.pluginAPI.LogWarn("Reindex worker superseded by a newer run, dropping status write",
 			"worker_job_id", status.JobID,
 			"current_job_id", current.JobID)
+		return
+	}
+
+	if err == nil && current.JobID == status.JobID &&
+		current.Status == JobStatusCancelRequested && status.Status == JobStatusRunning {
+		status.Status = JobStatusCancelRequested
 		return
 	}
 

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -2739,13 +2739,13 @@ func TestResumeFromCheckpoint(t *testing.T) {
 
 // TestMarkOrphanedJobAsFailed tests the automatic marking of orphaned jobs on startup
 func TestMarkOrphanedJobAsFailed(t *testing.T) {
-	t.Run("marks running job on same node as failed", func(t *testing.T) {
+	t.Run("marks stale running job on same node as failed", func(t *testing.T) {
 		mockClient := mocks.NewMockClient(t)
 
 		// Get current hostname to match the job's NodeID
 		hostname, _ := os.Hostname()
 
-		// Return a running job on this node
+		// Return a stale running job on this node
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
 			Run(func(args mock.Arguments) {
 				status := args.Get(1).(*JobStatus)
@@ -2774,21 +2774,67 @@ func TestMarkOrphanedJobAsFailed(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, savedStatus)
 		assert.Equal(t, JobStatusFailed, savedStatus.Status)
-		assert.Contains(t, savedStatus.Error, "Job orphaned")
-		assert.Contains(t, savedStatus.Error, hostname)
+		assert.Contains(t, savedStatus.Error, "orphaned")
+		assert.True(t, savedStatus.Resumable,
+			"orphan reclaim must mark the row Resumable so admins can resume from cursor")
+		assert.Equal(t, int64(1000), savedStatus.ProcessedRows,
+			"orphan reclaim must preserve ProcessedRows for resume")
 		assert.False(t, savedStatus.CompletedAt.IsZero())
 	})
 
-	t.Run("does not mark job running on different node", func(t *testing.T) {
+	t.Run("marks stale running job on a different node as failed", func(t *testing.T) {
+		// Hostname-bound recovery is the wedge: in containerized deploys the
+		// hostname changes on restart, and in clusters the original node may
+		// be gone. Reclaim must key on staleness, not NodeID.
 		mockClient := mocks.NewMockClient(t)
 
-		// Return a running job on a DIFFERENT node
+		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
+			Run(func(args mock.Arguments) {
+				status := args.Get(1).(*JobStatus)
+				status.JobID = "wedged-job"
+				status.Status = JobStatusRunning
+				status.NodeID = "different-node-hostname"
+				status.ProcessedRows = 5000
+				status.StartedAt = time.Now().Add(-1 * time.Hour)
+				status.LastUpdatedAt = time.Now().Add(-StaleJobThreshold - time.Minute)
+			}).
+			Return(nil)
+
+		var saved JobStatus
+		mockClient.On("KVCompareAndSet", ReindexJobKey, mock.AnythingOfType("indexer.JobStatus"), mock.MatchedBy(func(v interface{}) bool {
+			status, ok := v.(JobStatus)
+			if !ok {
+				return false
+			}
+			saved = status
+			return status.Status == JobStatusFailed
+		})).Return(true, nil)
+
+		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
+
+		indexer := New(nil, nil, mockClient, nil, nil, nil)
+		err := indexer.MarkOrphanedJobAsFailed()
+
+		require.NoError(t, err)
+		assert.Equal(t, JobStatusFailed, saved.Status,
+			"a stale row on any node must be reclaimable; otherwise hostname-bound deploys wedge forever")
+		assert.True(t, saved.Resumable)
+		assert.Equal(t, int64(5000), saved.ProcessedRows)
+	})
+
+	t.Run("does NOT mark a job whose heartbeat is just inside the threshold", func(t *testing.T) {
+		// Boundary case: don't kill live jobs. A heartbeat one second
+		// inside StaleJobThreshold must not be treated as stale.
+		mockClient := mocks.NewMockClient(t)
+
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
 			Run(func(args mock.Arguments) {
 				status := args.Get(1).(*JobStatus)
 				status.Status = JobStatusRunning
 				status.NodeID = "different-node-hostname"
 				status.ProcessedRows = 1000
+				status.StartedAt = time.Now().Add(-time.Hour)
+				status.LastUpdatedAt = time.Now().Add(-StaleJobThreshold + time.Second)
 			}).
 			Return(nil)
 
@@ -2869,6 +2915,7 @@ func TestMarkOrphanedJobAsFailed(t *testing.T) {
 				status.Status = JobStatusRunning
 				status.NodeID = hostname
 				status.JobID = "stale-observation"
+				status.StartedAt = time.Now().Add(-1 * time.Hour)
 			}).
 			Return(nil)
 
@@ -3595,17 +3642,15 @@ func TestCancelRequestedIsRecoverableWhenStale(t *testing.T) {
 			"cancel_requested with no recent heartbeat must be flagged stale or it wedges every future Start")
 	})
 
-	t.Run("MarkOrphanedJobAsFailed reclaims a cancel_requested row owned by this node", func(t *testing.T) {
+	t.Run("MarkOrphanedJobAsFailed reclaims a stale cancel_requested row regardless of node", func(t *testing.T) {
 		mockClient := mocks.NewMockClient(t)
-
-		hostname, _ := os.Hostname()
 
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
 			Run(func(args mock.Arguments) {
 				status := args.Get(1).(*JobStatus)
 				status.JobID = "wedged-cancel"
 				status.Status = JobStatusCancelRequested
-				status.NodeID = hostname
+				status.NodeID = "any-other-node"
 				status.StartedAt = time.Now().Add(-time.Hour)
 			}).
 			Return(nil)
@@ -3627,5 +3672,38 @@ func TestCancelRequestedIsRecoverableWhenStale(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, JobStatusFailed, saved.Status,
 			"MarkOrphanedJobAsFailed must reclaim cancel_requested rows or the row stays wedged forever")
+		assert.True(t, saved.Resumable, "reclaim should mark cancel-wedged rows resumable")
 	})
+}
+
+// TestSaveJobStatusPreservesCancelRequested asserts that saveJobStatus
+// must not silently overwrite cancel_requested with running for the same
+// JobID. Otherwise the worker's heartbeat would erase the admin's cancel
+// signal.
+func TestSaveJobStatusPreservesCancelRequested(t *testing.T) {
+	mockClient := mocks.NewMockClient(t)
+
+	const jobID = "running-job"
+	mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
+		Run(func(args mock.Arguments) {
+			status := args.Get(1).(*JobStatus)
+			status.JobID = jobID
+			status.Status = JobStatusCancelRequested
+		}).
+		Return(nil)
+	mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
+
+	indexer := New(nil, nil, mockClient, nil, nil, nil)
+
+	worker := &JobStatus{
+		JobID:         jobID,
+		Status:        JobStatusRunning,
+		ProcessedRows: 100,
+	}
+	indexer.saveJobStatus(worker)
+
+	mockClient.AssertNotCalled(t, "KVCompareAndSet", mock.Anything, mock.Anything, mock.Anything)
+	mockClient.AssertNotCalled(t, "KVSet", mock.Anything, mock.Anything)
+	assert.Equal(t, JobStatusCancelRequested, worker.Status,
+		"saveJobStatus must propagate cancel_requested to the worker's local status so it observes the cancel on the next loop iteration")
 }

--- a/server/main.go
+++ b/server/main.go
@@ -275,8 +275,10 @@ func (p *Plugin) OnActivate() error {
 	// Create indexer service with getter function
 	indexerService := indexer.New(getSearch, configGetter, mmClient, bots, dbClient.DB, p.API)
 
-	// Mark any orphaned reindex jobs from this node as failed
-	// This handles the case where the plugin/server crashed while a job was running
+	// Mark any orphaned reindex jobs as failed (any node, staleness-based).
+	// Handles wedge cases where the plugin/server crashed while a job was
+	// running; works in containerized deploys where the hostname changes
+	// on restart and clustered deploys where the original node may be gone.
 	if orphanErr := indexerService.MarkOrphanedJobAsFailed(); orphanErr != nil {
 		pluginAPI.Log.Warn("Failed to check for orphaned reindex job", "error", orphanErr)
 	}

--- a/webapp/src/components/system_console/embedding_search/reindex_section.tsx
+++ b/webapp/src/components/system_console/embedding_search/reindex_section.tsx
@@ -189,6 +189,12 @@ const StaleText = styled.div`
     flex: 1;
 `;
 
+const StaleActions = styled.div`
+    margin-top: 8px;
+    display: flex;
+    gap: 8px;
+`;
+
 interface ReindexSectionProps {
     jobStatus: JobStatusType | null;
     statusMessage: StatusMessageType;
@@ -221,6 +227,8 @@ export const ReindexSection = ({
     // cancel_requested is non-terminal: the worker is still running until it
     // observes the request and writes canceled.
     const isReindexing = jobStatus?.status === 'running' || jobStatus?.status === 'cancel_requested';
+
+    const hasProgress = (jobStatus?.processed_rows ?? 0) > 0;
 
     // Check if job can be resumed (failed or canceled with progress)
     const canResume = (jobStatus?.status === 'failed' || jobStatus?.status === 'canceled') &&
@@ -266,9 +274,19 @@ export const ReindexSection = ({
                         <strong><FormattedMessage defaultMessage='Job May Be Stale'/></strong>
                         <br/>
                         <FormattedMessage
-                            defaultMessage='The reindex job has not updated in over 10 minutes. The node running it ({nodeId}) may have crashed. You can start a new reindex to resume from where it left off.'
+                            defaultMessage='The reindex job has not updated in over 10 minutes. The node running it ({nodeId}) may have crashed. Start a new run to take over from where it left off.'
                             values={{nodeId: jobStatus?.node_id || 'unknown'}}
                         />
+                        <StaleActions>
+                            {hasProgress && (
+                                <SecondaryButton onClick={onResumeClick}>
+                                    <FormattedMessage defaultMessage='Resume from checkpoint'/>
+                                </SecondaryButton>
+                            )}
+                            <SecondaryButton onClick={onReindexClick}>
+                                <FormattedMessage defaultMessage='Reindex from scratch'/>
+                            </SecondaryButton>
+                        </StaleActions>
                     </StaleText>
                 </StaleBanner>
             )}


### PR DESCRIPTION
#### Summary

Stuck reindex jobs in `cancel_requested` state could wedge forever. There were two underlying bugs:

1. **Hostname-bound orphan reclaim**: `MarkOrphanedJobAsFailed` only reclaimed rows where `NodeID == hostname`. In containerized deploys (k8s pods) the hostname changes on restart, and in clusters the original node may be gone — so the row stayed wedged across restarts.
2. **Cancel signal lost via heartbeat overwrite**: `saveJobStatus` did `KVGet → CAS oldValue=current, newValue=running`. If the admin's cancel CAS landed before the worker's `KVGet`, the worker read `cancel_requested` and then CASed back to `running`, silently erasing the cancel. The row would then either wedge (if the worker died) or quietly run to completion (if it didn't).

Fix:

- `MarkOrphanedJobAsFailed` now keys on `isJobStale` instead of `NodeID`, and sets `Resumable=true` so the cursor is preserved for resume.
- `saveJobStatus` adds a 4-line guard: if `current.Status == cancel_requested` for our JobID, drop the heartbeat write and propagate `cancel_requested` onto the worker's local status so the next loop iteration observes the cancel and exits.
- The stale banner UI now exposes "Resume from checkpoint" (when `processed_rows > 0`) and "Reindex from scratch" buttons, so admins can recover without restarting the plugin or waiting for a sweeper.

Recovery now works in both paths (verified independently):

- **Plugin restart**: `OnActivate` reclaims the stale row to `failed, Resumable=true` regardless of original NodeID. Admin clicks Resume; `StartReindexJob(clearIndex=false)` preserves `ProcessedRows`/`TotalRows`/`CutoffAt`, doesn't delete the cursor, and the new worker resumes from the last checkpoint.
- **No restart, ≤10 min wait**: `isJobStale` flips true; the stale banner appears with Resume/Reindex actions. Same `StartReindexJob` CAS-replace path; the new `saveJobStatus` guard prevents any still-alive zombie worker from un-canceling the row before the CAS lands.


```release-note
Fixed an issue where reindex jobs stuck in cancel_requested could wedge indefinitely, especially in containerized deploys. Stuck jobs are now reclaimed on plugin startup regardless of hostname, and the system console exposes Resume/Reindex actions when a job is detected as stale.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of orphaned reindex jobs across distributed deployments by detecting stale jobs regardless of originating node; enhances reliability in clustered and containerized environments.
  * Fixed race condition that could overwrite cancellation requests during job status updates.

* **Improvements**
  * Enhanced reindex UI to conditionally display "Resume from checkpoint" button only when prior progress exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->