### PR TITLE
Wire load-test mock LLM service

### DIFF
--- a/bots/bots.go
+++ b/bots/bots.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/config"
 	"github.com/mattermost/mattermost-plugin-agents/enterprise"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/mattermost/mattermost-plugin-agents/loadtest"
 	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 	"github.com/mattermost/mattermost-plugin-agents/subtitles"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -423,15 +424,10 @@ func (b *MMBots) ensureDefaultProfileImage(bot *Bot) {
 }
 
 func (b *MMBots) getLLM(serviceConfig llm.ServiceConfig, botConfig llm.BotConfig) (llm.LanguageModel, error) {
-	// Create the correct model using Bifrost for all providers
-	var result llm.LanguageModel
-	bifrostLLM, err := bifrost.NewFromServiceConfig(serviceConfig, botConfig)
+	result, err := b.getBaseLLM(serviceConfig, botConfig)
 	if err != nil {
-		b.pluginAPI.Log.Error("Unsupported service type for bot", "bot_name", botConfig.Name, "service_type", serviceConfig.Type)
-		return nil, fmt.Errorf("failed to create Bifrost client for %s: %w", serviceConfig.Type, err)
+		return nil, err
 	}
-
-	result = bifrostLLM
 
 	// Truncation Support
 	result = llm.NewLLMTruncationWrapper(result)
@@ -453,6 +449,33 @@ func (b *MMBots) getLLM(serviceConfig llm.ServiceConfig, botConfig llm.BotConfig
 	result = llm.NewStructuredOutputFallbackWrapper(result, botConfig.StructuredOutputEnabled)
 
 	return result, nil
+}
+
+func (b *MMBots) getBaseLLM(serviceConfig llm.ServiceConfig, botConfig llm.BotConfig) (llm.LanguageModel, error) {
+	if serviceConfig.Type == llm.ServiceTypeLoadTestMock {
+		profile, err := loadtest.ParseProfile(serviceConfig.LoadTestMockConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse load-test mock profile for bot %s: %w", botConfig.Name, err)
+		}
+		if b.pluginAPI != nil {
+			b.pluginAPI.Log.Info(
+				"Initialized load-test mock LLM",
+				"bot_name", botConfig.Name,
+				"service_id", serviceConfig.ID,
+				"profile_summary", profile.Summary(),
+			)
+		}
+		return loadtest.NewMockLLM(profile), nil
+	}
+
+	bifrostLLM, err := bifrost.NewFromServiceConfig(serviceConfig, botConfig)
+	if err != nil {
+		if b.pluginAPI != nil {
+			b.pluginAPI.Log.Error("Unsupported service type for bot", "bot_name", botConfig.Name, "service_type", serviceConfig.Type)
+		}
+		return nil, fmt.Errorf("failed to create Bifrost client for %s: %w", serviceConfig.Type, err)
+	}
+	return bifrostLLM, nil
 }
 
 // TODO: This really doesn't belong here. Figure out where to put this.

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -4,12 +4,15 @@
 package bots
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost-plugin-agents/enterprise"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/mattermost/mattermost-plugin-agents/loadtest"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
@@ -60,6 +63,169 @@ func (m *mockConfig) EnableTokenUsageLogToFile() bool {
 
 func (m *mockConfig) GetTranscriptGenerator() string {
 	return "testbot"
+}
+
+func newTestMMBots(t *testing.T, cfg *mockConfig) *MMBots {
+	t.Helper()
+	mockAPI := &plugintest.API{}
+	client := pluginapi.NewClient(mockAPI, nil)
+	mockAPI.On("LogError", mock.Anything).Return(nil).Maybe()
+	licenseChecker := enterprise.NewLicenseChecker(client)
+	return New(mockAPI, client, licenseChecker, cfg, nil, &http.Client{}, nil)
+}
+
+func loadTestService(raw json.RawMessage) llm.ServiceConfig {
+	return llm.ServiceConfig{
+		ID:                 "loadtest-svc",
+		Type:               llm.ServiceTypeLoadTestMock,
+		LoadTestMockConfig: raw,
+	}
+}
+
+func loadTestBot() llm.BotConfig {
+	return llm.BotConfig{
+		Name: "loadtest-bot",
+	}
+}
+
+func buildTinyLoadTestProfile(t *testing.T, profileWeights map[string]float64) json.RawMessage {
+	t.Helper()
+	type lat struct {
+		TTFTMs                    [2]int `json:"ttft_ms"`
+		ChunkCount                [2]int `json:"chunk_count"`
+		ChunkIntervalMs           [2]int `json:"chunk_interval_ms"`
+		TotalWallTimeMsPerRequest [2]int `json:"total_wall_time_ms_per_request"`
+	}
+	zero := lat{[2]int{0, 0}, [2]int{0, 0}, [2]int{0, 0}, [2]int{0, 0}}
+	if profileWeights == nil {
+		profileWeights = map[string]float64{
+			"realistic_default": 1,
+			"realistic_fast":    0,
+			"realistic_slow":    0,
+		}
+	}
+	payload := struct {
+		LatencyProfiles map[string]lat     `json:"latency_profiles"`
+		ProfileWeights  map[string]float64 `json:"profile_weights"`
+	}{
+		LatencyProfiles: map[string]lat{
+			"realistic_default": zero,
+			"realistic_fast":    zero,
+			"realistic_slow":    zero,
+		},
+		ProfileWeights: profileWeights,
+	}
+	b, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return b
+}
+
+func TestGetBaseLLMLoadTestMockReturnsMock(t *testing.T) {
+	cfg := &mockConfig{}
+	mmBots := newTestMMBots(t, cfg)
+	mockAPI := mmBots.ensureBotsClusterMutex.(*plugintest.API)
+
+	mockAPI.On("LogInfo",
+		"Initialized load-test mock LLM",
+		"bot_name", loadTestBot().Name,
+		"service_id", "loadtest-svc",
+		"profile_summary", mock.MatchedBy(func(summary string) bool { return summary != "" }),
+	).Return().Once()
+
+	model, err := mmBots.getBaseLLM(loadTestService(buildTinyLoadTestProfile(t, nil)), loadTestBot())
+	require.NoError(t, err)
+	require.IsType(t, &loadtest.MockLLM{}, model)
+	mockAPI.AssertExpectations(t)
+}
+
+func TestGetLLMLoadTestMockUsesWrapperChain(t *testing.T) {
+	cfg := &mockConfig{}
+	mmBots := newTestMMBots(t, cfg)
+	mockAPI := mmBots.ensureBotsClusterMutex.(*plugintest.API)
+
+	mockAPI.On("LogInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+
+	model, err := mmBots.getLLM(loadTestService(buildTinyLoadTestProfile(t, nil)), loadTestBot())
+	require.NoError(t, err)
+	require.NotNil(t, model)
+	require.Equal(t, 100000, model.InputTokenLimit())
+	require.Equal(t, 1, model.CountTokens("abcd"))
+}
+
+func TestGetLLMLoadTestMockInvalidProfileJSON(t *testing.T) {
+	cfg := &mockConfig{}
+	mmBots := newTestMMBots(t, cfg)
+
+	_, err := mmBots.getLLM(loadTestService(json.RawMessage(`{`)), loadTestBot())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse load-test mock profile")
+	require.Contains(t, err.Error(), "loadtest profile")
+
+	_, err = mmBots.getLLM(loadTestService(json.RawMessage(`{"unknown_top_level":true}`)), loadTestBot())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse load-test mock profile")
+}
+
+func TestGetBaseLLMLoadTestMockEmptyConfigUsesDefaultProfile(t *testing.T) {
+	cfg := &mockConfig{}
+	mmBots := newTestMMBots(t, cfg)
+	mockAPI := mmBots.ensureBotsClusterMutex.(*plugintest.API)
+
+	var summary string
+	mockAPI.On("LogInfo",
+		"Initialized load-test mock LLM",
+		"bot_name", loadTestBot().Name,
+		"service_id", "loadtest-svc",
+		"profile_summary", mock.MatchedBy(func(s string) bool {
+			summary = s
+			return strings.Contains(s, "realistic_default") &&
+				strings.Contains(s, "realistic_fast") &&
+				strings.Contains(s, "realistic_slow") &&
+				strings.Contains(s, "0.7000") &&
+				strings.Contains(s, "0.2000") &&
+				strings.Contains(s, "0.1000") &&
+				strings.Contains(s, "reasoning_skip_p=0.1000")
+		}),
+	).Return().Once()
+
+	svc := loadTestService(nil)
+	svc.LoadTestMockConfig = nil
+
+	model, err := mmBots.getBaseLLM(svc, loadTestBot())
+	require.NoError(t, err)
+	require.IsType(t, &loadtest.MockLLM{}, model)
+	require.NotEmpty(t, summary)
+	mockAPI.AssertExpectations(t)
+}
+
+func TestGetBaseLLMLoadTestMockProfileWeightOverride(t *testing.T) {
+	cfg := &mockConfig{}
+	mmBots := newTestMMBots(t, cfg)
+	mockAPI := mmBots.ensureBotsClusterMutex.(*plugintest.API)
+
+	var summary string
+	mockAPI.On("LogInfo",
+		"Initialized load-test mock LLM",
+		"bot_name", loadTestBot().Name,
+		"service_id", "loadtest-svc",
+		"profile_summary", mock.MatchedBy(func(s string) bool {
+			summary = s
+			return strings.Contains(s, "realistic_default=1.0000") &&
+				strings.Contains(s, "realistic_fast=0.0000") &&
+				strings.Contains(s, "realistic_slow=0.0000")
+		}),
+	).Return().Once()
+
+	weights := map[string]float64{
+		"realistic_default": 1.0,
+		"realistic_fast":    0.0,
+		"realistic_slow":    0.0,
+	}
+	model, err := mmBots.getBaseLLM(loadTestService(buildTinyLoadTestProfile(t, weights)), loadTestBot())
+	require.NoError(t, err)
+	require.IsType(t, &loadtest.MockLLM{}, model)
+	require.NotEmpty(t, summary)
+	mockAPI.AssertExpectations(t)
 }
 
 func TestGetAllBotUserIDs(t *testing.T) {

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -4,6 +4,7 @@
 package bots
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -149,7 +150,9 @@ func TestGetLLMLoadTestMockUsesWrapperChain(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, model)
 	require.Equal(t, 100000, model.InputTokenLimit())
-	require.Equal(t, 1, model.CountTokens("abcd"))
+	n, err := model.CountTokens(context.Background(), llm.CompletionRequest{Posts: []llm.Post{{Message: "abcd"}}})
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
 }
 
 func TestGetLLMLoadTestMockInvalidProfileJSON(t *testing.T) {

--- a/llm/configuration.go
+++ b/llm/configuration.go
@@ -4,7 +4,6 @@
 package llm
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -237,11 +236,7 @@ func IsValidService(service ServiceConfig) bool {
 		}
 		return json.Valid([]byte(service.VertexAuthCredentials))
 	case ServiceTypeLoadTestMock:
-		raw := service.LoadTestMockConfig
-		if len(bytes.TrimSpace(raw)) == 0 {
-			return true
-		}
-		return json.Valid(raw)
+		return isValidLoadTestMockConfig(service.LoadTestMockConfig)
 	default:
 		return false
 	}

--- a/llm/configuration.go
+++ b/llm/configuration.go
@@ -4,6 +4,7 @@
 package llm
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -46,6 +47,10 @@ type ServiceConfig struct {
 	// UseResponsesAPI determines whether to use the new OpenAI Responses API
 	// Only applicable to OpenAI and OpenAI-compatible services
 	UseResponsesAPI bool `json:"useResponsesAPI"`
+
+	// LoadTestMockConfig is raw JSON merged by loadtest.ParseProfile for ServiceTypeLoadTestMock.
+	// Nil, empty, or whitespace-only means the default read/search-heavy profile.
+	LoadTestMockConfig json.RawMessage `json:"loadTestMockConfig,omitempty"`
 }
 
 // ServiceUsesResponsesAPI reports whether the Responses API path is used for this service.
@@ -231,6 +236,12 @@ func IsValidService(service ServiceConfig) bool {
 			return true
 		}
 		return json.Valid([]byte(service.VertexAuthCredentials))
+	case ServiceTypeLoadTestMock:
+		raw := service.LoadTestMockConfig
+		if len(bytes.TrimSpace(raw)) == 0 {
+			return true
+		}
+		return json.Valid(raw)
 	default:
 		return false
 	}

--- a/llm/configuration_test.go
+++ b/llm/configuration_test.go
@@ -557,6 +557,24 @@ func TestIsValidService(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "Invalid loadtest mock service unknown profile field",
+			service: ServiceConfig{
+				ID:                 "loadtest",
+				Type:               ServiceTypeLoadTestMock,
+				LoadTestMockConfig: json.RawMessage(`{"unknown_top_level":true}`),
+			},
+			want: false,
+		},
+		{
+			name: "Invalid loadtest mock service unknown latency profile weight",
+			service: ServiceConfig{
+				ID:                 "loadtest",
+				Type:               ServiceTypeLoadTestMock,
+				LoadTestMockConfig: json.RawMessage(`{"profile_weights":{"does_not_exist":1}}`),
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/llm/configuration_test.go
+++ b/llm/configuration_test.go
@@ -524,6 +524,39 @@ func TestIsValidService(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "Valid loadtest mock service minimal",
+			service: ServiceConfig{
+				ID:   "loadtest",
+				Type: ServiceTypeLoadTestMock,
+			},
+			want: true,
+		},
+		{
+			name: "Valid loadtest mock service with profile JSON",
+			service: ServiceConfig{
+				ID:   "loadtest",
+				Type: ServiceTypeLoadTestMock,
+				LoadTestMockConfig: json.RawMessage(`{"profile_weights":{"realistic_default":1,"realistic_fast":0,"realistic_slow":0}}`),
+			},
+			want: true,
+		},
+		{
+			name: "Invalid loadtest mock service missing ID",
+			service: ServiceConfig{
+				Type: ServiceTypeLoadTestMock,
+			},
+			want: false,
+		},
+		{
+			name: "Invalid loadtest mock service malformed JSON config",
+			service: ServiceConfig{
+				ID:                 "loadtest",
+				Type:               ServiceTypeLoadTestMock,
+				LoadTestMockConfig: json.RawMessage(`{`),
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/llm/configuration_test.go
+++ b/llm/configuration_test.go
@@ -4,6 +4,7 @@
 package llm
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -535,8 +536,8 @@ func TestIsValidService(t *testing.T) {
 		{
 			name: "Valid loadtest mock service with profile JSON",
 			service: ServiceConfig{
-				ID:   "loadtest",
-				Type: ServiceTypeLoadTestMock,
+				ID:                 "loadtest",
+				Type:               ServiceTypeLoadTestMock,
 				LoadTestMockConfig: json.RawMessage(`{"profile_weights":{"realistic_default":1,"realistic_fast":0,"realistic_slow":0}}`),
 			},
 			want: true,

--- a/llm/loadtest_validation.go
+++ b/llm/loadtest_validation.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"math"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-agents/toolrunner/limits"
+)
+
+type loadTestMockProfileOverlay struct {
+	Name                     *string                                       `json:"name,omitempty"`
+	Seed                     *int64                                        `json:"seed,omitempty"`
+	LatencyProfiles          map[string]loadTestLatencyProfileOverlay      `json:"latency_profiles,omitempty"`
+	ProfileWeights           map[string]float64                            `json:"profile_weights,omitempty"`
+	ReasoningSkipProbability *float64                                      `json:"reasoning_skip_probability,omitempty"`
+	StreamingEnabled         *bool                                         `json:"streaming_enabled,omitempty"`
+	ToolUseProbability       *float64                                      `json:"tool_use_probability,omitempty"`
+	ToolWeights              map[string]float64                            `json:"tool_weights,omitempty"`
+	MaxToolRounds            *int                                          `json:"max_tool_rounds,omitempty"`
+	ToolArgumentProfiles     map[string]loadTestToolArgumentProfileOverlay `json:"tool_argument_profiles,omitempty"`
+	FinalResponseTemplates   []string                                      `json:"final_response_templates,omitempty"`
+}
+
+type loadTestLatencyProfileOverlay struct {
+	TTFTMs                    *[2]int `json:"ttft_ms,omitempty"`
+	ChunkCount                *[2]int `json:"chunk_count,omitempty"`
+	ChunkIntervalMs           *[2]int `json:"chunk_interval_ms,omitempty"`
+	TotalWallTimeMsPerRequest *[2]int `json:"total_wall_time_ms_per_request,omitempty"`
+}
+
+type loadTestToolArgumentProfileOverlay struct {
+	PostLimits     []int    `json:"post_limits,omitempty"`
+	SearchQueries  []string `json:"search_queries,omitempty"`
+	SearchLimits   []int    `json:"search_limits,omitempty"`
+	MessageLengths []int    `json:"message_lengths,omitempty"`
+	Usernames      []string `json:"usernames,omitempty"`
+	ChannelIDs     []string `json:"channel_ids,omitempty"`
+	ChannelNames   []string `json:"channel_names,omitempty"`
+	TeamIDs        []string `json:"team_ids,omitempty"`
+	TeamNames      []string `json:"team_names,omitempty"`
+	PostIDs        []string `json:"post_ids,omitempty"`
+}
+
+type loadTestLatencyProfile struct {
+	TTFTMs                    [2]int
+	ChunkCount                [2]int
+	ChunkIntervalMs           [2]int
+	TotalWallTimeMsPerRequest [2]int
+}
+
+func isValidLoadTestMockConfig(raw json.RawMessage) bool {
+	if raw == nil || len(bytes.TrimSpace(raw)) == 0 {
+		return true
+	}
+
+	var ov loadTestMockProfileOverlay
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&ov); err != nil {
+		return false
+	}
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); err != io.EOF {
+		return false
+	}
+
+	latencyProfiles := defaultLoadTestLatencyProfiles()
+	if ov.LatencyProfiles != nil {
+		if len(ov.LatencyProfiles) == 0 {
+			latencyProfiles = map[string]loadTestLatencyProfile{}
+		} else {
+			for name, overlay := range ov.LatencyProfiles {
+				existing, ok := latencyProfiles[name]
+				if !ok && !overlay.isComplete() {
+					return false
+				}
+				latencyProfiles[name] = overlay.applyTo(existing)
+			}
+		}
+	}
+
+	profileWeights := defaultLoadTestProfileWeights()
+	if ov.ProfileWeights != nil {
+		if len(ov.ProfileWeights) == 0 {
+			profileWeights = map[string]float64{}
+		} else {
+			for name, weight := range ov.ProfileWeights {
+				profileWeights[name] = weight
+			}
+		}
+	}
+
+	toolWeights := defaultLoadTestToolWeights()
+	if ov.ToolWeights != nil {
+		if len(ov.ToolWeights) == 0 {
+			toolWeights = map[string]float64{}
+		} else {
+			for name, weight := range ov.ToolWeights {
+				toolWeights[name] = weight
+			}
+		}
+	}
+
+	reasoningSkipProbability := 0.10
+	if ov.ReasoningSkipProbability != nil {
+		reasoningSkipProbability = *ov.ReasoningSkipProbability
+	}
+	toolUseProbability := 0.65
+	if ov.ToolUseProbability != nil {
+		toolUseProbability = *ov.ToolUseProbability
+	}
+	maxToolRounds := 5
+	if ov.MaxToolRounds != nil {
+		maxToolRounds = *ov.MaxToolRounds
+	}
+	finalResponseTemplates := []string{
+		"Load test summary for request %d.",
+		"Assistant reply %d (mock).",
+		"Completed mock response #%d.",
+	}
+	if ov.FinalResponseTemplates != nil {
+		finalResponseTemplates = ov.FinalResponseTemplates
+	}
+
+	return validateLoadTestMockProfile(latencyProfiles, profileWeights, toolWeights, reasoningSkipProbability, toolUseProbability, maxToolRounds, finalResponseTemplates)
+}
+
+func defaultLoadTestLatencyProfiles() map[string]loadTestLatencyProfile {
+	return map[string]loadTestLatencyProfile{
+		"realistic_default": {
+			TTFTMs:                    [2]int{3000, 12000},
+			ChunkCount:                [2]int{150, 400},
+			ChunkIntervalMs:           [2]int{30, 80},
+			TotalWallTimeMsPerRequest: [2]int{15000, 25000},
+		},
+		"realistic_fast": {
+			TTFTMs:                    [2]int{600, 2500},
+			ChunkCount:                [2]int{40, 120},
+			ChunkIntervalMs:           [2]int{40, 100},
+			TotalWallTimeMsPerRequest: [2]int{5000, 10000},
+		},
+		"realistic_slow": {
+			TTFTMs:                    [2]int{12000, 22000},
+			ChunkCount:                [2]int{400, 1000},
+			ChunkIntervalMs:           [2]int{15, 40},
+			TotalWallTimeMsPerRequest: [2]int{28000, 40000},
+		},
+	}
+}
+
+func defaultLoadTestProfileWeights() map[string]float64 {
+	return map[string]float64{
+		"realistic_default": 0.70,
+		"realistic_fast":    0.20,
+		"realistic_slow":    0.10,
+	}
+}
+
+func defaultLoadTestToolWeights() map[string]float64 {
+	return map[string]float64{
+		"read_channel":        0.20,
+		"search_posts":        0.20,
+		"search_users":        0.10,
+		"get_channel_info":    0.12,
+		"WebSearch":           0.12,
+		"read_post":           0.08,
+		"get_channel_members": 0.05,
+		"get_user_channels":   0.05,
+		"create_post":         0.02,
+		"dm":                  0.03,
+		"group_message":       0.03,
+	}
+}
+
+func (o loadTestLatencyProfileOverlay) isComplete() bool {
+	return o.TTFTMs != nil &&
+		o.ChunkCount != nil &&
+		o.ChunkIntervalMs != nil &&
+		o.TotalWallTimeMsPerRequest != nil
+}
+
+func (o loadTestLatencyProfileOverlay) applyTo(base loadTestLatencyProfile) loadTestLatencyProfile {
+	if o.TTFTMs != nil {
+		base.TTFTMs = *o.TTFTMs
+	}
+	if o.ChunkCount != nil {
+		base.ChunkCount = *o.ChunkCount
+	}
+	if o.ChunkIntervalMs != nil {
+		base.ChunkIntervalMs = *o.ChunkIntervalMs
+	}
+	if o.TotalWallTimeMsPerRequest != nil {
+		base.TotalWallTimeMsPerRequest = *o.TotalWallTimeMsPerRequest
+	}
+	return base
+}
+
+func validateLoadTestMockProfile(latencyProfiles map[string]loadTestLatencyProfile, profileWeights map[string]float64, toolWeights map[string]float64, reasoningSkipProbability float64, toolUseProbability float64, maxToolRounds int, finalResponseTemplates []string) bool {
+	if len(latencyProfiles) == 0 {
+		return false
+	}
+	for _, lp := range latencyProfiles {
+		if !isValidLoadTestLatencyRange(lp.TTFTMs) ||
+			!isValidLoadTestLatencyRange(lp.ChunkCount) ||
+			!isValidLoadTestLatencyRange(lp.ChunkIntervalMs) ||
+			!isValidLoadTestLatencyRange(lp.TotalWallTimeMsPerRequest) {
+			return false
+		}
+	}
+	if !isValidLoadTestWeightMap(profileWeights, true) {
+		return false
+	}
+	for name := range profileWeights {
+		if _, ok := latencyProfiles[name]; !ok {
+			return false
+		}
+	}
+	if !isValidLoadTestWeightMap(toolWeights, true) {
+		return false
+	}
+	if !isFiniteLoadTestProbability(reasoningSkipProbability) || !isFiniteLoadTestProbability(toolUseProbability) {
+		return false
+	}
+	if maxToolRounds < 0 || maxToolRounds > limits.MaxToolRounds {
+		return false
+	}
+	if len(finalResponseTemplates) == 0 {
+		return false
+	}
+	for _, template := range finalResponseTemplates {
+		if strings.TrimSpace(template) == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidLoadTestWeightMap(m map[string]float64, requirePositiveSum bool) bool {
+	if len(m) == 0 {
+		return false
+	}
+	sum := 0.0
+	for k, w := range m {
+		if k == "" || math.IsNaN(w) || math.IsInf(w, 0) || w < 0 {
+			return false
+		}
+		sum += w
+	}
+	return !requirePositiveSum || sum > 0
+}
+
+func isFiniteLoadTestProbability(p float64) bool {
+	return !math.IsNaN(p) && !math.IsInf(p, 0) && p >= 0 && p <= 1
+}
+
+func isValidLoadTestLatencyRange(bounds [2]int) bool {
+	return bounds[0] >= 0 && bounds[1] >= 0 && bounds[0] <= bounds[1]
+}

--- a/llm/service_types.go
+++ b/llm/service_types.go
@@ -14,4 +14,5 @@ const (
 	ServiceTypeScale            = "scale"
 	ServiceTypeGemini           = "gemini"
 	ServiceTypeVertex           = "vertex"
+	ServiceTypeLoadTestMock     = "loadtest_mock"
 )

--- a/loadtest/mock_llm.go
+++ b/loadtest/mock_llm.go
@@ -418,8 +418,18 @@ func (m *MockLLM) ChatCompletionNoStream(ctx context.Context, req llm.Completion
 	return sr.FinalText, nil
 }
 
-// CountTokens approximates tokens as ~4 characters with a minimum of 1 when non-empty.
-func (m *MockLLM) CountTokens(text string) int {
+// CountTokens approximates input tokens across the request's posts. The mock
+// always returns a count, so callers never fall back to EstimateTokens.
+func (m *MockLLM) CountTokens(_ context.Context, request llm.CompletionRequest, _ ...llm.LanguageModelOption) (int, error) {
+	var b strings.Builder
+	for _, p := range request.Posts {
+		b.WriteString(p.Message)
+	}
+	return countTextTokens(b.String()), nil
+}
+
+// countTextTokens approximates tokens as ~4 characters with a minimum of 1 when non-empty.
+func countTextTokens(text string) int {
 	if len(text) == 0 {
 		return 0
 	}
@@ -432,6 +442,11 @@ func (m *MockLLM) CountTokens(text string) int {
 
 // InputTokenLimit returns a generous limit for load testing.
 func (m *MockLLM) InputTokenLimit() int {
+	return 100000
+}
+
+// OutputTokenLimit returns a generous limit for load testing.
+func (m *MockLLM) OutputTokenLimit() int {
 	return 100000
 }
 

--- a/loadtest/mock_llm_test.go
+++ b/loadtest/mock_llm_test.go
@@ -481,7 +481,6 @@ func TestToolArgumentsVaryBySeed(t *testing.T) {
 
 func TestCountTokens(t *testing.T) {
 	t.Parallel()
-	m := NewMockLLM(fastTestProfile())
 	tests := []struct {
 		name  string
 		input string
@@ -495,11 +494,26 @@ func TestCountTokens(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			mock := NewMockLLM(fastTestProfile())
-			require.Equal(t, tt.want, mock.CountTokens(tt.input))
+			require.Equal(t, tt.want, countTextTokens(tt.input))
 		})
 	}
+}
+
+func TestCountTokensSumsPosts(t *testing.T) {
+	t.Parallel()
+	m := NewMockLLM(fastTestProfile())
+	n, err := m.CountTokens(context.Background(), llm.CompletionRequest{
+		Posts: []llm.Post{{Message: "abcd"}, {Message: "efgh"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+}
+
+func TestMockLLMTokenLimits(t *testing.T) {
+	t.Parallel()
+	m := NewMockLLM(fastTestProfile())
 	require.Equal(t, 100000, m.InputTokenLimit())
+	require.Equal(t, 100000, m.OutputTokenLimit())
 }
 
 func TestCountToolRoundsExportedViaBehavior(t *testing.T) {

--- a/loadtest/profile.go
+++ b/loadtest/profile.go
@@ -12,7 +12,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/mattermost/mattermost-plugin-agents/toolrunner"
+	"github.com/mattermost/mattermost-plugin-agents/toolrunner/limits"
 )
 
 // LatencyProfile describes one named latency mix for mock streaming.
@@ -345,8 +345,8 @@ func (p MockProfile) Validate() error {
 	if p.MaxToolRounds < 0 {
 		return fmt.Errorf("max_tool_rounds must be non-negative, got %d", p.MaxToolRounds)
 	}
-	if p.MaxToolRounds > toolrunner.MaxToolRounds {
-		return fmt.Errorf("max_tool_rounds must be <= %d (toolrunner limit), got %d", toolrunner.MaxToolRounds, p.MaxToolRounds)
+	if p.MaxToolRounds > limits.MaxToolRounds {
+		return fmt.Errorf("max_tool_rounds must be <= %d (toolrunner limit), got %d", limits.MaxToolRounds, p.MaxToolRounds)
 	}
 	if len(p.FinalResponseTemplates) == 0 {
 		return fmt.Errorf("final_response_templates must be non-empty")

--- a/toolrunner/limits/limits.go
+++ b/toolrunner/limits/limits.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package limits
+
+// MaxToolRounds is the maximum number of tool-call-execute-recall iterations
+// before the runner gives up and returns whatever it has.
+const MaxToolRounds = 10

--- a/toolrunner/toolrunner.go
+++ b/toolrunner/toolrunner.go
@@ -11,13 +11,14 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/telemetry"
+	"github.com/mattermost/mattermost-plugin-agents/toolrunner/limits"
 	"go.opentelemetry.io/otel/trace"
 )
 
 // MaxToolRounds is the maximum number of tool-call-execute-recall iterations
 // before the runner gives up and returns whatever it has. This prevents
 // infinite loops from models that keep requesting tools.
-const MaxToolRounds = 10
+const MaxToolRounds = limits.MaxToolRounds
 
 // ToolRunner manages the call-execute-recall loop for LLM tool use.
 // It calls the LLM, checks for tool calls in the stream, executes


### PR DESCRIPTION
#### Summary
Adds `loadtest_mock` as a bot service type and wires `bots.getLLM()` to select the in-process load-test mock before Bifrost construction while preserving the existing wrapper chain.

#### Stack
1. #724 Add load-test mock LLM foundation
2. **#725** Wire load-test mock LLM service
3. #726 Add Agents load-test simulator controller
4. #727 Document Agents load-test profile reporting

QA: `go test ./llm/... ./loadtest/... ./bots/... ./toolrunner/... -count=1 -race`.

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
Added a loadtest_mock service type for configuring Agents load-test mock LLMs.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a load-test mock LLM service type with configurable mock profiles and latency/behaviour simulation.

* **Tests**
  * Added comprehensive tests covering load-test mock initialization, token counting/limits, profile parsing, overrides, and validation error cases.

* **Validation**
  * Stronger validation for load-test mock configuration (strict JSON checks, profile/weight/range constraints, probabilities and tool-round limits).

* **Chores**
  * Centralized max tool-rounds limit as an exported constant for consistent enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->