### PR TITLE
Document Agents load-test profile reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Comprehensive documentation is available in the `/docs` directory:
 
 - [User Guide](docs/user_guide.md): Learn how to interact with AI features
 - [Admin Guide](docs/admin_guide.md): Detailed installation and configuration instructions
+- [Load Testing](docs/load-testing.md): Configure the in-process mock LLM and load-test-ng Agents controller
 - [Provider Setup](docs/providers.md): Configuration for supported LLM providers
 - [Feature Documentation](docs/features/): Detailed guides for individual features
   - [Channel Summaries](docs/features/channel_summaries.md): Use the **Ask Agents about this channel** button to summarize and analyze channel activity

--- a/bots/bots.go
+++ b/bots/bots.go
@@ -442,6 +442,7 @@ func (b *MMBots) getBaseLLM(serviceConfig llm.ServiceConfig, botConfig llm.BotCo
 			return nil, fmt.Errorf("failed to parse load-test mock profile for bot %s: %w", botConfig.Name, err)
 		}
 		if b.pluginAPI != nil {
+			// Run-audit snapshot of the active mock profile (once per LLM init; not per request).
 			b.pluginAPI.Log.Info(
 				"Initialized load-test mock LLM",
 				"bot_name", botConfig.Name,

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -195,13 +195,18 @@ func TestGetBaseLLMLoadTestMockEmptyConfigUsesDefaultProfile(t *testing.T) {
 		"service_id", "loadtest-svc",
 		"profile_summary", mock.MatchedBy(func(s string) bool {
 			summary = s
-			return strings.Contains(s, "realistic_default") &&
+			return strings.Contains(s, "name=read_search_heavy_default") &&
+				strings.Contains(s, "streaming=true") &&
+				strings.Contains(s, "defaults_source=spikes/llm-latency-benchmark") &&
+				strings.Contains(s, "realistic_default") &&
 				strings.Contains(s, "realistic_fast") &&
 				strings.Contains(s, "realistic_slow") &&
 				strings.Contains(s, "0.7000") &&
 				strings.Contains(s, "0.2000") &&
 				strings.Contains(s, "0.1000") &&
-				strings.Contains(s, "reasoning_skip_p=0.1000")
+				strings.Contains(s, "reasoning_skip_p=0.1000") &&
+				strings.Contains(s, "post_limits=10,25,50,100") &&
+				strings.Contains(s, "status update")
 		}),
 	).Return().Once()
 

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -1,0 +1,123 @@
+# Load Testing Agents
+
+Developer and operator guide for non-production load-test setups using the Agents plugin `loadtest_mock` service type and the `mattermost-ai` load-test-ng controller.
+
+## Scope
+
+This document applies to **load-test and staging environments only**. It describes:
+
+- The in-process mock LLM (`loadtest_mock`) that implements `llm.LanguageModel` inside the plugin process.
+- Tool execution policy (`auto_run_everywhere`) so MCP tool calls run without human approval during simulations.
+- Enabling the Agents plugin (`mattermost-ai`) and its simulator actions from mattermost-load-test-ng.
+
+It does **not** replace production LLM configuration or security review for real provider traffic.
+
+## Configure the In-Process Mock LLM
+
+The `loadtest_mock` service type selects a **validated, in-process** `loadtest.MockLLM` before any Bifrost client is created. It is **not** a Bifrost provider, plugin transport, or standalone HTTP mock service. No external mock LLM endpoint is required.
+
+Assign the bot to a service with `"type": "loadtest_mock"` and optional raw JSON in `loadTestMockConfig`:
+
+```json
+{
+  "type": "loadtest_mock",
+  "loadTestMockConfig": {
+    "seed": 42,
+    "profile_weights": {
+      "realistic_default": 0.8,
+      "realistic_fast": 0.2,
+      "realistic_slow": 0
+    }
+  }
+}
+```
+
+- **Nil, empty, or whitespace-only `loadTestMockConfig`** merges onto `DefaultReadSearchHeavyProfile()` from `loadtest.ParseProfile()`.
+- **Invalid JSON or unknown fields** fail parsing before the mock is constructed; check server logs for `failed to parse load-test mock profile`.
+- At plugin startup, when the mock LLM is initialized, the server logs a single **run-audit snapshot**:
+
+  - Message: `Initialized load-test mock LLM`
+  - Field `profile_summary`: multiline text with latency ranges, weights, tool argument distributions, and `defaults_source=spikes/llm-latency-benchmark`
+
+The summary is emitted **once per bot service initialization**, not per chat request or stream chunk.
+
+## Configure Tool Auto-Run
+
+Mattermost MCP tools respect channel/user policy in the System Console. For unattended load tests, tool calls must not block on approval prompts.
+
+Configure MCP tool policies so relevant tools use **`auto_run_everywhere`** (see `webapp` System Console components such as `mcp_tool_config_row.tsx`). Without this, simulations may stall waiting for approval while the mock LLM still completes streams.
+
+## Enable Agents in mattermost-load-test-ng
+
+Integration is **cross-repository**:
+
+- This repo exposes `github.com/mattermost/mattermost-plugin-agents/loadtest` for blank-import registration and the Agents SimulController.
+- mattermost-load-test-ng must import that package and include **`mattermost-ai`** in `EnabledPlugins` for the simulated server configuration.
+
+**Plugin ID:** `mattermost-ai` (not `agents`).
+
+**Registered actions** (names matter for simulator wiring):
+
+- `mattermost-ai.AskAgentChannelMention`
+- `mattermost-ai.AskAgentDM`
+
+**Controller configuration:**
+
+- Default file path: `./config/mattermost-ai-loadtest.json`
+- Override with environment variable: `MM_AGENTS_LOADTEST_CONFIG` pointing at a JSON file
+
+**Trigger frequencies** (`triggerFrequencyChannelMention`, `triggerFrequencyDM`) are **relative weights** inside load-test-ng, not global percentages. For example, `0.001` is one-thousandth the weight of an action configured with frequency `1.0`. The simulator scales from the smallest non-zero frequency.
+
+Example `mattermost-ai-loadtest.json`:
+
+```json
+{
+  "triggerFrequencyChannelMention": 0.001,
+  "triggerFrequencyDM": 0.001,
+  "agentUsername": "ai",
+  "agentUserID": "",
+  "triggerMode": "both",
+  "promptProfile": "mixed",
+  "mockProfile": null
+}
+```
+
+Optional `mockProfile` embeds the same JSON schema as `loadTestMockConfig` when your ng-side harness merges mock defaults with simulator config (validated via `loadtest.ParseProfile` on read).
+
+During development you may use temporary `replace` directives in a **local** `go.mod`; do **not** commit unstable replace pins aimed only at your laptop.
+
+## Profile Defaults
+
+Unless overridden, the empirical **read/search-heavy** defaults apply (derived from `spikes/llm-latency-benchmark/`):
+
+| Latency mix           | TTFT (ms)     | chunk_count | chunk_interval_ms | total_wall_time_ms_per_request |
+|-----------------------|---------------|-------------|-------------------|--------------------------------|
+| `realistic_default`   | 3000-12000    | 150-400     | 30-80             | 15000-25000                    |
+| `realistic_fast`      | 600-2500      | 40-120      | 40-100            | 5000-10000                     |
+| `realistic_slow`      | 12000-22000   | 400-1000    | 15-40             | 28000-40000                    |
+
+- Profile weights (default): `realistic_default` **0.70**, `realistic_fast` **0.20**, `realistic_slow` **0.10**
+- `reasoning_skip_probability`: **0.10**
+- Streaming is enabled by default (`streaming_enabled: true`)
+
+See the active merged profile in logs under `profile_summary` after initialization.
+
+## Local Validation
+
+From the Agents plugin repository:
+
+```bash
+go test ./loadtest/... ./bots/... ./toolrunner/... -race
+```
+
+Run an integrated mattermost-load-test-ng scenario only after both this branch (or equivalent) and the ng-side wiring branch are available; remove or document any temporary `replace` directives first.
+
+## Troubleshooting
+
+| Symptom | What to check |
+|--------|----------------|
+| Plugin fails to start or bot LLM errors mentioning `loadtest profile` | Fix `loadTestMockConfig` JSON (unknown fields are rejected). Validate weights sum positively and reference existing latency profile keys. |
+| No simulated agent traffic | Confirm `EnabledPlugins` includes **`mattermost-ai`**. Confirm ng imports `github.com/mattermost/mattermost-plugin-agents/loadtest`. |
+| Actions never hit the agent user | Verify `agentUsername` / `agentUserID` match a real bot user in the test data set; check simulator logs for target resolution errors. |
+| Tool calls hang or never execute | Ensure MCP tools use **`auto_run_everywhere`** for load-test channels/users so approvals do not block automation. |
+| Need to confirm mock parameters | Search logs for `Initialized load-test mock LLM` and read `profile_summary` (initialization-time only). |

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -84,7 +84,7 @@ Example `mattermost-ai-loadtest.json`:
 
 Optional `mockProfile` embeds the same JSON schema as `loadTestMockConfig` when your ng-side harness merges mock defaults with simulator config (validated via `loadtest.ParseProfile` on read).
 
-During development you may use temporary `replace` directives in a **local** `go.mod`; do **not** commit unstable replace pins aimed only at your laptop.
+During development, you may use temporary `replace` directives in a **local** `go.mod`; do **not** commit unstable replace pins aimed only at your laptop.
 
 ## Profile Defaults
 

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -51,7 +51,7 @@ Configure MCP tool policies so relevant tools use **`auto_run_everywhere`** (see
 
 Integration is **cross-repository**:
 
-- This repo exposes `github.com/mattermost/mattermost-plugin-agents/loadtest` for blank-import registration and the Agents SimulController.
+- This repo exposes `github.com/mattermost/mattermost-plugin-agents/loadtest/controller` (a standalone nested Go module) for blank-import registration of the Agents SimulController.
 - mattermost-load-test-ng must import that package and include **`mattermost-ai`** in `EnabledPlugins` for the simulated server configuration.
 
 **Plugin ID:** `mattermost-ai` (not `agents`).
@@ -108,6 +108,8 @@ From the Agents plugin repository:
 
 ```bash
 go test ./loadtest/... ./bots/... ./toolrunner/... -race
+# The SimulController lives in a separate nested module, so test it on its own:
+(cd loadtest/controller && go test ./... -race)
 ```
 
 Run an integrated mattermost-load-test-ng scenario only after both this branch (or equivalent) and the ng-side wiring branch are available; remove or document any temporary `replace` directives first.
@@ -117,7 +119,7 @@ Run an integrated mattermost-load-test-ng scenario only after both this branch (
 | Symptom | What to check |
 |--------|----------------|
 | Plugin fails to start or bot LLM errors mentioning `loadtest profile` | Fix `loadTestMockConfig` JSON (unknown fields are rejected). Validate weights sum positively and reference existing latency profile keys. |
-| No simulated agent traffic | Confirm `EnabledPlugins` includes **`mattermost-ai`**. Confirm ng imports `github.com/mattermost/mattermost-plugin-agents/loadtest`. |
+| No simulated agent traffic | Confirm `EnabledPlugins` includes **`mattermost-ai`**. Confirm ng imports `github.com/mattermost/mattermost-plugin-agents/loadtest/controller`. |
 | Actions never hit the agent user | Verify `agentUsername` / `agentUserID` match a real bot user in the test data set; check simulator logs for target resolution errors. |
 | Tool calls hang or never execute | Ensure MCP tools use **`auto_run_everywhere`** for load-test channels/users so approvals do not block automation. |
 | Need to confirm mock parameters | Search logs for `Initialized load-test mock LLM` and read `profile_summary` (initialization-time only). |


### PR DESCRIPTION
#### Summary
Expands load-test mock profile reporting into a deterministic audit summary and adds operator/developer documentation for `loadtest_mock`, `auto_run_everywhere`, load-test-ng enablement, profile defaults, and troubleshooting.

#### Stack
1. #724 Add load-test mock LLM foundation
2. #725 Wire load-test mock LLM service
3. #726 Add Agents load-test simulator controller
4. **#727** Document Agents load-test profile reporting

QA: `go test ./loadtest/... -v`; `go test ./bots/... -v`; `go test ./loadtest/... ./bots/... ./toolrunner/... -v -race`; `make dist`.

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
Added documentation and profile audit logging for Agents load testing.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for running non-production load tests with the Agents plugin, including mock LLM configuration, MCP tool setup, and troubleshooting reference table.
  * Updated README with link to new load-testing documentation.

* **Tests**
  * Enhanced test coverage for load-test configuration validation and diagnostic output accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->