### PR TITLE
Explicit validation for userId when allowed_tools set

### DIFF
--- a/api/api_llm_bridge.go
+++ b/api/api_llm_bridge.go
@@ -282,6 +282,9 @@ func (a *API) prepareAgentBridgeCompletion(
 	if err != nil {
 		return nil, llm.CompletionRequest{}, nil, nil, nil, http.StatusBadRequest, fmt.Errorf("invalid allowed_tools: %w", err)
 	}
+	if allowedToolNames != nil && req.UserID == "" {
+		return nil, llm.CompletionRequest{}, nil, nil, nil, http.StatusBadRequest, errors.New("allowed_tools requires user_id")
+	}
 
 	bot, err := a.getBotByAgent(agent)
 	if err != nil {

--- a/api/api_llm_bridge_test.go
+++ b/api/api_llm_bridge_test.go
@@ -1654,6 +1654,30 @@ func TestBridgeClientAgentCompletionAllowedToolsEnablesAutoRun(t *testing.T) {
 	require.Len(t, fakeLLM.LastConversation.Context.Tools.GetTools(), 1)
 }
 
+func TestPrepareAgentBridgeCompletionAllowedToolsRequiresUserID(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	_, _, _, _, _, statusCode, err := e.api.prepareAgentBridgeCompletion(
+		testBotUserID,
+		bridgeclient.CompletionRequest{
+			Posts: []bridgeclient.Post{
+				{Role: "user", Message: "Hi"},
+			},
+			AllowedTools: []string{"eligible_tool"},
+		},
+		"",
+		llm.OperationBridgeAgent,
+		llm.SubTypeNoStream,
+	)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, statusCode)
+	require.Contains(t, err.Error(), "allowed_tools requires user_id")
+}
+
 func TestPrepareAgentBridgeCompletionToolHooksRequiresPluginID(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DefaultWriter = io.Discard


### PR DESCRIPTION
#### Summary
Explicit validation for userId when allowed_tools set. Previously it would fail further down the chain when assigning tools to the agent but it shouldn't get that far. 

#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* User ID is now required when using allowed tools parameter; requests missing this requirement will be rejected with a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->