### PR TITLE
Mirror request_as field on automation AIPromptActionConfig

### DIFF
--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -116,6 +116,11 @@ type AIPromptActionConfig struct {
 	ProviderID   string                `json:"provider_id"`
 	AllowedTools []string              `json:"allowed_tools,omitempty"`
 	Guardrails   *AutomationGuardrails `json:"guardrails,omitempty"`
+	// RequestAs selects which user the AI completion request is attributed to.
+	// Allowed values: "" or "triggerer" (default — the user who triggered the
+	// automation, falling back to the flow creator when the trigger has no
+	// associated user) or "creator" (always the flow creator).
+	RequestAs string `json:"request_as,omitempty"`
 }
 
 // Automation mirrors the channel-automation plugin's Automation model.


### PR DESCRIPTION
## Summary
- Mirror the new `request_as` field on the channel-automation plugin's `AIPromptActionConfig` (mattermost/mattermost-plugin-channel-automation#37) so the agents plugin doesn't drop it during JSON marshaling when the LLM creates or updates an automation.
