### PR TITLE
MM-68666 - Updating use effect for body theming

### DIFF
--- a/webapp/src/components/agents/agents_page.tsx
+++ b/webapp/src/components/agents/agents_page.tsx
@@ -15,13 +15,29 @@ export const AGENTS_ROUTE = `/plug/${manifest.id}/agents`;
 // No URL-matching or overlay needed; Mattermost's product routing handles it.
 const AgentsPage = () => {
     useEffect(() => {
-        // The host webapp owns `app__body` on document.body (see MM-67913 / Boards #188).
-        // ChannelController normally sets `channel-view` on #root, but it's not loaded in
-        // product views. Without it the global header loses its themed colors.
+        // ChannelController normally sets `app__body` on document.body and `channel-view`
+        // on #root, but it's not loaded in product views. Without them the global header
+        // and themed CSS variables are not applied (see MM-67913 / Boards #188).
+        const body = document.body;
         const root = document.getElementById('root');
-        if (root && !root.classList.contains('channel-view')) {
+        const addedAppBody = !body.classList.contains('app__body');
+        const addedChannelView = root && !root.classList.contains('channel-view');
+
+        if (addedAppBody) {
+            body.classList.add('app__body');
+        }
+        if (addedChannelView) {
             root.classList.add('channel-view');
         }
+
+        return () => {
+            if (addedAppBody) {
+                body.classList.remove('app__body');
+            }
+            if (addedChannelView) {
+                root?.classList.remove('channel-view');
+            }
+        };
     }, []);
 
     return (


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
MM-68666 - Updating use effect for body theming

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-68666

#### Screenshots
<img width="2968" height="1732" alt="CleanShot 2026-05-05 at 19 23 09@2x" src="https://github.com/user-attachments/assets/e8990529-48fb-4ca8-8e8c-e085a9d8d23b" />


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS class management and cleanup for the agents page to ensure consistent styling behaviour during navigation and page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->