### PR TITLE
Revert "MM-67913: stop toggling app__body on Agents product page (#683)"

### DIFF
--- a/webapp/src/components/agents/agents_page.tsx
+++ b/webapp/src/components/agents/agents_page.tsx
@@ -15,13 +15,19 @@ export const AGENTS_ROUTE = `/plug/${manifest.id}/agents`;
 // No URL-matching or overlay needed; Mattermost's product routing handles it.
 const AgentsPage = () => {
     useEffect(() => {
-        // The host webapp owns `app__body` on document.body (see MM-67913 / Boards #188).
-        // ChannelController normally sets `channel-view` on #root, but it's not loaded in
-        // product views. Without it the global header loses its themed colors.
+        // ChannelController normally sets these classes, but it's not loaded in
+        // product views. Without them the global header loses its themed colors.
+        // Playbooks and Boards do the same thing in their top-level components.
+        document.body.classList.add('app__body');
+
         const root = document.getElementById('root');
         if (root && !root.classList.contains('channel-view')) {
             root.classList.add('channel-view');
         }
+
+        return () => {
+            document.body.classList.remove('app__body');
+        };
     }, []);
 
     return (


### PR DESCRIPTION
## Summary

Reverts #683 (commit 685c20ef).

This PR restores the original behavior of toggling \`app__body\` on \`document.body\` in the Agents product page while the proper fix is validated separately.

## Reason for Revert

Reverting while we validate the fix further. A follow-up draft PR (#730) is ready to re-land the change once confirmed.

## Test Plan

- [ ] Navigate to the Agents product page and verify the global header retains its themed colors
- [ ] Verify no navigation flashes on page transitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal component initialization logic for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->