### PR TITLE
Combine each LLM conversation turn into a single post

### DIFF
--- a/api/api_no_tools_test.go
+++ b/api/api_no_tools_test.go
@@ -153,6 +153,10 @@ func (m *mockConvServiceStore) UpdateTurnPostID(_ string, _ *string) error {
 	return nil
 }
 
+func (m *mockConvServiceStore) DeleteResponseTurns(_ string, _ string) error {
+	return nil
+}
+
 func (m *mockConvServiceStore) GetMaxSequenceForConversation(conversationID string) (int, error) {
 	return len(m.turns[conversationID]), nil
 }

--- a/api/api_no_tools_test.go
+++ b/api/api_no_tools_test.go
@@ -142,6 +142,14 @@ func (m *mockConvServiceStore) UpdateTurnTokens(_ string, _, _ int64) error {
 	return nil
 }
 
+func (m *mockConvServiceStore) GetTurnByPostID(_ string) (*store.Turn, error) {
+	return nil, nil
+}
+
+func (m *mockConvServiceStore) UpdateTurnPostID(_ string, _ *string) error {
+	return nil
+}
+
 func (m *mockConvServiceStore) GetMaxSequenceForConversation(conversationID string) (int, error) {
 	return len(m.turns[conversationID]), nil
 }

--- a/api/api_no_tools_test.go
+++ b/api/api_no_tools_test.go
@@ -67,6 +67,9 @@ func (s *noToolsStreamingService) StreamToNewDM(_ context.Context, botID string,
 func (s *noToolsStreamingService) StreamToPost(context.Context, *llm.TextStreamResult, *model.Post, string, string) {
 }
 
+func (s *noToolsStreamingService) StreamContinuationToPost(context.Context, *llm.TextStreamResult, *model.Post, string, string) {
+}
+
 func (s *noToolsStreamingService) StopStreaming(string) {}
 
 func (s *noToolsStreamingService) GetStreamingContext(ctx context.Context, _ string) (context.Context, error) {

--- a/channels/analysis_conversation_test.go
+++ b/channels/analysis_conversation_test.go
@@ -132,6 +132,47 @@ func (s *inMemoryStore) UpdateTurnPostID(id string, postID *string) error {
 	return nil
 }
 
+func (s *inMemoryStore) DeleteResponseTurns(conversationID, postID string) error {
+	anchorSeq := -1
+	for _, id := range s.turnsByConv[conversationID] {
+		t, ok := s.turns[id]
+		if !ok {
+			continue
+		}
+		if t.Role == "assistant" && t.PostID != nil && *t.PostID == postID {
+			anchorSeq = t.Sequence
+			break
+		}
+	}
+	if anchorSeq < 0 {
+		return nil
+	}
+	userSeq := 0
+	for _, id := range s.turnsByConv[conversationID] {
+		t, ok := s.turns[id]
+		if !ok {
+			continue
+		}
+		if t.Role == "user" && t.Sequence < anchorSeq && t.Sequence > userSeq {
+			userSeq = t.Sequence
+		}
+	}
+	keep := s.turnsByConv[conversationID][:0]
+	for _, id := range s.turnsByConv[conversationID] {
+		t, ok := s.turns[id]
+		if !ok {
+			continue
+		}
+		if t.Sequence > userSeq && t.Sequence < anchorSeq {
+			delete(s.turns, id)
+			continue
+		}
+		keep = append(keep, id)
+	}
+	s.turnsByConv[conversationID] = keep
+	return nil
+}
+
 func (s *inMemoryStore) GetMaxSequenceForConversation(conversationID string) (int, error) {
 	maxSeq := 0
 	for _, id := range s.turnsByConv[conversationID] {

--- a/channels/analysis_conversation_test.go
+++ b/channels/analysis_conversation_test.go
@@ -113,6 +113,25 @@ func (s *inMemoryStore) UpdateTurnTokens(id string, tokensIn, tokensOut int64) e
 	return nil
 }
 
+func (s *inMemoryStore) GetTurnByPostID(postID string) (*store.Turn, error) {
+	for _, t := range s.turns {
+		if t.PostID != nil && *t.PostID == postID {
+			c := *t
+			return &c, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *inMemoryStore) UpdateTurnPostID(id string, postID *string) error {
+	turn, ok := s.turns[id]
+	if !ok {
+		return fmt.Errorf("turn not found")
+	}
+	turn.PostID = postID
+	return nil
+}
+
 func (s *inMemoryStore) GetMaxSequenceForConversation(conversationID string) (int, error) {
 	maxSeq := 0
 	for _, id := range s.turnsByConv[conversationID] {

--- a/channels/channels_eval_test.go
+++ b/channels/channels_eval_test.go
@@ -199,6 +199,23 @@ func (s *evalInMemoryStore) UpdateTurnTokens(id string, tokensIn, tokensOut int6
 	return nil
 }
 
+func (s *evalInMemoryStore) GetTurnByPostID(postID string) (*store.Turn, error) {
+	for _, t := range s.turns {
+		if t.PostID != nil && *t.PostID == postID {
+			c := t.Turn
+			return &c, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *evalInMemoryStore) UpdateTurnPostID(id string, postID *string) error {
+	if t, ok := s.turns[id]; ok {
+		t.PostID = postID
+	}
+	return nil
+}
+
 func (s *evalInMemoryStore) GetMaxSequenceForConversation(conversationID string) (int, error) {
 	maxSeq := 0
 	for _, id := range s.turnsByConv[conversationID] {

--- a/channels/channels_eval_test.go
+++ b/channels/channels_eval_test.go
@@ -216,6 +216,10 @@ func (s *evalInMemoryStore) UpdateTurnPostID(id string, postID *string) error {
 	return nil
 }
 
+func (s *evalInMemoryStore) DeleteResponseTurns(_ string, _ string) error {
+	return nil
+}
+
 func (s *evalInMemoryStore) GetMaxSequenceForConversation(conversationID string) (int, error) {
 	maxSeq := 0
 	for _, id := range s.turnsByConv[conversationID] {

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -28,8 +28,10 @@ type Store interface {
 	CreateTurn(turn *store.Turn) error
 	CreateTurnAutoSequence(turn *store.Turn) error
 	GetTurnsForConversation(conversationID string) ([]store.Turn, error)
+	GetTurnByPostID(postID string) (*store.Turn, error)
 	UpdateTurnContent(id string, content json.RawMessage) error
 	UpdateTurnTokens(id string, tokensIn, tokensOut int64) error
+	UpdateTurnPostID(id string, postID *string) error
 	GetMaxSequenceForConversation(conversationID string) (int, error)
 }
 
@@ -209,6 +211,20 @@ func (s *Service) CreateTurn(turn *store.Turn) error {
 // CreateTurnAutoSequence persists a new turn, atomically assigning the next sequence number.
 func (s *Service) CreateTurnAutoSequence(turn *store.Turn) error {
 	return s.store.CreateTurnAutoSequence(turn)
+}
+
+// GetTurnByPostID retrieves the assistant turn anchored to the given post,
+// or nil if none exists. Used by the streaming layer to detect a continuation
+// stream and demote the prior anchor before creating the new one.
+func (s *Service) GetTurnByPostID(postID string) (*store.Turn, error) {
+	return s.store.GetTurnByPostID(postID)
+}
+
+// UpdateTurnPostID sets or clears the PostID on a turn. Streaming uses this to
+// demote a prior anchor turn (PostID = nil) when finalizing a continuation
+// turn for the same response post.
+func (s *Service) UpdateTurnPostID(id string, postID *string) error {
+	return s.store.UpdateTurnPostID(id, postID)
 }
 
 // UpdateConversationRootPostID sets the RootPostID on a conversation.

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -214,26 +214,19 @@ func (s *Service) CreateTurnAutoSequence(turn *store.Turn) error {
 	return s.store.CreateTurnAutoSequence(turn)
 }
 
-// GetTurnByPostID retrieves the assistant turn anchored to the given post,
-// or nil if none exists. Used by the streaming layer to detect a continuation
-// stream and demote the prior anchor before creating the new one.
+// GetTurnByPostID returns the assistant turn anchored to postID, or nil.
 func (s *Service) GetTurnByPostID(postID string) (*store.Turn, error) {
 	return s.store.GetTurnByPostID(postID)
 }
 
-// UpdateTurnPostID sets or clears the PostID on a turn. Streaming uses this to
-// demote a prior anchor turn (PostID = nil) when finalizing a continuation
-// turn for the same response post.
+// UpdateTurnPostID sets or clears the PostID on a turn.
 func (s *Service) UpdateTurnPostID(id string, postID *string) error {
 	return s.store.UpdateTurnPostID(id, postID)
 }
 
-// DeleteResponseTurns removes every turn that belongs to a response — the
-// post anchor itself plus any assistant/tool_result turns between it and
-// the originating user turn. After this call the post has no DB state and
-// a regen can stream a fresh response identically to a first stream.
-// Callers must build any completion request BEFORE this runs, since
-// ExcludeAfterPostID walks back from the anchor that's about to disappear.
+// DeleteResponseTurns removes the post's anchor and any assistant/tool_result
+// turns between it and the originating user turn. Callers must build any
+// completion request before calling this — ExcludeAfterPostID needs the anchor.
 func (s *Service) DeleteResponseTurns(conversationID, postID string) error {
 	return s.store.DeleteResponseTurns(conversationID, postID)
 }
@@ -397,13 +390,9 @@ func (s *Service) BuildCompletionRequest(
 	redactUnshared := true
 	if len(opts) > 0 {
 		redactUnshared = !opts[0].AllowUnsharedToolContent
-		// ExcludeAfterPostID truncates the conversation back to right after
-		// the user turn that initiated the response for this post, so the
-		// LLM regenerates from the same starting point. Truncating only at
-		// the post's anchor would leave any continuation history (a demoted
-		// prior anchor plus its tool_result turns from a tool-approval
-		// resume) at the tail — that ends in assistant content, which
-		// bifrost-backed models reject as an unsupported prefill.
+		// Truncate back to right after the originating user turn. Stopping
+		// at the anchor alone would leave demoted continuation turns at the
+		// tail; bifrost rejects an assistant-ended request as prefill.
 		if opts[0].ExcludeAfterPostID != "" {
 			excludeID := opts[0].ExcludeAfterPostID
 			anchorIdx := -1

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -386,15 +386,31 @@ func (s *Service) BuildCompletionRequest(
 	redactUnshared := true
 	if len(opts) > 0 {
 		redactUnshared = !opts[0].AllowUnsharedToolContent
-		// If ExcludeAfterPostID is set, truncate the turn slice at (and including)
-		// the turn whose PostID matches, so that turn and all subsequent turns are dropped.
+		// ExcludeAfterPostID truncates the conversation back to right after
+		// the user turn that initiated the response for this post, so the
+		// LLM regenerates from the same starting point. Truncating only at
+		// the post's anchor would leave any continuation history (a demoted
+		// prior anchor plus its tool_result turns from a tool-approval
+		// resume) at the tail — that ends in assistant content, which
+		// bifrost-backed models reject as an unsupported prefill.
 		if opts[0].ExcludeAfterPostID != "" {
 			excludeID := opts[0].ExcludeAfterPostID
+			anchorIdx := -1
 			for i, turn := range turns {
-				if turn.PostID != nil && *turn.PostID == excludeID {
-					turns = turns[:i]
+				if turn.Role == "assistant" && turn.PostID != nil && *turn.PostID == excludeID {
+					anchorIdx = i
 					break
 				}
+			}
+			if anchorIdx >= 0 {
+				truncateAt := anchorIdx
+				for i := anchorIdx - 1; i >= 0; i-- {
+					if turns[i].Role == "user" {
+						truncateAt = i + 1
+						break
+					}
+				}
+				turns = turns[:truncateAt]
 			}
 		}
 	}

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -32,6 +32,7 @@ type Store interface {
 	UpdateTurnContent(id string, content json.RawMessage) error
 	UpdateTurnTokens(id string, tokensIn, tokensOut int64) error
 	UpdateTurnPostID(id string, postID *string) error
+	DeleteResponseTurns(conversationID, postID string) error
 	GetMaxSequenceForConversation(conversationID string) (int, error)
 }
 
@@ -225,6 +226,16 @@ func (s *Service) GetTurnByPostID(postID string) (*store.Turn, error) {
 // turn for the same response post.
 func (s *Service) UpdateTurnPostID(id string, postID *string) error {
 	return s.store.UpdateTurnPostID(id, postID)
+}
+
+// DeleteResponseTurns removes the assistant and tool_result turns between
+// the originating user turn and the post anchor for the given post. The
+// anchor itself is preserved (regen updates it in place at finalize). Use
+// this on regeneration to scrub stale intermediate turns from a prior
+// generation so the regenerated response doesn't render with leftover
+// rounds attached.
+func (s *Service) DeleteResponseTurns(conversationID, postID string) error {
+	return s.store.DeleteResponseTurns(conversationID, postID)
 }
 
 // UpdateConversationRootPostID sets the RootPostID on a conversation.

--- a/conversation/service.go
+++ b/conversation/service.go
@@ -228,12 +228,12 @@ func (s *Service) UpdateTurnPostID(id string, postID *string) error {
 	return s.store.UpdateTurnPostID(id, postID)
 }
 
-// DeleteResponseTurns removes the assistant and tool_result turns between
-// the originating user turn and the post anchor for the given post. The
-// anchor itself is preserved (regen updates it in place at finalize). Use
-// this on regeneration to scrub stale intermediate turns from a prior
-// generation so the regenerated response doesn't render with leftover
-// rounds attached.
+// DeleteResponseTurns removes every turn that belongs to a response — the
+// post anchor itself plus any assistant/tool_result turns between it and
+// the originating user turn. After this call the post has no DB state and
+// a regen can stream a fresh response identically to a first stream.
+// Callers must build any completion request BEFORE this runs, since
+// ExcludeAfterPostID walks back from the anchor that's about to disappear.
 func (s *Service) DeleteResponseTurns(conversationID, postID string) error {
 	return s.store.DeleteResponseTurns(conversationID, postID)
 }

--- a/conversation/service_test.go
+++ b/conversation/service_test.go
@@ -900,6 +900,85 @@ func TestBuildCompletionRequest_ExcludeAfterPostID(t *testing.T) {
 	assert.Equal(t, "user2", req.Posts[3].Message)
 }
 
+// Regression: regenerating a post whose response went through a
+// tool-approval continuation must drop the demoted prior anchor + its
+// tool_result turn along with the post anchor, otherwise the request ends
+// in assistant content (the continuation history) and bifrost-backed models
+// reject it as an unsupported assistant prefill.
+func TestBuildCompletionRequest_ExcludeAfterPostID_ToolApprovalContinuationLeavesUserTail(t *testing.T) {
+	svc, s := setupTestService(t)
+
+	result, err := svc.CreateConversation(CreateConversationParams{
+		UserID:       model.NewId(),
+		BotID:        model.NewId(),
+		Operation:    "conversation",
+		SystemPrompt: "system",
+		UserMessage:  "user1",
+		UserPostID:   stringPtr("user_post1"),
+	})
+	require.NoError(t, err)
+	convID := result.ConversationID
+
+	// Demoted prior anchor: this is the shape left behind by the
+	// streaming layer when a continuation stream finalizes — the original
+	// anchor turn loses its PostID but keeps its content + tool_use.
+	demotedContent, _ := json.Marshal([]ContentBlock{
+		{Type: BlockTypeText, Text: "Let me search."},
+		{Type: BlockTypeToolUse, ID: "tc1", Name: "search", Status: StatusSuccess, Shared: BoolPtr(true)},
+	})
+	err = s.CreateTurn(&store.Turn{
+		ID:             model.NewId(),
+		ConversationID: convID,
+		PostID:         nil,
+		Role:           "assistant",
+		Content:        demotedContent,
+		Sequence:       2,
+		CreatedAt:      model.GetMillis(),
+	})
+	require.NoError(t, err)
+
+	resultContent, _ := json.Marshal([]ContentBlock{
+		{Type: BlockTypeToolResult, ToolUseID: "tc1", Content: "5 channels found", Shared: BoolPtr(true)},
+	})
+	err = s.CreateTurn(&store.Turn{
+		ID:             model.NewId(),
+		ConversationID: convID,
+		PostID:         nil,
+		Role:           "tool_result",
+		Content:        resultContent,
+		Sequence:       3,
+		CreatedAt:      model.GetMillis(),
+	})
+	require.NoError(t, err)
+
+	// New anchor — the post being regenerated.
+	anchorContent, _ := json.Marshal([]ContentBlock{{Type: BlockTypeText, Text: "Found 5 channels."}})
+	err = s.CreateTurn(&store.Turn{
+		ID:             model.NewId(),
+		ConversationID: convID,
+		PostID:         stringPtr("resp_post"),
+		Role:           "assistant",
+		Content:        anchorContent,
+		Sequence:       4,
+		CreatedAt:      model.GetMillis(),
+	})
+	require.NoError(t, err)
+
+	conv, err := s.GetConversation(convID)
+	require.NoError(t, err)
+
+	req, err := svc.BuildCompletionRequest(conv, &llm.Context{}, BuildOptions{ExcludeAfterPostID: "resp_post"})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, req.Posts)
+	last := req.Posts[len(req.Posts)-1]
+	require.Equal(t, llm.PostRoleUser, last.Role,
+		"regen request must end with the user turn that initiated the response — never with the continuation's assistant + tool_result tail")
+	require.Equal(t, "user1", last.Message)
+	require.Len(t, req.Posts, 2, "expected system + user1 only; demoted assistant + tool_result must be dropped")
+	require.Equal(t, llm.PostRoleSystem, req.Posts[0].Role)
+}
+
 func TestCreatePlaceholderAssistantTurn(t *testing.T) {
 	svc, s := setupTestService(t)
 

--- a/conversation/service_test.go
+++ b/conversation/service_test.go
@@ -900,11 +900,9 @@ func TestBuildCompletionRequest_ExcludeAfterPostID(t *testing.T) {
 	assert.Equal(t, "user2", req.Posts[3].Message)
 }
 
-// Regression: regenerating a post whose response went through a
-// tool-approval continuation must drop the demoted prior anchor + its
-// tool_result turn along with the post anchor, otherwise the request ends
-// in assistant content (the continuation history) and bifrost-backed models
-// reject it as an unsupported assistant prefill.
+// Regen of a post that went through a tool-approval continuation must drop
+// the demoted prior anchor and its tool_result, so the request ends on the
+// user turn (bifrost rejects an assistant-ended prefill).
 func TestBuildCompletionRequest_ExcludeAfterPostID_ToolApprovalContinuationLeavesUserTail(t *testing.T) {
 	svc, s := setupTestService(t)
 
@@ -919,9 +917,7 @@ func TestBuildCompletionRequest_ExcludeAfterPostID_ToolApprovalContinuationLeave
 	require.NoError(t, err)
 	convID := result.ConversationID
 
-	// Demoted prior anchor: this is the shape left behind by the
-	// streaming layer when a continuation stream finalizes — the original
-	// anchor turn loses its PostID but keeps its content + tool_use.
+	// Demoted prior anchor (left behind by a continuation finalize).
 	demotedContent, _ := json.Marshal([]ContentBlock{
 		{Type: BlockTypeText, Text: "Let me search."},
 		{Type: BlockTypeToolUse, ID: "tc1", Name: "search", Status: StatusSuccess, Shared: BoolPtr(true)},
@@ -951,7 +947,6 @@ func TestBuildCompletionRequest_ExcludeAfterPostID_ToolApprovalContinuationLeave
 	})
 	require.NoError(t, err)
 
-	// New anchor — the post being regenerated.
 	anchorContent, _ := json.Marshal([]ContentBlock{{Type: BlockTypeText, Text: "Found 5 channels."}})
 	err = s.CreateTurn(&store.Turn{
 		ID:             model.NewId(),
@@ -972,10 +967,9 @@ func TestBuildCompletionRequest_ExcludeAfterPostID_ToolApprovalContinuationLeave
 
 	require.NotEmpty(t, req.Posts)
 	last := req.Posts[len(req.Posts)-1]
-	require.Equal(t, llm.PostRoleUser, last.Role,
-		"regen request must end with the user turn that initiated the response — never with the continuation's assistant + tool_result tail")
+	require.Equal(t, llm.PostRoleUser, last.Role)
 	require.Equal(t, "user1", last.Message)
-	require.Len(t, req.Posts, 2, "expected system + user1 only; demoted assistant + tool_result must be dropped")
+	require.Len(t, req.Posts, 2)
 	require.Equal(t, llm.PostRoleSystem, req.Posts[0].Role)
 }
 

--- a/conversations/dm_conversation_test.go
+++ b/conversations/dm_conversation_test.go
@@ -149,6 +149,36 @@ func (s *fakeConvStore) UpdateTurnContent(id string, content json.RawMessage) er
 	return nil
 }
 
+func (s *fakeConvStore) GetTurnByPostID(postID string) (*store.Turn, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, t := range s.allTurns {
+		if t.PostID != nil && *t.PostID == postID {
+			c := *t
+			return &c, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *fakeConvStore) UpdateTurnPostID(id string, postID *string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.allTurns[id]
+	if !ok {
+		return fmt.Errorf("turn %s not found", id)
+	}
+	t.PostID = postID
+	for convID, turns := range s.turns {
+		for i := range turns {
+			if turns[i].ID == id {
+				s.turns[convID][i].PostID = postID
+			}
+		}
+	}
+	return nil
+}
+
 func (s *fakeConvStore) UpdateTurnTokens(id string, tokensIn, tokensOut int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/conversations/dm_conversation_test.go
+++ b/conversations/dm_conversation_test.go
@@ -179,6 +179,41 @@ func (s *fakeConvStore) UpdateTurnPostID(id string, postID *string) error {
 	return nil
 }
 
+func (s *fakeConvStore) DeleteResponseTurns(conversationID, postID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	turns := s.turns[conversationID]
+
+	anchorSeq := -1
+	for _, t := range turns {
+		if t.Role == "assistant" && t.PostID != nil && *t.PostID == postID {
+			anchorSeq = t.Sequence
+			break
+		}
+	}
+	if anchorSeq < 0 {
+		return nil
+	}
+	userSeq := 0
+	for i := len(turns) - 1; i >= 0; i-- {
+		if turns[i].Role == "user" && turns[i].Sequence < anchorSeq {
+			userSeq = turns[i].Sequence
+			break
+		}
+	}
+
+	keep := turns[:0]
+	for _, t := range turns {
+		if t.Sequence > userSeq && t.Sequence < anchorSeq {
+			delete(s.allTurns, t.ID)
+			continue
+		}
+		keep = append(keep, t)
+	}
+	s.turns[conversationID] = keep
+	return nil
+}
+
 func (s *fakeConvStore) UpdateTurnTokens(id string, tokensIn, tokensOut int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/conversations/handle_messages.go
+++ b/conversations/handle_messages.go
@@ -435,11 +435,8 @@ func (c *Conversations) streamResponseToExistingPost(ctx context.Context, stream
 	return nil
 }
 
-// streamContinuationToExistingPost streams a follow-up round onto a post that
-// already carries an assistant turn — used after the user approves pending
-// tool calls so the prior preamble + resolved tool cards stay visible while
-// the new round streams in below them. Regeneration must NOT use this entry
-// point; see streamingService.StreamContinuationToPost for the full contract.
+// streamContinuationToExistingPost streams a tool-approval follow-up.
+// See streamingService.StreamContinuationToPost.
 func (c *Conversations) streamContinuationToExistingPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, postingUser *model.User, channel *model.Channel) error {
 	streamCtx, err := c.streamingService.GetStreamingContext(ctx, post.Id)
 	if err != nil {

--- a/conversations/handle_messages.go
+++ b/conversations/handle_messages.go
@@ -435,6 +435,26 @@ func (c *Conversations) streamResponseToExistingPost(ctx context.Context, stream
 	return nil
 }
 
+// streamContinuationToExistingPost streams a follow-up round onto a post that
+// already carries an assistant turn — used after the user approves pending
+// tool calls so the prior preamble + resolved tool cards stay visible while
+// the new round streams in below them. Regeneration must NOT use this entry
+// point; see streamingService.StreamContinuationToPost for the full contract.
+func (c *Conversations) streamContinuationToExistingPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, postingUser *model.User, channel *model.Channel) error {
+	streamCtx, err := c.streamingService.GetStreamingContext(ctx, post.Id)
+	if err != nil {
+		return err
+	}
+
+	locale := c.responseLocale(postingUser, channel)
+	go func() {
+		defer c.streamingService.FinishStreaming(post.Id)
+		c.streamingService.StreamContinuationToPost(streamCtx, stream, post, locale, postingUser.Id)
+	}()
+
+	return nil
+}
+
 func (c *Conversations) failResponsePlaceholder(post *model.Post, userLocale string) {
 	message := "Sorry! An error occurred while accessing the LLM. See server logs for details."
 	if c.i18n != nil {

--- a/conversations/regeneration.go
+++ b/conversations/regeneration.go
@@ -250,6 +250,15 @@ func (c *Conversations) regenerateViaConversation(
 		return nil, fmt.Errorf("failed to get conversation for regen: %w", err)
 	}
 
+	// Scrub the prior generation's intermediate turns (auto-run rounds and
+	// any tool_result turns) before streaming. Without this, the webapp's
+	// per-round renderer would replay the prior tool calls alongside the
+	// regenerated response after the post-end refetch. The anchor turn
+	// stays — finalize updates it in place.
+	if delErr := c.convService.DeleteResponseTurns(conv.ID, post.Id); delErr != nil {
+		c.mmClient.LogError("Failed to scrub prior response turns on regen", "error", delErr.Error(), "post_id", post.Id, "conversation_id", conv.ID)
+	}
+
 	contextOpts := []llm.ContextOption{
 		c.contextBuilder.WithLLMContextDefaultTools(bot),
 	}

--- a/conversations/regeneration.go
+++ b/conversations/regeneration.go
@@ -250,15 +250,6 @@ func (c *Conversations) regenerateViaConversation(
 		return nil, fmt.Errorf("failed to get conversation for regen: %w", err)
 	}
 
-	// Scrub the prior generation's intermediate turns (auto-run rounds and
-	// any tool_result turns) before streaming. Without this, the webapp's
-	// per-round renderer would replay the prior tool calls alongside the
-	// regenerated response after the post-end refetch. The anchor turn
-	// stays — finalize updates it in place.
-	if delErr := c.convService.DeleteResponseTurns(conv.ID, post.Id); delErr != nil {
-		c.mmClient.LogError("Failed to scrub prior response turns on regen", "error", delErr.Error(), "post_id", post.Id, "conversation_id", conv.ID)
-	}
-
 	contextOpts := []llm.ContextOption{
 		c.contextBuilder.WithLLMContextDefaultTools(bot),
 	}
@@ -287,7 +278,9 @@ func (c *Conversations) regenerateViaConversation(
 		}
 	}
 
-	// BuildCompletionRequest redacts unshared tool output by default.
+	// Build the completion request BEFORE scrubbing — ExcludeAfterPostID
+	// walks back from the anchor turn that DeleteResponseTurns is about to
+	// remove. BuildCompletionRequest redacts unshared tool output by default.
 	// DMs opt in to the full content because their follow-up stream is
 	// scoped to the requester; DM tool_results are always shared=true so
 	// nothing would actually be redacted either way, this just documents
@@ -298,6 +291,17 @@ func (c *Conversations) regenerateViaConversation(
 	})
 	if buildErr != nil {
 		return nil, fmt.Errorf("failed to build completion request for regen: %w", buildErr)
+	}
+
+	// Scrub the prior generation entirely — the anchor turn AND any
+	// auto-run round / tool_result turns between it and the originating user
+	// turn. The streaming layer then runs identically to a first stream:
+	// WriteToolTurns appends new intermediates and finalize creates a fresh
+	// anchor at the end. No update-in-place special case, no sequence
+	// inversion that would hide the new tool turns from the webapp's
+	// back-walk renderer.
+	if delErr := c.convService.DeleteResponseTurns(conv.ID, post.Id); delErr != nil {
+		c.mmClient.LogError("Failed to scrub prior response turns on regen", "error", delErr.Error(), "post_id", post.Id, "conversation_id", conv.ID)
 	}
 
 	var opts []llm.LanguageModelOption

--- a/conversations/regeneration.go
+++ b/conversations/regeneration.go
@@ -278,13 +278,9 @@ func (c *Conversations) regenerateViaConversation(
 		}
 	}
 
-	// Build the completion request BEFORE scrubbing — ExcludeAfterPostID
-	// walks back from the anchor turn that DeleteResponseTurns is about to
-	// remove. BuildCompletionRequest redacts unshared tool output by default.
-	// DMs opt in to the full content because their follow-up stream is
-	// scoped to the requester; DM tool_results are always shared=true so
-	// nothing would actually be redacted either way, this just documents
-	// intent.
+	// Build the request BEFORE scrubbing — ExcludeAfterPostID needs the anchor.
+	// AllowUnsharedToolContent on DMs is a no-op (DM tool_results are shared)
+	// but documents intent.
 	completionReq, buildErr := c.convService.BuildCompletionRequest(conv, llmContext, conversation.BuildOptions{
 		ExcludeAfterPostID:       post.Id,
 		AllowUnsharedToolContent: isDM,
@@ -293,13 +289,7 @@ func (c *Conversations) regenerateViaConversation(
 		return nil, fmt.Errorf("failed to build completion request for regen: %w", buildErr)
 	}
 
-	// Scrub the prior generation entirely — the anchor turn AND any
-	// auto-run round / tool_result turns between it and the originating user
-	// turn. The streaming layer then runs identically to a first stream:
-	// WriteToolTurns appends new intermediates and finalize creates a fresh
-	// anchor at the end. No update-in-place special case, no sequence
-	// inversion that would hide the new tool turns from the webapp's
-	// back-walk renderer.
+	// Scrub the prior generation so the stream runs identically to a first.
 	if delErr := c.convService.DeleteResponseTurns(conv.ID, post.Id); delErr != nil {
 		c.mmClient.LogError("Failed to scrub prior response turns on regen", "error", delErr.Error(), "post_id", post.Id, "conversation_id", conv.ID)
 	}

--- a/conversations/test_helpers_test.go
+++ b/conversations/test_helpers_test.go
@@ -28,6 +28,9 @@ func (s *fakeStreamingService) StreamToNewDM(context.Context, string, *llm.TextS
 func (s *fakeStreamingService) StreamToPost(context.Context, *llm.TextStreamResult, *model.Post, string, string) {
 }
 
+func (s *fakeStreamingService) StreamContinuationToPost(context.Context, *llm.TextStreamResult, *model.Post, string, string) {
+}
+
 func (s *fakeStreamingService) StopStreaming(string) {}
 
 func (s *fakeStreamingService) GetStreamingContext(inCtx context.Context, _ string) (context.Context, error) {

--- a/conversations/tool_approval.go
+++ b/conversations/tool_approval.go
@@ -482,11 +482,8 @@ func (c *Conversations) streamToolFollowUp(
 		return fmt.Errorf("tool runner failed on tool follow-up: %w", err)
 	}
 
-	// Stream onto the same post the user just approved. The continuation
-	// path demotes the prior anchor at finalize so the new turn becomes the
-	// post's anchor while the resolved tool cards stay visible (they live
-	// on the demoted turn, which the webapp picks up while walking back
-	// from the new anchor).
+	// Stream onto the same post; finalize demotes the prior anchor so
+	// resolved tool cards remain visible alongside the new round.
 	if err := c.streamContinuationToExistingPost(ctx, runResult.Stream, post, user, channel); err != nil {
 		return fmt.Errorf("failed to stream tool follow-up: %w", err)
 	}

--- a/conversations/tool_approval.go
+++ b/conversations/tool_approval.go
@@ -482,13 +482,12 @@ func (c *Conversations) streamToolFollowUp(
 		return fmt.Errorf("tool runner failed on tool follow-up: %w", err)
 	}
 
-	// Stream onto the same post the user just approved. The streaming layer
-	// detects the existing anchor turn, sends a "continue" control event, and
-	// demotes the prior anchor at finalize so the new turn replaces it. The
-	// resolved tool cards stay visible because their tool_use blocks live on
-	// the demoted turn (now a non-anchor turn that the webapp picks up while
-	// walking back from the new anchor).
-	if err := c.streamResponseToExistingPost(ctx, runResult.Stream, post, user, channel); err != nil {
+	// Stream onto the same post the user just approved. The continuation
+	// path demotes the prior anchor at finalize so the new turn becomes the
+	// post's anchor while the resolved tool cards stay visible (they live
+	// on the demoted turn, which the webapp picks up while walking back
+	// from the new anchor).
+	if err := c.streamContinuationToExistingPost(ctx, runResult.Stream, post, user, channel); err != nil {
 		return fmt.Errorf("failed to stream tool follow-up: %w", err)
 	}
 

--- a/conversations/tool_approval.go
+++ b/conversations/tool_approval.go
@@ -482,12 +482,13 @@ func (c *Conversations) streamToolFollowUp(
 		return fmt.Errorf("tool runner failed on tool follow-up: %w", err)
 	}
 
-	responsePost := &model.Post{
-		ChannelId: channel.Id,
-		RootId:    responseRootIDFromPost(post),
-	}
-	responsePost.AddProp(streaming.ConversationIDProp, conv.ID)
-	if err := c.streamingService.StreamToNewPost(ctx, bot.GetMMBot().UserId, user.Id, runResult.Stream, responsePost, post.Id); err != nil {
+	// Stream onto the same post the user just approved. The streaming layer
+	// detects the existing anchor turn, sends a "continue" control event, and
+	// demotes the prior anchor at finalize so the new turn replaces it. The
+	// resolved tool cards stay visible because their tool_use blocks live on
+	// the demoted turn (now a non-anchor turn that the webapp picks up while
+	// walking back from the new anchor).
+	if err := c.streamResponseToExistingPost(ctx, runResult.Stream, post, user, channel); err != nil {
 		return fmt.Errorf("failed to stream tool follow-up: %w", err)
 	}
 
@@ -520,14 +521,6 @@ func findPendingToolTurn(turns []store.Turn, clickedPostID string) (*store.Turn,
 	}
 
 	return nil, nil, fmt.Errorf("no pending tool calls found for clicked post: %w", ErrStaleToolClick)
-}
-
-// responseRootIDFromPost returns the root ID for responding in a thread.
-func responseRootIDFromPost(post *model.Post) string {
-	if post.RootId != "" {
-		return post.RootId
-	}
-	return post.Id
 }
 
 // rehydrateRunTrace stamps ctx with the user-turn ID that initiated the run

--- a/e2e/helpers/llmbot-post.ts
+++ b/e2e/helpers/llmbot-post.ts
@@ -135,11 +135,8 @@ export class LLMBotPostHelper {
     }
 
     /**
-     * Get the post text content. Multi-round responses (auto-run tool rounds
-     * + a final answer) render one [data-testid="posttext"] per round in
-     * order. Returning .last() gives the final answer text — the round
-     * tests typically assert against. Tests needing a different round can
-     * use the underlying locator directly.
+     * Get the final answer's post text. Multi-round responses render one
+     * [data-testid="posttext"] per round; .last() returns the final round.
      * @param postId - Optional post ID to scope the search
      */
     getPostText(postId?: string): Locator {

--- a/e2e/helpers/llmbot-post.ts
+++ b/e2e/helpers/llmbot-post.ts
@@ -135,12 +135,16 @@ export class LLMBotPostHelper {
     }
 
     /**
-     * Get the post text content
+     * Get the post text content. Multi-round responses (auto-run tool rounds
+     * + a final answer) render one [data-testid="posttext"] per round in
+     * order. Returning .last() gives the final answer text — the round
+     * tests typically assert against. Tests needing a different round can
+     * use the underlying locator directly.
      * @param postId - Optional post ID to scope the search
      */
     getPostText(postId?: string): Locator {
         const baseLocator = postId ? this.getLLMBotPost(postId) : this.getLLMBotPost();
-        return baseLocator.locator('[data-testid="posttext"]').first();
+        return baseLocator.locator('[data-testid="posttext"]').last();
     }
 
     /**

--- a/e2e/tests/tool-config/mock-api/tool-call-policies.spec.ts
+++ b/e2e/tests/tool-config/mock-api/tool-call-policies.spec.ts
@@ -552,7 +552,7 @@ test.describe('Tool Call Policies (Mocked LLM)', () => {
         await expect(rhs.getByRole('button', {name: /^accept$/i})).not.toBeVisible();
     });
 
-    test('approval continuation creates a second post that does not duplicate the first post tools or show the empty-result fallback', async ({ page }) => {
+    test('approval continuation streams into the same post and does not show the empty-result fallback', async ({ page }) => {
         test.setTimeout(120000);
 
         const townSquareChannelID = await getTownSquareChannelID();
@@ -634,14 +634,12 @@ test.describe('Tool Call Policies (Mocked LLM)', () => {
         await expect(acceptButton).toBeVisible({timeout: 30000});
         await acceptButton.click();
 
-        const postB = botPosts.nth(1);
-        await expect(postB.getByText(continuationMarker)).toBeVisible({timeout: 30000});
-
-        // Each post scopes its tool cards to its own response — the aggregation
-        // must stop at the previous anchor so the continuation does not render
-        // the predecessor's tool_use blocks (and vice versa).
+        // Continuation now streams into the SAME post as the tool round.
+        // Both the original tool card and the follow-up text are visible in
+        // postA; no second bot post is created.
+        await expect(postA.getByText(continuationMarker)).toBeVisible({timeout: 30000});
         await expect(postA.getByText('Get Channel Info', {exact: true})).toBeVisible();
-        await expect(postB.getByText('Get Channel Info', {exact: true})).not.toBeVisible();
+        await expect(botPosts).toHaveCount(1);
     });
 
     test('channel auto_run requires Accept (DM-only policy), while auto_run_everywhere skips approval entirely', async ({ page }) => {

--- a/search/search_conversation_test.go
+++ b/search/search_conversation_test.go
@@ -111,6 +111,26 @@ func (s *fakeConversationStore) UpdateTurnTokens(id string, tokensIn, tokensOut 
 	return errors.New("turn not found")
 }
 
+func (s *fakeConversationStore) GetTurnByPostID(postID string) (*store.Turn, error) {
+	for _, t := range s.turns {
+		if t.PostID != nil && *t.PostID == postID {
+			c := *t
+			return &c, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *fakeConversationStore) UpdateTurnPostID(id string, postID *string) error {
+	for _, t := range s.turns {
+		if t.ID == id {
+			t.PostID = postID
+			return nil
+		}
+	}
+	return errors.New("turn not found")
+}
+
 func (s *fakeConversationStore) GetMaxSequenceForConversation(conversationID string) (int, error) {
 	maxSeq := 0
 	for _, t := range s.turns {

--- a/search/search_conversation_test.go
+++ b/search/search_conversation_test.go
@@ -131,6 +131,10 @@ func (s *fakeConversationStore) UpdateTurnPostID(id string, postID *string) erro
 	return errors.New("turn not found")
 }
 
+func (s *fakeConversationStore) DeleteResponseTurns(_ string, _ string) error {
+	return nil
+}
+
 func (s *fakeConversationStore) GetMaxSequenceForConversation(conversationID string) (int, error) {
 	maxSeq := 0
 	for _, t := range s.turns {

--- a/store/turns.go
+++ b/store/turns.go
@@ -166,6 +166,27 @@ RETURNING Sequence`
 	return fmt.Errorf("failed to create turn after %d retries: %w", maxAutoSequenceRetries, lastErr)
 }
 
+// UpdateTurnPostID sets the PostID column for a turn. Pass nil to clear the
+// anchor — used when finalizing a continuation stream so the new turn becomes
+// the canonical anchor and prior rounds for the same response post lose their
+// post link. The webapp's anchor lookup relies on at most one assistant turn
+// per post_id.
+func (s *Store) UpdateTurnPostID(id string, postID *string) error {
+	query, args, err := s.builder.
+		Update("LLM_Turns").
+		Set("PostID", postID).
+		Where(sq.Eq{"ID": id}).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("failed to build update turn post id query: %w", err)
+	}
+	_, err = s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to update turn post id: %w", err)
+	}
+	return nil
+}
+
 // UpdateTurnTokens updates the TokensIn and TokensOut fields on a turn.
 func (s *Store) UpdateTurnTokens(id string, tokensIn, tokensOut int64) error {
 	query, args, err := s.builder.

--- a/store/turns.go
+++ b/store/turns.go
@@ -187,11 +187,12 @@ func (s *Store) UpdateTurnPostID(id string, postID *string) error {
 	return nil
 }
 
-// DeleteResponseTurns removes the assistant + tool_result turns that belong
-// to a response between the user turn that initiated it and the anchor turn
-// for the given post. The anchor itself stays — regen's stream updates it
-// in place. Used to scrub stale intermediate turns from a prior generation
-// so the regenerated response doesn't render alongside leftover content.
+// DeleteResponseTurns removes every turn that belongs to a response — the
+// anchor itself and any assistant/tool_result turns between the user turn
+// that initiated it and that anchor. After this, the post has no DB state
+// and a regen can stream a fresh response identically to a first stream.
+// Callers must build any completion request BEFORE this runs, since the
+// anchor used to walk back from is gone afterwards.
 func (s *Store) DeleteResponseTurns(conversationID, postID string) error {
 	const query = `
 DELETE FROM LLM_Turns
@@ -206,7 +207,7 @@ WHERE ConversationID = $1
         LIMIT 1
       )
   ), 0)
-  AND Sequence < (
+  AND Sequence <= (
     SELECT Sequence FROM LLM_Turns
     WHERE ConversationID = $1 AND Role = 'assistant' AND PostID = $2
     LIMIT 1

--- a/store/turns.go
+++ b/store/turns.go
@@ -166,11 +166,8 @@ RETURNING Sequence`
 	return fmt.Errorf("failed to create turn after %d retries: %w", maxAutoSequenceRetries, lastErr)
 }
 
-// UpdateTurnPostID sets the PostID column for a turn. Pass nil to clear the
-// anchor — used when finalizing a continuation stream so the new turn becomes
-// the canonical anchor and prior rounds for the same response post lose their
-// post link. The webapp's anchor lookup relies on at most one assistant turn
-// per post_id.
+// UpdateTurnPostID sets or clears the PostID column for a turn. The webapp's
+// anchor lookup expects at most one assistant turn per post_id.
 func (s *Store) UpdateTurnPostID(id string, postID *string) error {
 	query, args, err := s.builder.
 		Update("LLM_Turns").
@@ -187,12 +184,9 @@ func (s *Store) UpdateTurnPostID(id string, postID *string) error {
 	return nil
 }
 
-// DeleteResponseTurns removes every turn that belongs to a response — the
-// anchor itself and any assistant/tool_result turns between the user turn
-// that initiated it and that anchor. After this, the post has no DB state
-// and a regen can stream a fresh response identically to a first stream.
-// Callers must build any completion request BEFORE this runs, since the
-// anchor used to walk back from is gone afterwards.
+// DeleteResponseTurns removes the post's anchor turn and any assistant or
+// tool_result turns between it and the originating user turn. Callers must
+// build any completion request before calling this.
 func (s *Store) DeleteResponseTurns(conversationID, postID string) error {
 	const query = `
 DELETE FROM LLM_Turns

--- a/store/turns.go
+++ b/store/turns.go
@@ -187,6 +187,36 @@ func (s *Store) UpdateTurnPostID(id string, postID *string) error {
 	return nil
 }
 
+// DeleteResponseTurns removes the assistant + tool_result turns that belong
+// to a response between the user turn that initiated it and the anchor turn
+// for the given post. The anchor itself stays — regen's stream updates it
+// in place. Used to scrub stale intermediate turns from a prior generation
+// so the regenerated response doesn't render alongside leftover content.
+func (s *Store) DeleteResponseTurns(conversationID, postID string) error {
+	const query = `
+DELETE FROM LLM_Turns
+WHERE ConversationID = $1
+  AND Sequence > COALESCE((
+    SELECT MAX(Sequence) FROM LLM_Turns
+    WHERE ConversationID = $1
+      AND Role = 'user'
+      AND Sequence < (
+        SELECT Sequence FROM LLM_Turns
+        WHERE ConversationID = $1 AND Role = 'assistant' AND PostID = $2
+        LIMIT 1
+      )
+  ), 0)
+  AND Sequence < (
+    SELECT Sequence FROM LLM_Turns
+    WHERE ConversationID = $1 AND Role = 'assistant' AND PostID = $2
+    LIMIT 1
+  )`
+	if _, err := s.db.Exec(query, conversationID, postID); err != nil {
+		return fmt.Errorf("failed to delete response turns: %w", err)
+	}
+	return nil
+}
+
 // UpdateTurnTokens updates the TokensIn and TokensOut fields on a turn.
 func (s *Store) UpdateTurnTokens(id string, tokensIn, tokensOut int64) error {
 	query, args, err := s.builder.

--- a/store/turns_test.go
+++ b/store/turns_test.go
@@ -451,12 +451,6 @@ func TestGetTurnByPostID(t *testing.T) {
 	}
 }
 
-// TestUpdateTurnPostID exercises the SQL UPDATE that demotes (or reassigns)
-// a turn's post anchor. The streaming layer relies on this to keep "exactly
-// one assistant turn anchored per post" — a typo'd column name or missing
-// WHERE clause would either silently fail or, worse, demote every turn in
-// the table. Mirrors the TestGetTurnByPostID pattern so the round trip
-// (write → read) is end-to-end.
 func TestUpdateTurnPostID(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -481,10 +475,9 @@ func TestUpdateTurnPostID(t *testing.T) {
 				err := s.UpdateTurnPostID(turnID, nil)
 				require.NoError(t, err)
 
-				// Lookup by the old post id no longer finds it.
 				gone, err := s.GetTurnByPostID("post-anchor")
 				require.NoError(t, err)
-				assert.Nil(t, gone, "demoted turn must not be findable via its old post id")
+				assert.Nil(t, gone)
 			},
 		},
 		{
@@ -506,12 +499,10 @@ func TestUpdateTurnPostID(t *testing.T) {
 				err := s.UpdateTurnPostID(turnID, &newPost)
 				require.NoError(t, err)
 
-				// Old anchor: gone.
 				oldHit, err := s.GetTurnByPostID("old-post")
 				require.NoError(t, err)
 				assert.Nil(t, oldHit)
 
-				// New anchor: present.
 				newHit, err := s.GetTurnByPostID("new-post")
 				require.NoError(t, err)
 				require.NotNil(t, newHit)
@@ -519,20 +510,18 @@ func TestUpdateTurnPostID(t *testing.T) {
 			},
 		},
 		{
-			name: "leaves OTHER rows untouched (WHERE clause is honored)",
+			name: "leaves other rows untouched",
 			setup: func(t *testing.T, s *Store) string {
 				conv := makeConversation()
 				err := s.CreateConversation(conv)
 				require.NoError(t, err)
 
-				// The turn we'll demote.
 				targetTurn := makeTurn(conv.ID, 1, func(tu *Turn) {
 					tu.PostID = stringPtr("target-post")
 				})
 				err = s.CreateTurn(targetTurn)
 				require.NoError(t, err)
 
-				// A sibling turn that must NOT be touched.
 				sibling := makeTurn(conv.ID, 2, func(tu *Turn) {
 					tu.PostID = stringPtr("sibling-post")
 				})
@@ -545,20 +534,19 @@ func TestUpdateTurnPostID(t *testing.T) {
 				err := s.UpdateTurnPostID(turnID, nil)
 				require.NoError(t, err)
 
-				// The sibling's post anchor is unaffected.
 				sibling, err := s.GetTurnByPostID("sibling-post")
 				require.NoError(t, err)
-				require.NotNil(t, sibling, "demoting one turn must not clear unrelated turns' PostIDs")
+				require.NotNil(t, sibling)
 			},
 		},
 		{
-			name: "returns nil error for non-existent ID (no row updated)",
+			name: "non-existent ID is a no-op",
 			setup: func(t *testing.T, s *Store) string {
 				return ""
 			},
 			validate: func(t *testing.T, s *Store, _ string) {
 				err := s.UpdateTurnPostID("does-not-exist", nil)
-				assert.NoError(t, err, "demoting a non-existent turn is a no-op, not an error")
+				assert.NoError(t, err)
 			},
 		},
 	}
@@ -576,11 +564,6 @@ func TestUpdateTurnPostID(t *testing.T) {
 	}
 }
 
-// TestDeleteResponseTurns exercises the SQL DELETE that scrubs every turn of
-// a prior generation when a post is regenerated — the anchor itself plus any
-// demoted assistants/tool_results between the originating user turn and the
-// anchor. After the delete the post has no DB state, so the next stream
-// creates fresh turns (no update-in-place special case).
 func TestDeleteResponseTurns(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -625,13 +608,12 @@ func TestDeleteResponseTurns(t *testing.T) {
 
 				turns, err := s.GetTurnsForConversation(convID)
 				require.NoError(t, err)
-				require.Len(t, turns, 1, "only the originating user turn remains; anchor + intermediates deleted")
+				require.Len(t, turns, 1)
 				assert.Equal(t, "user", turns[0].Role)
 
-				// The anchor is gone — looking it up by post id returns nothing.
 				gone, err := s.GetTurnByPostID(postID)
 				require.NoError(t, err)
-				assert.Nil(t, gone, "anchor must be deleted, not just demoted")
+				assert.Nil(t, gone)
 			},
 		},
 		{
@@ -669,8 +651,6 @@ func TestDeleteResponseTurns(t *testing.T) {
 
 				turns, err := s.GetTurnsForConversation(convID)
 				require.NoError(t, err)
-				// First user, first anchor, second user remain; the second
-				// anchor (post being regenerated) and its intermediates are gone.
 				require.Len(t, turns, 3)
 				assert.Equal(t, 1, turns[0].Sequence)
 				assert.Equal(t, 2, turns[1].Sequence)

--- a/store/turns_test.go
+++ b/store/turns_test.go
@@ -576,10 +576,11 @@ func TestUpdateTurnPostID(t *testing.T) {
 	}
 }
 
-// TestDeleteResponseTurns exercises the SQL DELETE that scrubs intermediate
-// turns of a prior generation when a post is regenerated. The anchor turn
-// stays (regen updates it in place); demoted assistants and tool_results
-// between the originating user turn and the anchor are removed.
+// TestDeleteResponseTurns exercises the SQL DELETE that scrubs every turn of
+// a prior generation when a post is regenerated — the anchor itself plus any
+// demoted assistants/tool_results between the originating user turn and the
+// anchor. After the delete the post has no DB state, so the next stream
+// creates fresh turns (no update-in-place special case).
 func TestDeleteResponseTurns(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -587,7 +588,7 @@ func TestDeleteResponseTurns(t *testing.T) {
 		validate func(t *testing.T, s *Store, convID, postID string)
 	}{
 		{
-			name: "removes demoted assistant + tool_result between user turn and anchor",
+			name: "removes anchor + demoted assistant + tool_result between user turn and anchor",
 			setup: func(t *testing.T, s *Store) (string, string) {
 				conv := makeConversation()
 				err := s.CreateConversation(conv)
@@ -624,11 +625,13 @@ func TestDeleteResponseTurns(t *testing.T) {
 
 				turns, err := s.GetTurnsForConversation(convID)
 				require.NoError(t, err)
-				require.Len(t, turns, 2, "user turn + anchor remain; demoted + tool_result deleted")
+				require.Len(t, turns, 1, "only the originating user turn remains; anchor + intermediates deleted")
 				assert.Equal(t, "user", turns[0].Role)
-				assert.Equal(t, "assistant", turns[1].Role)
-				require.NotNil(t, turns[1].PostID)
-				assert.Equal(t, postID, *turns[1].PostID)
+
+				// The anchor is gone — looking it up by post id returns nothing.
+				gone, err := s.GetTurnByPostID(postID)
+				require.NoError(t, err)
+				assert.Nil(t, gone, "anchor must be deleted, not just demoted")
 			},
 		},
 		{
@@ -666,12 +669,12 @@ func TestDeleteResponseTurns(t *testing.T) {
 
 				turns, err := s.GetTurnsForConversation(convID)
 				require.NoError(t, err)
-				// First user, first anchor, second user, second anchor.
-				require.Len(t, turns, 4)
+				// First user, first anchor, second user remain; the second
+				// anchor (post being regenerated) and its intermediates are gone.
+				require.Len(t, turns, 3)
 				assert.Equal(t, 1, turns[0].Sequence)
 				assert.Equal(t, 2, turns[1].Sequence)
 				assert.Equal(t, 3, turns[2].Sequence)
-				assert.Equal(t, 5, turns[3].Sequence)
 			},
 		},
 		{

--- a/store/turns_test.go
+++ b/store/turns_test.go
@@ -576,6 +576,137 @@ func TestUpdateTurnPostID(t *testing.T) {
 	}
 }
 
+// TestDeleteResponseTurns exercises the SQL DELETE that scrubs intermediate
+// turns of a prior generation when a post is regenerated. The anchor turn
+// stays (regen updates it in place); demoted assistants and tool_results
+// between the originating user turn and the anchor are removed.
+func TestDeleteResponseTurns(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, s *Store) (convID, postID string)
+		validate func(t *testing.T, s *Store, convID, postID string)
+	}{
+		{
+			name: "removes demoted assistant + tool_result between user turn and anchor",
+			setup: func(t *testing.T, s *Store) (string, string) {
+				conv := makeConversation()
+				err := s.CreateConversation(conv)
+				require.NoError(t, err)
+
+				postID := "regen-post"
+				err = s.CreateTurn(makeTurn(conv.ID, 1, func(tu *Turn) {
+					tu.Role = "user"
+				}))
+				require.NoError(t, err)
+				demoted := makeTurn(conv.ID, 2, func(tu *Turn) {
+					tu.Role = "assistant"
+					tu.PostID = nil
+				})
+				err = s.CreateTurn(demoted)
+				require.NoError(t, err)
+				toolResult := makeTurn(conv.ID, 3, func(tu *Turn) {
+					tu.Role = "tool_result"
+				})
+				err = s.CreateTurn(toolResult)
+				require.NoError(t, err)
+				anchor := makeTurn(conv.ID, 4, func(tu *Turn) {
+					tu.Role = "assistant"
+					tu.PostID = stringPtr(postID)
+				})
+				err = s.CreateTurn(anchor)
+				require.NoError(t, err)
+
+				return conv.ID, postID
+			},
+			validate: func(t *testing.T, s *Store, convID, postID string) {
+				err := s.DeleteResponseTurns(convID, postID)
+				require.NoError(t, err)
+
+				turns, err := s.GetTurnsForConversation(convID)
+				require.NoError(t, err)
+				require.Len(t, turns, 2, "user turn + anchor remain; demoted + tool_result deleted")
+				assert.Equal(t, "user", turns[0].Role)
+				assert.Equal(t, "assistant", turns[1].Role)
+				require.NotNil(t, turns[1].PostID)
+				assert.Equal(t, postID, *turns[1].PostID)
+			},
+		},
+		{
+			name: "leaves earlier turns (before the prior user turn) untouched",
+			setup: func(t *testing.T, s *Store) (string, string) {
+				conv := makeConversation()
+				err := s.CreateConversation(conv)
+				require.NoError(t, err)
+
+				postID := "second-post"
+				err = s.CreateTurn(makeTurn(conv.ID, 1, func(tu *Turn) { tu.Role = "user" }))
+				require.NoError(t, err)
+				err = s.CreateTurn(makeTurn(conv.ID, 2, func(tu *Turn) {
+					tu.Role = "assistant"
+					tu.PostID = stringPtr("first-post")
+				}))
+				require.NoError(t, err)
+				err = s.CreateTurn(makeTurn(conv.ID, 3, func(tu *Turn) { tu.Role = "user" }))
+				require.NoError(t, err)
+				err = s.CreateTurn(makeTurn(conv.ID, 4, func(tu *Turn) {
+					tu.Role = "assistant"
+					tu.PostID = nil
+				}))
+				require.NoError(t, err)
+				err = s.CreateTurn(makeTurn(conv.ID, 5, func(tu *Turn) {
+					tu.Role = "assistant"
+					tu.PostID = stringPtr(postID)
+				}))
+				require.NoError(t, err)
+				return conv.ID, postID
+			},
+			validate: func(t *testing.T, s *Store, convID, postID string) {
+				err := s.DeleteResponseTurns(convID, postID)
+				require.NoError(t, err)
+
+				turns, err := s.GetTurnsForConversation(convID)
+				require.NoError(t, err)
+				// First user, first anchor, second user, second anchor.
+				require.Len(t, turns, 4)
+				assert.Equal(t, 1, turns[0].Sequence)
+				assert.Equal(t, 2, turns[1].Sequence)
+				assert.Equal(t, 3, turns[2].Sequence)
+				assert.Equal(t, 5, turns[3].Sequence)
+			},
+		},
+		{
+			name: "no-op when the post has no anchor",
+			setup: func(t *testing.T, s *Store) (string, string) {
+				conv := makeConversation()
+				err := s.CreateConversation(conv)
+				require.NoError(t, err)
+				err = s.CreateTurn(makeTurn(conv.ID, 1, func(tu *Turn) { tu.Role = "user" }))
+				require.NoError(t, err)
+				return conv.ID, "no-such-post"
+			},
+			validate: func(t *testing.T, s *Store, convID, postID string) {
+				err := s.DeleteResponseTurns(convID, postID)
+				require.NoError(t, err)
+				turns, err := s.GetTurnsForConversation(convID)
+				require.NoError(t, err)
+				require.Len(t, turns, 1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := setupTestStore(t)
+
+			err := s.RunMigrations()
+			require.NoError(t, err)
+
+			convID, postID := tt.setup(t, s)
+			tt.validate(t, s, convID, postID)
+		})
+	}
+}
+
 func TestTurnCleanupWithConversation(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/store/turns_test.go
+++ b/store/turns_test.go
@@ -451,6 +451,131 @@ func TestGetTurnByPostID(t *testing.T) {
 	}
 }
 
+// TestUpdateTurnPostID exercises the SQL UPDATE that demotes (or reassigns)
+// a turn's post anchor. The streaming layer relies on this to keep "exactly
+// one assistant turn anchored per post" — a typo'd column name or missing
+// WHERE clause would either silently fail or, worse, demote every turn in
+// the table. Mirrors the TestGetTurnByPostID pattern so the round trip
+// (write → read) is end-to-end.
+func TestUpdateTurnPostID(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, s *Store) (turnID string)
+		validate func(t *testing.T, s *Store, turnID string)
+	}{
+		{
+			name: "clears the post anchor when given nil",
+			setup: func(t *testing.T, s *Store) string {
+				conv := makeConversation()
+				err := s.CreateConversation(conv)
+				require.NoError(t, err)
+
+				turn := makeTurn(conv.ID, 1, func(tu *Turn) {
+					tu.PostID = stringPtr("post-anchor")
+				})
+				err = s.CreateTurn(turn)
+				require.NoError(t, err)
+				return turn.ID
+			},
+			validate: func(t *testing.T, s *Store, turnID string) {
+				err := s.UpdateTurnPostID(turnID, nil)
+				require.NoError(t, err)
+
+				// Lookup by the old post id no longer finds it.
+				gone, err := s.GetTurnByPostID("post-anchor")
+				require.NoError(t, err)
+				assert.Nil(t, gone, "demoted turn must not be findable via its old post id")
+			},
+		},
+		{
+			name: "reassigns the post anchor to a new id",
+			setup: func(t *testing.T, s *Store) string {
+				conv := makeConversation()
+				err := s.CreateConversation(conv)
+				require.NoError(t, err)
+
+				turn := makeTurn(conv.ID, 1, func(tu *Turn) {
+					tu.PostID = stringPtr("old-post")
+				})
+				err = s.CreateTurn(turn)
+				require.NoError(t, err)
+				return turn.ID
+			},
+			validate: func(t *testing.T, s *Store, turnID string) {
+				newPost := "new-post"
+				err := s.UpdateTurnPostID(turnID, &newPost)
+				require.NoError(t, err)
+
+				// Old anchor: gone.
+				oldHit, err := s.GetTurnByPostID("old-post")
+				require.NoError(t, err)
+				assert.Nil(t, oldHit)
+
+				// New anchor: present.
+				newHit, err := s.GetTurnByPostID("new-post")
+				require.NoError(t, err)
+				require.NotNil(t, newHit)
+				assert.Equal(t, turnID, newHit.ID)
+			},
+		},
+		{
+			name: "leaves OTHER rows untouched (WHERE clause is honored)",
+			setup: func(t *testing.T, s *Store) string {
+				conv := makeConversation()
+				err := s.CreateConversation(conv)
+				require.NoError(t, err)
+
+				// The turn we'll demote.
+				targetTurn := makeTurn(conv.ID, 1, func(tu *Turn) {
+					tu.PostID = stringPtr("target-post")
+				})
+				err = s.CreateTurn(targetTurn)
+				require.NoError(t, err)
+
+				// A sibling turn that must NOT be touched.
+				sibling := makeTurn(conv.ID, 2, func(tu *Turn) {
+					tu.PostID = stringPtr("sibling-post")
+				})
+				err = s.CreateTurn(sibling)
+				require.NoError(t, err)
+
+				return targetTurn.ID
+			},
+			validate: func(t *testing.T, s *Store, turnID string) {
+				err := s.UpdateTurnPostID(turnID, nil)
+				require.NoError(t, err)
+
+				// The sibling's post anchor is unaffected.
+				sibling, err := s.GetTurnByPostID("sibling-post")
+				require.NoError(t, err)
+				require.NotNil(t, sibling, "demoting one turn must not clear unrelated turns' PostIDs")
+			},
+		},
+		{
+			name: "returns nil error for non-existent ID (no row updated)",
+			setup: func(t *testing.T, s *Store) string {
+				return ""
+			},
+			validate: func(t *testing.T, s *Store, _ string) {
+				err := s.UpdateTurnPostID("does-not-exist", nil)
+				assert.NoError(t, err, "demoting a non-existent turn is a no-op, not an error")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := setupTestStore(t)
+
+			err := s.RunMigrations()
+			require.NoError(t, err)
+
+			turnID := tt.setup(t, s)
+			tt.validate(t, s, turnID)
+		})
+	}
+}
+
 func TestTurnCleanupWithConversation(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -53,6 +53,18 @@ type Service interface {
 	StreamToNewPost(ctx context.Context, botID string, requesterUserID string, stream *llm.TextStreamResult, post *model.Post, respondingToPostID string) error
 	StreamToNewDM(ctx context.Context, botID string, stream *llm.TextStreamResult, userID string, post *model.Post, respondingToPostID string) error
 	StreamToPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, userLocale string, requesterUserID string)
+
+	// StreamContinuationToPost streams a follow-up round onto a post that
+	// already has an assistant turn (the tool-approval resume flow). At
+	// finalize, the prior anchor turn is demoted so the new turn becomes
+	// the post's anchor and the webapp's per-round renderer picks up both
+	// the prior and new content.
+	//
+	// Plain regeneration must NOT use this entry point — the regenerated
+	// answer is meant to replace the prior one, not be appended as a new
+	// round below it.
+	StreamContinuationToPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, userLocale string, requesterUserID string)
+
 	StopStreaming(postID string)
 	GetStreamingContext(inCtx context.Context, postID string) (context.Context, error)
 	FinishStreaming(postID string)
@@ -63,20 +75,22 @@ type postStreamContext struct {
 }
 
 // TurnStore is the subset of store operations needed by the streaming layer.
-// The streaming layer creates exactly one assistant turn per stream, at the
-// END of the stream, with the fully-accumulated content — that way the turn's
-// auto-assigned sequence lands after any tool-round turns that WriteToolTurns
-// persisted during the stream.
-//
-// GetTurnByPostID and UpdateTurnPostID support continuation streams: when an
-// agent turn that ended with pending tool calls is resumed (after the user
-// approves), the new round streams onto the SAME post. At finalize, the prior
-// anchor turn for that post is demoted (PostID cleared) so the webapp's
-// post→anchor lookup keeps finding exactly one match per post.
+// At finalize the streamer ends up in one of three states for the post's
+// assistant anchor turn:
+//   - first stream: no prior anchor → create one (CreateTurnAutoSequence).
+//   - regeneration: prior anchor → update its content/tokens in place
+//     (UpdateTurnContent, UpdateTurnTokens) so the post stays single-anchored
+//     and the regenerated response replaces the prior one.
+//   - continuation (tool-approval resume): prior anchor → demote
+//     (UpdateTurnPostID(nil)) and append a new anchor at the back of the
+//     conversation, so the webapp's per-round renderer sees the prior round
+//     followed by the new one.
 type TurnStore interface {
 	CreateTurnAutoSequence(turn *store.Turn) error
 	GetTurnByPostID(postID string) (*store.Turn, error)
 	UpdateTurnPostID(id string, postID *string) error
+	UpdateTurnContent(id string, content json.RawMessage) error
+	UpdateTurnTokens(id string, tokensIn, tokensOut int64) error
 }
 
 // turnAccumulator collects stream state. The turn is not written to the
@@ -86,11 +100,13 @@ type turnAccumulator struct {
 	postID         string
 	isDM           bool // true for DM channels; controls shared flag on tool_use blocks
 
-	// priorAnchorID is set when StreamToPost detected a continuation at start
-	// — the existing assistant turn anchored to this post. finalizeTurn uses
-	// it to demote that turn before creating the new anchor without an extra
-	// GetTurnByPostID round trip.
-	priorAnchorID string
+	// existingAnchorID is the prior assistant turn anchored to this post,
+	// looked up once at stream start. Empty if no prior anchor exists. How
+	// finalizeTurn uses it depends on isContinuation:
+	//   - regen / non-continuation: update in place (replace content).
+	//   - continuation: demote (clear PostID) and append a fresh anchor.
+	existingAnchorID string
+	isContinuation   bool
 
 	// Accumulated content
 	text          strings.Builder
@@ -338,29 +354,23 @@ func (p *MMPostStreamService) FinishStreaming(postID string) {
 }
 
 // newTurnAccumulator constructs an in-memory accumulator for a streaming
-// assistant response. priorAnchorID is the existing assistant turn anchored
-// to this post (set on continuation streams), or "" for first-time streams.
-// Nothing is persisted until finalizeTurn runs.
-func newTurnAccumulator(conversationID, postID, priorAnchorID string, isDM bool) *turnAccumulator {
+// assistant response. existingAnchorID is the existing assistant turn
+// anchored to this post (or "" if none); isContinuation distinguishes the
+// tool-approval resume flow from a regeneration. Nothing is persisted
+// until finalizeTurn runs.
+func newTurnAccumulator(conversationID, postID, existingAnchorID string, isContinuation, isDM bool) *turnAccumulator {
 	return &turnAccumulator{
-		conversationID: conversationID,
-		postID:         postID,
-		priorAnchorID:  priorAnchorID,
-		isDM:           isDM,
+		conversationID:   conversationID,
+		postID:           postID,
+		existingAnchorID: existingAnchorID,
+		isContinuation:   isContinuation,
+		isDM:             isDM,
 	}
 }
 
-// finalizeTurn builds content blocks from accumulated state and persists them
-// as a single new assistant turn. Creating the turn at stream END rather than
-// start gives it the highest sequence in the conversation — ensuring the
-// final response sits after any tool-round turns WriteToolTurns persisted
-// during the stream.
-//
-// If a prior assistant turn is already anchored to this post (continuation
-// after user-approved tool calls), its PostID is cleared first so the new
-// turn becomes the canonical anchor. The prior turn keeps its content and
-// stays in sequence; the webapp's back-walk through non-anchor turns picks
-// it up alongside the newly-written tool_result rounds.
+// finalizeTurn dispatches the accumulated content to the right write path:
+// fresh create for first streams, demote-then-append for continuation
+// streams (tool-approval resume), and update-in-place for regeneration.
 func (p *MMPostStreamService) finalizeTurn(acc *turnAccumulator) {
 	blocks := acc.buildContentBlocks()
 
@@ -370,9 +380,26 @@ func (p *MMPostStreamService) finalizeTurn(acc *turnAccumulator) {
 		return
 	}
 
-	if acc.priorAnchorID != "" {
-		if demoteErr := p.turnStore.UpdateTurnPostID(acc.priorAnchorID, nil); demoteErr != nil {
-			p.mmClient.LogError("Failed to demote prior anchor turn", "error", demoteErr, "post_id", acc.postID, "turn_id", acc.priorAnchorID)
+	if acc.existingAnchorID != "" && !acc.isContinuation {
+		// Regeneration: replace the existing anchor's content. Sequence and
+		// PostID stay put so the webapp keeps finding the same single
+		// anchor with the regenerated response.
+		if updateErr := p.turnStore.UpdateTurnContent(acc.existingAnchorID, contentJSON); updateErr != nil {
+			p.mmClient.LogError("Failed to update regenerated turn content", "error", updateErr, "post_id", acc.postID, "turn_id", acc.existingAnchorID)
+		}
+		if tokenErr := p.turnStore.UpdateTurnTokens(acc.existingAnchorID, acc.tokensIn, acc.tokensOut); tokenErr != nil {
+			p.mmClient.LogError("Failed to update regenerated turn tokens", "error", tokenErr, "post_id", acc.postID, "turn_id", acc.existingAnchorID)
+		}
+		return
+	}
+
+	if acc.existingAnchorID != "" && acc.isContinuation {
+		// Continuation: demote the prior anchor so the new turn we're about
+		// to create becomes the post's canonical anchor. The demoted turn
+		// keeps its content and the webapp's back-walk picks it up as a
+		// prior round.
+		if demoteErr := p.turnStore.UpdateTurnPostID(acc.existingAnchorID, nil); demoteErr != nil {
+			p.mmClient.LogError("Failed to demote prior anchor turn", "error", demoteErr, "post_id", acc.postID, "turn_id", acc.existingAnchorID)
 		}
 	}
 
@@ -468,11 +495,22 @@ func redactToolCalls(toolCalls []llm.ToolCall) []llm.ToolCall {
 	return redacted
 }
 
-// StreamToPost streams the result of a TextStreamResult to a post.
-// it will internally handle logging needs and updating the post.
-// requesterUserID is the user who initiated the request; tool call details
-// are scoped to this user while other channel members see redacted metadata.
+// StreamToPost streams a fresh response onto a post. Use this for the first
+// stream after creating a placeholder, and for regeneration — both replace
+// any prior content. For the tool-approval resume flow that wants to
+// preserve the prior round and append the next one, call
+// StreamContinuationToPost instead.
 func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, userLocale string, requesterUserID string) {
+	p.streamToPostImpl(ctx, stream, post, userLocale, requesterUserID, false)
+}
+
+// StreamContinuationToPost is the resume-after-tool-approval entry point.
+// See the Service interface for the full contract.
+func (p *MMPostStreamService) StreamContinuationToPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, userLocale string, requesterUserID string) {
+	p.streamToPostImpl(ctx, stream, post, userLocale, requesterUserID, true)
+}
+
+func (p *MMPostStreamService) streamToPostImpl(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, userLocale string, requesterUserID string, isContinuation bool) {
 	// Top-level posts are their own thread root, so falling back to post.Id
 	// keeps the attribute populated and makes "all spans for this thread"
 	// queries work uniformly for both replies and root posts.
@@ -491,20 +529,26 @@ func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.Text
 
 	broadcast := &model.WebsocketBroadcast{ChannelId: post.ChannelId}
 
-	// Continuation: a prior round on this same post already finalized an
-	// anchor turn (e.g., the user just approved pending tool calls). Send
-	// "continue" instead of "start" so the webapp keeps the resolved tool
-	// cards visible, and clear post.Message so the new round's text replaces
-	// the prior round's preamble rather than appending to it. The turn ID
-	// flows through to finalizeTurn so demote happens without a second
-	// GetTurnByPostID round trip.
+	// Look up any prior anchor turn for this post. Both code paths use the
+	// result, but for different ends:
+	//   - Continuation (StreamContinuationToPost): emit "continue" instead
+	//     of "start" so the webapp keeps resolved tool cards visible; clear
+	//     post.Message so the new round's text replaces the prior preamble;
+	//     pass the turn ID through so finalizeTurn can demote without a
+	//     second round trip.
+	//   - Regen (StreamToPost on a post that already has an anchor):
+	//     finalizeTurn updates that turn in place rather than creating a
+	//     second anchor for the same post. The control event stays "start"
+	//     because regen is a fresh response from the user's POV.
 	controlEvent := PostStreamingControlStart
-	priorAnchorID := ""
+	existingAnchorID := ""
 	if p.turnStore != nil {
 		if existing, lookupErr := p.turnStore.GetTurnByPostID(post.Id); lookupErr == nil && existing != nil && existing.Role == "assistant" {
-			controlEvent = PostStreamingControlContinue
-			priorAnchorID = existing.ID
-			post.Message = ""
+			existingAnchorID = existing.ID
+			if isContinuation {
+				controlEvent = PostStreamingControlContinue
+				post.Message = ""
+			}
 		}
 	}
 	p.sendPostStreamingControlEventWithBroadcast(post, controlEvent, broadcast)
@@ -520,7 +564,7 @@ func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.Text
 			if ch, chErr := p.mmClient.GetChannel(post.ChannelId); chErr == nil {
 				isDM = mmapi.IsDMWith(requesterUserID, ch)
 			}
-			acc = newTurnAccumulator(convID, post.Id, priorAnchorID, isDM)
+			acc = newTurnAccumulator(convID, post.Id, existingAnchorID, isContinuation, isDM)
 		}
 	}
 

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -38,11 +38,9 @@ const PostStreamingControlCancel = "cancel"
 const PostStreamingControlEnd = "end"
 const PostStreamingControlStart = "start"
 
-// PostStreamingControlContinue signals that a fresh stream is resuming on a
-// post that already carries content from an earlier round (typically the
-// follow-up after the user approved pending tool calls). The webapp clears
-// the visible message but keeps the resolved tool cards so the post combines
-// every round of one LLM conversation turn into a single post.
+// PostStreamingControlContinue signals a tool-approval resume stream onto a
+// post that already has content. The webapp clears the visible message but
+// keeps the resolved tool cards.
 const PostStreamingControlContinue = "continue"
 
 // WebSearchContextProp is still read by conversations/web_search_context.go when
@@ -55,14 +53,8 @@ type Service interface {
 	StreamToPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, userLocale string, requesterUserID string)
 
 	// StreamContinuationToPost streams a follow-up round onto a post that
-	// already has an assistant turn (the tool-approval resume flow). At
-	// finalize, the prior anchor turn is demoted so the new turn becomes
-	// the post's anchor and the webapp's per-round renderer picks up both
-	// the prior and new content.
-	//
-	// Plain regeneration must NOT use this entry point — the regenerated
-	// answer is meant to replace the prior one, not be appended as a new
-	// round below it.
+	// already has an assistant turn (tool-approval resume). Finalize demotes
+	// the prior anchor so both rounds render. Do not use for regeneration.
 	StreamContinuationToPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, userLocale string, requesterUserID string)
 
 	StopStreaming(postID string)
@@ -75,15 +67,9 @@ type postStreamContext struct {
 }
 
 // TurnStore is the subset of store operations needed by the streaming layer.
-// At finalize the streamer ends up in one of two states for the post's
-// assistant anchor turn:
-//   - fresh stream (first stream OR regen — for regen the caller scrubs the
-//     prior turns first via DeleteResponseTurns, leaving no DB state for the
-//     post): create a new anchor (CreateTurnAutoSequence).
-//   - continuation (tool-approval resume): prior anchor exists → demote
-//     (UpdateTurnPostID(nil)) and append a new anchor at the back of the
-//     conversation, so the webapp's per-round renderer sees the prior round
-//     followed by the new one.
+// Finalize either creates a fresh anchor (first stream / regen, with the caller
+// having scrubbed any prior turns) or demotes the existing anchor and creates
+// a new one (continuation).
 type TurnStore interface {
 	CreateTurnAutoSequence(turn *store.Turn) error
 	GetTurnByPostID(postID string) (*store.Turn, error)
@@ -97,11 +83,8 @@ type turnAccumulator struct {
 	postID         string
 	isDM           bool // true for DM channels; controls shared flag on tool_use blocks
 
-	// existingAnchorID is the prior anchor turn for this post, looked up
-	// once at stream start. Only the continuation flow uses it (to demote
-	// the prior anchor at finalize). For first streams and regen it stays
-	// empty: regen relies on the caller scrubbing prior turns via
-	// DeleteResponseTurns before getting here.
+	// existingAnchorID is the prior anchor for this post, looked up at stream
+	// start. Used only by continuation finalize to demote the prior anchor.
 	existingAnchorID string
 	isContinuation   bool
 
@@ -350,10 +333,7 @@ func (p *MMPostStreamService) FinishStreaming(postID string) {
 	delete(p.contexts, postID)
 }
 
-// newTurnAccumulator constructs an in-memory accumulator for a streaming
-// assistant response. existingAnchorID is the existing assistant turn
-// anchored to this post (or "" if none); isContinuation distinguishes the
-// tool-approval resume flow from a regeneration. Nothing is persisted
+// newTurnAccumulator constructs an in-memory accumulator. Nothing is persisted
 // until finalizeTurn runs.
 func newTurnAccumulator(conversationID, postID, existingAnchorID string, isContinuation, isDM bool) *turnAccumulator {
 	return &turnAccumulator{
@@ -365,10 +345,8 @@ func newTurnAccumulator(conversationID, postID, existingAnchorID string, isConti
 	}
 }
 
-// finalizeTurn dispatches the accumulated content to the right write path:
-// fresh create for first streams and regen (the caller scrubs prior turns
-// before regen, so there's no anchor to be found here), and
-// demote-then-append for continuation streams (tool-approval resume).
+// finalizeTurn writes the accumulated content as a new assistant turn. For
+// continuation streams it first demotes the prior anchor.
 func (p *MMPostStreamService) finalizeTurn(acc *turnAccumulator) {
 	blocks := acc.buildContentBlocks()
 
@@ -379,10 +357,7 @@ func (p *MMPostStreamService) finalizeTurn(acc *turnAccumulator) {
 	}
 
 	if acc.existingAnchorID != "" && acc.isContinuation {
-		// Continuation: demote the prior anchor so the new turn we're about
-		// to create becomes the post's canonical anchor. The demoted turn
-		// keeps its content and the webapp's back-walk picks it up as a
-		// prior round.
+		// Demote the prior anchor so the new turn becomes the post's anchor.
 		if demoteErr := p.turnStore.UpdateTurnPostID(acc.existingAnchorID, nil); demoteErr != nil {
 			p.mmClient.LogError("Failed to demote prior anchor turn", "error", demoteErr, "post_id", acc.postID, "turn_id", acc.existingAnchorID)
 		}
@@ -480,18 +455,13 @@ func redactToolCalls(toolCalls []llm.ToolCall) []llm.ToolCall {
 	return redacted
 }
 
-// StreamToPost streams a fresh response onto a post: the first stream after
-// creating a placeholder, or a regeneration. Either way finalize creates a
-// new anchor turn — for regen the caller is responsible for scrubbing the
-// prior anchor and intermediates first (DeleteResponseTurns). Use
-// StreamContinuationToPost for the tool-approval resume flow, which keeps
-// the prior round and appends the next one as a new anchor.
+// StreamToPost streams a fresh response onto a post (first stream or regen,
+// where the caller has already scrubbed prior turns). For tool-approval resume
+// use StreamContinuationToPost.
 func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, userLocale string, requesterUserID string) {
 	p.streamToPostImpl(ctx, stream, post, userLocale, requesterUserID, false)
 }
 
-// StreamContinuationToPost is the resume-after-tool-approval entry point.
-// See the Service interface for the full contract.
 func (p *MMPostStreamService) StreamContinuationToPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, userLocale string, requesterUserID string) {
 	p.streamToPostImpl(ctx, stream, post, userLocale, requesterUserID, true)
 }
@@ -515,12 +485,8 @@ func (p *MMPostStreamService) streamToPostImpl(ctx context.Context, stream *llm.
 
 	broadcast := &model.WebsocketBroadcast{ChannelId: post.ChannelId}
 
-	// Look up any prior anchor turn for this post. Only the continuation
-	// flow (tool-approval resume) needs it: the existing turn stays, gets
-	// demoted at finalize, and the new round becomes the post's anchor.
-	// For first streams there is no prior anchor; for regen the caller
-	// already scrubbed the prior turns via DeleteResponseTurns before
-	// calling here, so the lookup also returns nothing.
+	// Look up any prior anchor; only continuation uses it (to demote at
+	// finalize). First stream and regen find none.
 	controlEvent := PostStreamingControlStart
 	existingAnchorID := ""
 	if p.turnStore != nil {
@@ -592,9 +558,7 @@ func (p *MMPostStreamService) streamToPostImpl(ctx context.Context, stream *llm.
 					T := i18n.LocalizerFunc(p.i18n, userLocale)
 					emptyText := T("agents.stream_to_post_llm_not_return", "Sorry! The LLM did not return a result.")
 					post.Message = emptyText
-					// Mirror the fallback text into the accumulator so the
-					// persisted turn carries it; otherwise the round renders
-					// empty after the post-end refetch.
+					// Mirror into the accumulator so the turn carries the fallback.
 					if acc != nil {
 						acc.text.WriteString(emptyText)
 					}
@@ -627,10 +591,7 @@ func (p *MMPostStreamService) streamToPostImpl(ctx context.Context, stream *llm.
 				T := i18n.LocalizerFunc(p.i18n, userLocale)
 				errorText := T("agents.stream_to_post_access_llm_error", "Sorry! An error occurred while accessing the LLM. See server logs for details.")
 				post.Message += errorText
-				// Mirror the error text into the accumulator so finalize
-				// persists it as the turn's text — otherwise the round
-				// renders empty and the user only sees the (transient)
-				// post.Message until the post-end refetch wipes it.
+				// Mirror into the accumulator so the turn carries the error.
 				if acc != nil {
 					if separator != "" {
 						acc.text.WriteString(separator)
@@ -672,24 +633,14 @@ func (p *MMPostStreamService) streamToPostImpl(ctx context.Context, stream *llm.
 						toolCalls[i].SanitizeArguments()
 					}
 					if acc != nil {
-						// ToolRunner emits two tool-call events per round: a
-						// "pending" event before execution (original statuses)
-						// and a "resolved" event after execution (Success,
-						// Error, or AutoApproved). On resolved we discard the
-						// placeholder accumulator and live-post state so only
-						// the final round's content lands on the response
-						// post's anchor turn — toolrunner separately writes
-						// the just-resolved round to the conversation via the
-						// onToolTurns callback at end-of-stream. On pending
-						// we retain the tool calls so a rejected-approval
-						// turn still carries them.
-						//
-						// We do NOT broadcast a `next: ""` event here. The
-						// webapp uses the resolved tool_call event itself to
-						// snapshot the just-completed round's text/tools into
-						// its rounds list. An empty `next` first would clear
-						// the text before the snapshot ran and drop the
-						// round's preamble.
+						// On resolved, reset the accumulator: toolrunner
+						// persists the just-completed round separately via
+						// onToolTurns, and only the final round's content
+						// belongs on the anchor. Do NOT broadcast next: ""
+						// here — the webapp snapshots the round's preamble
+						// at the resolved tool_call event. On pending,
+						// retain the calls so a rejected-approval turn
+						// keeps them.
 						if isResolvedToolCallsEvent(toolCalls) {
 							acc.text.Reset()
 							acc.reasoning.Reset()

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -38,6 +38,13 @@ const PostStreamingControlCancel = "cancel"
 const PostStreamingControlEnd = "end"
 const PostStreamingControlStart = "start"
 
+// PostStreamingControlContinue signals that a fresh stream is resuming on a
+// post that already carries content from an earlier round (typically the
+// follow-up after the user approved pending tool calls). The webapp clears
+// the visible message but keeps the resolved tool cards so the post combines
+// every round of one LLM conversation turn into a single post.
+const PostStreamingControlContinue = "continue"
+
 // WebSearchContextProp is still read by conversations/web_search_context.go when
 // extracting web search state from legacy thread posts.
 const WebSearchContextProp = "web_search_context"
@@ -60,8 +67,16 @@ type postStreamContext struct {
 // END of the stream, with the fully-accumulated content — that way the turn's
 // auto-assigned sequence lands after any tool-round turns that WriteToolTurns
 // persisted during the stream.
+//
+// GetTurnByPostID and UpdateTurnPostID support continuation streams: when an
+// agent turn that ended with pending tool calls is resumed (after the user
+// approves), the new round streams onto the SAME post. At finalize, the prior
+// anchor turn for that post is demoted (PostID cleared) so the webapp's
+// post→anchor lookup keeps finding exactly one match per post.
 type TurnStore interface {
 	CreateTurnAutoSequence(turn *store.Turn) error
+	GetTurnByPostID(postID string) (*store.Turn, error)
+	UpdateTurnPostID(id string, postID *string) error
 }
 
 // turnAccumulator collects stream state. The turn is not written to the
@@ -331,6 +346,12 @@ func newTurnAccumulator(conversationID, postID string, isDM bool) *turnAccumulat
 // start gives it the highest sequence in the conversation — ensuring the
 // final response sits after any tool-round turns WriteToolTurns persisted
 // during the stream.
+//
+// If a prior assistant turn is already anchored to this post (continuation
+// after user-approved tool calls), its PostID is cleared first so the new
+// turn becomes the canonical anchor. The prior turn keeps its content and
+// stays in sequence; the webapp's back-walk through non-anchor turns picks
+// it up alongside the newly-written tool_result rounds.
 func (p *MMPostStreamService) finalizeTurn(acc *turnAccumulator) {
 	blocks := acc.buildContentBlocks()
 
@@ -338,6 +359,14 @@ func (p *MMPostStreamService) finalizeTurn(acc *turnAccumulator) {
 	if err != nil {
 		p.mmClient.LogError("Failed to marshal turn content blocks", "error", err, "post_id", acc.postID)
 		return
+	}
+
+	if existing, lookupErr := p.turnStore.GetTurnByPostID(acc.postID); lookupErr != nil {
+		p.mmClient.LogError("Failed to look up prior anchor turn", "error", lookupErr, "post_id", acc.postID)
+	} else if existing != nil && existing.Role == "assistant" {
+		if demoteErr := p.turnStore.UpdateTurnPostID(existing.ID, nil); demoteErr != nil {
+			p.mmClient.LogError("Failed to demote prior anchor turn", "error", demoteErr, "post_id", acc.postID, "turn_id", existing.ID)
+		}
 	}
 
 	postIDCopy := acc.postID
@@ -454,7 +483,20 @@ func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.Text
 	defer span.End()
 
 	broadcast := &model.WebsocketBroadcast{ChannelId: post.ChannelId}
-	p.sendPostStreamingControlEventWithBroadcast(post, PostStreamingControlStart, broadcast)
+
+	// Continuation: a prior round on this same post already finalized an
+	// anchor turn (e.g., the user just approved pending tool calls). Send
+	// "continue" instead of "start" so the webapp keeps the resolved tool
+	// cards visible, and clear post.Message so the new round's text replaces
+	// the prior round's preamble rather than appending to it.
+	controlEvent := PostStreamingControlStart
+	if p.turnStore != nil {
+		if existing, lookupErr := p.turnStore.GetTurnByPostID(post.Id); lookupErr == nil && existing != nil && existing.Role == "assistant" {
+			controlEvent = PostStreamingControlContinue
+			post.Message = ""
+		}
+	}
+	p.sendPostStreamingControlEventWithBroadcast(post, controlEvent, broadcast)
 
 	// Create turn accumulator if turn persistence is enabled and a conversation_id is set
 	var acc *turnAccumulator
@@ -584,6 +626,13 @@ func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.Text
 						// the final round's content lands on the response post.
 						// On the pending event we retain the tool calls so a
 						// rejected-approval turn still carries them.
+						//
+						// We do NOT broadcast a `next: ""` event here. The
+						// webapp uses the resolved tool_call event itself to
+						// snapshot the just-completed round's text/tools into
+						// its rounds list. Sending an empty `next` first
+						// would clear the text before the snapshot ran,
+						// dropping the round's preamble.
 						if isResolvedToolCallsEvent(toolCalls) {
 							acc.text.Reset()
 							acc.reasoning.Reset()
@@ -592,7 +641,6 @@ func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.Text
 							acc.toolCalls = nil
 							messageBuilder.Reset()
 							post.Message = ""
-							p.sendPostStreamingUpdateEventWithBroadcast(post, post.Message, broadcast)
 						} else {
 							acc.toolCalls = toolCalls
 						}

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -97,11 +97,11 @@ type turnAccumulator struct {
 	postID         string
 	isDM           bool // true for DM channels; controls shared flag on tool_use blocks
 
-	// existingAnchorID is the prior assistant turn anchored to this post,
-	// looked up once at stream start. Empty if no prior anchor exists. How
-	// finalizeTurn uses it depends on isContinuation:
-	//   - regen / non-continuation: update in place (replace content).
-	//   - continuation: demote (clear PostID) and append a fresh anchor.
+	// existingAnchorID is the prior anchor turn for this post, looked up
+	// once at stream start. Only the continuation flow uses it (to demote
+	// the prior anchor at finalize). For first streams and regen it stays
+	// empty: regen relies on the caller scrubbing prior turns via
+	// DeleteResponseTurns before getting here.
 	existingAnchorID string
 	isContinuation   bool
 
@@ -480,11 +480,12 @@ func redactToolCalls(toolCalls []llm.ToolCall) []llm.ToolCall {
 	return redacted
 }
 
-// StreamToPost streams a fresh response onto a post. Use this for the first
-// stream after creating a placeholder, and for regeneration — both replace
-// any prior content. For the tool-approval resume flow that wants to
-// preserve the prior round and append the next one, call
-// StreamContinuationToPost instead.
+// StreamToPost streams a fresh response onto a post: the first stream after
+// creating a placeholder, or a regeneration. Either way finalize creates a
+// new anchor turn — for regen the caller is responsible for scrubbing the
+// prior anchor and intermediates first (DeleteResponseTurns). Use
+// StreamContinuationToPost for the tool-approval resume flow, which keeps
+// the prior round and appends the next one as a new anchor.
 func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.TextStreamResult, post *model.Post, userLocale string, requesterUserID string) {
 	p.streamToPostImpl(ctx, stream, post, userLocale, requesterUserID, false)
 }
@@ -673,21 +674,22 @@ func (p *MMPostStreamService) streamToPostImpl(ctx context.Context, stream *llm.
 					if acc != nil {
 						// ToolRunner emits two tool-call events per round: a
 						// "pending" event before execution (original statuses)
-						// and a "resolved" event after execution (Success or
-						// Error). On resolved, this round's text, reasoning
-						// and tool calls have already been persisted separately
-						// via WriteToolTurns, so we reset the placeholder
-						// accumulator and associated live-post state so only
-						// the final round's content lands on the response post.
-						// On the pending event we retain the tool calls so a
-						// rejected-approval turn still carries them.
+						// and a "resolved" event after execution (Success,
+						// Error, or AutoApproved). On resolved we discard the
+						// placeholder accumulator and live-post state so only
+						// the final round's content lands on the response
+						// post's anchor turn — toolrunner separately writes
+						// the just-resolved round to the conversation via the
+						// onToolTurns callback at end-of-stream. On pending
+						// we retain the tool calls so a rejected-approval
+						// turn still carries them.
 						//
 						// We do NOT broadcast a `next: ""` event here. The
 						// webapp uses the resolved tool_call event itself to
 						// snapshot the just-completed round's text/tools into
-						// its rounds list. Sending an empty `next` first
-						// would clear the text before the snapshot ran,
-						// dropping the round's preamble.
+						// its rounds list. An empty `next` first would clear
+						// the text before the snapshot ran and drop the
+						// round's preamble.
 						if isResolvedToolCallsEvent(toolCalls) {
 							acc.text.Reset()
 							acc.reasoning.Reset()

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -589,7 +589,14 @@ func (p *MMPostStreamService) streamToPostImpl(ctx context.Context, stream *llm.
 				if strings.TrimSpace(post.Message) == "" && !hasToolCalls {
 					p.mmClient.LogError("LLM closed stream with no result")
 					T := i18n.LocalizerFunc(p.i18n, userLocale)
-					post.Message = T("agents.stream_to_post_llm_not_return", "Sorry! The LLM did not return a result.")
+					emptyText := T("agents.stream_to_post_llm_not_return", "Sorry! The LLM did not return a result.")
+					post.Message = emptyText
+					// Mirror the fallback text into the accumulator so the
+					// persisted turn carries it; otherwise the round renders
+					// empty after the post-end refetch.
+					if acc != nil {
+						acc.text.WriteString(emptyText)
+					}
 					p.sendPostStreamingUpdateEventWithBroadcast(post, post.Message, broadcast)
 				}
 
@@ -608,14 +615,27 @@ func (p *MMPostStreamService) streamToPostImpl(ctx context.Context, stream *llm.
 				}
 
 				// Handle partial results
+				var separator string
 				if strings.TrimSpace(post.Message) == "" {
 					post.Message = ""
 				} else {
-					post.Message += "\n\n"
+					separator = "\n\n"
+					post.Message += separator
 				}
 				p.mmClient.LogError("Streaming result to post failed partway", "error", err)
 				T := i18n.LocalizerFunc(p.i18n, userLocale)
-				post.Message += T("agents.stream_to_post_access_llm_error", "Sorry! An error occurred while accessing the LLM. See server logs for details.")
+				errorText := T("agents.stream_to_post_access_llm_error", "Sorry! An error occurred while accessing the LLM. See server logs for details.")
+				post.Message += errorText
+				// Mirror the error text into the accumulator so finalize
+				// persists it as the turn's text — otherwise the round
+				// renders empty and the user only sees the (transient)
+				// post.Message until the post-end refetch wipes it.
+				if acc != nil {
+					if separator != "" {
+						acc.text.WriteString(separator)
+					}
+					acc.text.WriteString(errorText)
+				}
 
 				if err := p.mmClient.UpdatePost(post); err != nil {
 					p.mmClient.LogError("Error recovering from streaming error", "error", err)

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -75,13 +75,12 @@ type postStreamContext struct {
 }
 
 // TurnStore is the subset of store operations needed by the streaming layer.
-// At finalize the streamer ends up in one of three states for the post's
+// At finalize the streamer ends up in one of two states for the post's
 // assistant anchor turn:
-//   - first stream: no prior anchor → create one (CreateTurnAutoSequence).
-//   - regeneration: prior anchor → update its content/tokens in place
-//     (UpdateTurnContent, UpdateTurnTokens) so the post stays single-anchored
-//     and the regenerated response replaces the prior one.
-//   - continuation (tool-approval resume): prior anchor → demote
+//   - fresh stream (first stream OR regen — for regen the caller scrubs the
+//     prior turns first via DeleteResponseTurns, leaving no DB state for the
+//     post): create a new anchor (CreateTurnAutoSequence).
+//   - continuation (tool-approval resume): prior anchor exists → demote
 //     (UpdateTurnPostID(nil)) and append a new anchor at the back of the
 //     conversation, so the webapp's per-round renderer sees the prior round
 //     followed by the new one.
@@ -89,8 +88,6 @@ type TurnStore interface {
 	CreateTurnAutoSequence(turn *store.Turn) error
 	GetTurnByPostID(postID string) (*store.Turn, error)
 	UpdateTurnPostID(id string, postID *string) error
-	UpdateTurnContent(id string, content json.RawMessage) error
-	UpdateTurnTokens(id string, tokensIn, tokensOut int64) error
 }
 
 // turnAccumulator collects stream state. The turn is not written to the
@@ -369,27 +366,15 @@ func newTurnAccumulator(conversationID, postID, existingAnchorID string, isConti
 }
 
 // finalizeTurn dispatches the accumulated content to the right write path:
-// fresh create for first streams, demote-then-append for continuation
-// streams (tool-approval resume), and update-in-place for regeneration.
+// fresh create for first streams and regen (the caller scrubs prior turns
+// before regen, so there's no anchor to be found here), and
+// demote-then-append for continuation streams (tool-approval resume).
 func (p *MMPostStreamService) finalizeTurn(acc *turnAccumulator) {
 	blocks := acc.buildContentBlocks()
 
 	contentJSON, err := json.Marshal(blocks)
 	if err != nil {
 		p.mmClient.LogError("Failed to marshal turn content blocks", "error", err, "post_id", acc.postID)
-		return
-	}
-
-	if acc.existingAnchorID != "" && !acc.isContinuation {
-		// Regeneration: replace the existing anchor's content. Sequence and
-		// PostID stay put so the webapp keeps finding the same single
-		// anchor with the regenerated response.
-		if updateErr := p.turnStore.UpdateTurnContent(acc.existingAnchorID, contentJSON); updateErr != nil {
-			p.mmClient.LogError("Failed to update regenerated turn content", "error", updateErr, "post_id", acc.postID, "turn_id", acc.existingAnchorID)
-		}
-		if tokenErr := p.turnStore.UpdateTurnTokens(acc.existingAnchorID, acc.tokensIn, acc.tokensOut); tokenErr != nil {
-			p.mmClient.LogError("Failed to update regenerated turn tokens", "error", tokenErr, "post_id", acc.postID, "turn_id", acc.existingAnchorID)
-		}
 		return
 	}
 
@@ -529,17 +514,12 @@ func (p *MMPostStreamService) streamToPostImpl(ctx context.Context, stream *llm.
 
 	broadcast := &model.WebsocketBroadcast{ChannelId: post.ChannelId}
 
-	// Look up any prior anchor turn for this post. Both code paths use the
-	// result, but for different ends:
-	//   - Continuation (StreamContinuationToPost): emit "continue" instead
-	//     of "start" so the webapp keeps resolved tool cards visible; clear
-	//     post.Message so the new round's text replaces the prior preamble;
-	//     pass the turn ID through so finalizeTurn can demote without a
-	//     second round trip.
-	//   - Regen (StreamToPost on a post that already has an anchor):
-	//     finalizeTurn updates that turn in place rather than creating a
-	//     second anchor for the same post. The control event stays "start"
-	//     because regen is a fresh response from the user's POV.
+	// Look up any prior anchor turn for this post. Only the continuation
+	// flow (tool-approval resume) needs it: the existing turn stays, gets
+	// demoted at finalize, and the new round becomes the post's anchor.
+	// For first streams there is no prior anchor; for regen the caller
+	// already scrubbed the prior turns via DeleteResponseTurns before
+	// calling here, so the lookup also returns nothing.
 	controlEvent := PostStreamingControlStart
 	existingAnchorID := ""
 	if p.turnStore != nil {

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -86,6 +86,12 @@ type turnAccumulator struct {
 	postID         string
 	isDM           bool // true for DM channels; controls shared flag on tool_use blocks
 
+	// priorAnchorID is set when StreamToPost detected a continuation at start
+	// — the existing assistant turn anchored to this post. finalizeTurn uses
+	// it to demote that turn before creating the new anchor without an extra
+	// GetTurnByPostID round trip.
+	priorAnchorID string
+
 	// Accumulated content
 	text          strings.Builder
 	reasoning     strings.Builder
@@ -332,11 +338,14 @@ func (p *MMPostStreamService) FinishStreaming(postID string) {
 }
 
 // newTurnAccumulator constructs an in-memory accumulator for a streaming
-// assistant response. Nothing is persisted until finalizeTurn runs.
-func newTurnAccumulator(conversationID, postID string, isDM bool) *turnAccumulator {
+// assistant response. priorAnchorID is the existing assistant turn anchored
+// to this post (set on continuation streams), or "" for first-time streams.
+// Nothing is persisted until finalizeTurn runs.
+func newTurnAccumulator(conversationID, postID, priorAnchorID string, isDM bool) *turnAccumulator {
 	return &turnAccumulator{
 		conversationID: conversationID,
 		postID:         postID,
+		priorAnchorID:  priorAnchorID,
 		isDM:           isDM,
 	}
 }
@@ -361,11 +370,9 @@ func (p *MMPostStreamService) finalizeTurn(acc *turnAccumulator) {
 		return
 	}
 
-	if existing, lookupErr := p.turnStore.GetTurnByPostID(acc.postID); lookupErr != nil {
-		p.mmClient.LogError("Failed to look up prior anchor turn", "error", lookupErr, "post_id", acc.postID)
-	} else if existing != nil && existing.Role == "assistant" {
-		if demoteErr := p.turnStore.UpdateTurnPostID(existing.ID, nil); demoteErr != nil {
-			p.mmClient.LogError("Failed to demote prior anchor turn", "error", demoteErr, "post_id", acc.postID, "turn_id", existing.ID)
+	if acc.priorAnchorID != "" {
+		if demoteErr := p.turnStore.UpdateTurnPostID(acc.priorAnchorID, nil); demoteErr != nil {
+			p.mmClient.LogError("Failed to demote prior anchor turn", "error", demoteErr, "post_id", acc.postID, "turn_id", acc.priorAnchorID)
 		}
 	}
 
@@ -488,11 +495,15 @@ func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.Text
 	// anchor turn (e.g., the user just approved pending tool calls). Send
 	// "continue" instead of "start" so the webapp keeps the resolved tool
 	// cards visible, and clear post.Message so the new round's text replaces
-	// the prior round's preamble rather than appending to it.
+	// the prior round's preamble rather than appending to it. The turn ID
+	// flows through to finalizeTurn so demote happens without a second
+	// GetTurnByPostID round trip.
 	controlEvent := PostStreamingControlStart
+	priorAnchorID := ""
 	if p.turnStore != nil {
 		if existing, lookupErr := p.turnStore.GetTurnByPostID(post.Id); lookupErr == nil && existing != nil && existing.Role == "assistant" {
 			controlEvent = PostStreamingControlContinue
+			priorAnchorID = existing.ID
 			post.Message = ""
 		}
 	}
@@ -509,7 +520,7 @@ func (p *MMPostStreamService) StreamToPost(ctx context.Context, stream *llm.Text
 			if ch, chErr := p.mmClient.GetChannel(post.ChannelId); chErr == nil {
 				isDM = mmapi.IsDMWith(requesterUserID, ch)
 			}
-			acc = newTurnAccumulator(convID, post.Id, isDM)
+			acc = newTurnAccumulator(convID, post.Id, priorAnchorID, isDM)
 		}
 	}
 

--- a/streaming/turn_persistence_test.go
+++ b/streaming/turn_persistence_test.go
@@ -473,7 +473,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		require.Equal(t, int64(30), streamTurn.TokensOut)
 	})
 
-	t.Run("error persists partial content", func(t *testing.T) {
+	t.Run("error persists partial content followed by the error fallback", func(t *testing.T) {
 		ts := &fakeTurnStore{}
 		client := &fakeStreamingClient{
 			channels: map[string]*model.Channel{
@@ -501,7 +501,11 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		blocks := parseContentBlocks(t, streamTurn.Content)
 		require.Len(t, blocks, 1)
 		require.Equal(t, conversation.BlockTypeText, blocks[0].Type)
-		require.Equal(t, "Partial text", blocks[0].Text)
+		// Partial text is preserved AND the error fallback is appended so
+		// the persisted turn carries the user-visible message — without
+		// this the round renders empty after the post-end refetch.
+		require.Contains(t, blocks[0].Text, "Partial text")
+		require.Contains(t, blocks[0].Text, "An error occurred")
 	})
 
 	t.Run("cancellation persists partial content", func(t *testing.T) {
@@ -891,11 +895,12 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		require.Equal(t, "https://example.com", parsedAnnotations[0].URL)
 	})
 
-	// Reproducer: a stream that produces no text/reasoning/tool_calls should
-	// finalize to "[]" so the webapp can safely iterate `turn.content`. The
-	// current implementation marshals a nil slice to "null" instead, which
-	// crashes the webapp with "turn.content is null".
-	t.Run("empty stream finalizes to empty array not null", func(t *testing.T) {
+	// Reproducer: a stream that produces no text/reasoning/tool_calls and
+	// no tool_use should finalize with the empty-result fallback text in
+	// the turn so the webapp's per-round renderer has something to show
+	// instead of an empty round, and the persisted content is always a
+	// JSON array (never null — webapp crashes on turn.content.filter).
+	t.Run("empty stream finalizes with the LLM-no-result fallback text", func(t *testing.T) {
 		ts := &fakeTurnStore{}
 		client := &fakeStreamingClient{
 			channels: map[string]*model.Channel{
@@ -918,11 +923,12 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		defer ts.mu.Unlock()
 		streamTurn := findStreamTurn(ts.turns, postID)
 		require.NotNil(t, streamTurn)
-		// The persisted content must be a JSON array so the webapp can iterate it.
 		require.NotEqual(t, "null", string(streamTurn.Content),
-			"empty stream must not persist literal null; webapp crashes on turn.content.filter")
+			"persisted content must be a JSON array; webapp crashes on turn.content.filter")
 		blocks := parseContentBlocks(t, streamTurn.Content)
-		require.Empty(t, blocks)
+		require.Len(t, blocks, 1)
+		require.Equal(t, conversation.BlockTypeText, blocks[0].Type)
+		require.Contains(t, blocks[0].Text, "did not return a result")
 	})
 
 	// Reproducer: when the ToolRunner emits multiple rounds of tool calls on

--- a/streaming/turn_persistence_test.go
+++ b/streaming/turn_persistence_test.go
@@ -19,9 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeTurnStore implements TurnStore and records every created turn.
-// Streaming creates its assistant turn at finalize; for continuation streams
-// it also looks up and demotes the prior anchor turn for the same post.
+// fakeTurnStore implements TurnStore and records every operation.
 type fakeTurnStore struct {
 	mu        sync.Mutex
 	turns     []*store.Turn
@@ -501,9 +499,6 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		blocks := parseContentBlocks(t, streamTurn.Content)
 		require.Len(t, blocks, 1)
 		require.Equal(t, conversation.BlockTypeText, blocks[0].Type)
-		// Partial text is preserved AND the error fallback is appended so
-		// the persisted turn carries the user-visible message — without
-		// this the round renders empty after the post-end refetch.
 		require.Contains(t, blocks[0].Text, "Partial text")
 		require.Contains(t, blocks[0].Text, "An error occurred")
 	})
@@ -895,11 +890,8 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		require.Equal(t, "https://example.com", parsedAnnotations[0].URL)
 	})
 
-	// Reproducer: a stream that produces no text/reasoning/tool_calls and
-	// no tool_use should finalize with the empty-result fallback text in
-	// the turn so the webapp's per-round renderer has something to show
-	// instead of an empty round, and the persisted content is always a
-	// JSON array (never null — webapp crashes on turn.content.filter).
+	// An empty stream must persist the no-result fallback (and the content
+	// must be a JSON array, not null — webapp crashes on .filter).
 	t.Run("empty stream finalizes with the LLM-no-result fallback text", func(t *testing.T) {
 		ts := &fakeTurnStore{}
 		client := &fakeStreamingClient{
@@ -923,8 +915,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		defer ts.mu.Unlock()
 		streamTurn := findStreamTurn(ts.turns, postID)
 		require.NotNil(t, streamTurn)
-		require.NotEqual(t, "null", string(streamTurn.Content),
-			"persisted content must be a JSON array; webapp crashes on turn.content.filter")
+		require.NotEqual(t, "null", string(streamTurn.Content))
 		blocks := parseContentBlocks(t, streamTurn.Content)
 		require.Len(t, blocks, 1)
 		require.Equal(t, conversation.BlockTypeText, blocks[0].Type)
@@ -1010,16 +1001,9 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 			"final placeholder turn must contain only the final round's text")
 	})
 
-	// Continuation: when StreamToPost runs against a post that already has an
-	// assistant turn anchored to it (the user just approved tool calls and we
-	// re-stream onto the SAME post), the prior anchor must be demoted at
-	// finalize so the webapp's post→anchor lookup still resolves to exactly
-	// one match.
 	t.Run("continuation stream demotes the prior anchor and emits continue control", func(t *testing.T) {
 		ts := &fakeTurnStore{}
 
-		// Seed a prior anchor turn — analogous to one written by the first
-		// stream's finalize when it ended on pending tool_use blocks.
 		priorPostIDCopy := postID
 		priorContent, mErr := json.Marshal([]conversation.ContentBlock{
 			{Type: conversation.BlockTypeText, Text: "Let me search for that."},
@@ -1056,7 +1040,6 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		ts.mu.Lock()
 		defer ts.mu.Unlock()
 
-		// Prior anchor lost its post link.
 		var prior *store.Turn
 		for _, t := range ts.turns {
 			if t.ID == "prior-anchor" {
@@ -1065,9 +1048,8 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 			}
 		}
 		require.NotNil(t, prior)
-		require.Nil(t, prior.PostID, "prior anchor must be demoted on continuation")
+		require.Nil(t, prior.PostID)
 
-		// New anchor turn carries the post link and the new round's content.
 		require.Len(t, ts.turns, 2)
 		var newAnchor *store.Turn
 		for _, t := range ts.turns {
@@ -1084,7 +1066,6 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		require.Equal(t, conversation.BlockTypeText, blocks[0].Type)
 		require.Equal(t, "Found 5 channels.", blocks[0].Text)
 
-		// Continue control event was sent instead of start.
 		var sawContinue, sawStart bool
 		for _, ev := range client.events {
 			if ev.event != "postupdate" {
@@ -1099,13 +1080,11 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 				}
 			}
 		}
-		require.True(t, sawContinue, "continuation must emit a continue control event")
-		require.False(t, sawStart, "continuation must not emit start (the webapp would clear tool cards)")
+		require.True(t, sawContinue)
+		require.False(t, sawStart)
 	})
 
-	// Continuation detection must only fire on a prior ASSISTANT turn for
-	// THIS post. Each of these table cases would silently regress the
-	// detection guard if the role/post-id checks were removed.
+	// Continuation must only fire on a prior assistant turn for THIS post.
 	t.Run("continuation detection guards", func(t *testing.T) {
 		userPostIDCopy := "user-post-id"
 		unrelatedPostIDCopy := "other-post-id"
@@ -1122,7 +1101,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 				want: PostStreamingControlStart,
 			},
 			{
-				name: "user turn with the same post_id (must NOT trigger continue)",
+				name: "user turn with the same post_id",
 				seed: []*store.Turn{{
 					ID:             "u1",
 					ConversationID: conversationID,
@@ -1134,7 +1113,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 				want: PostStreamingControlStart,
 			},
 			{
-				name: "assistant turn for an unrelated post (must NOT trigger continue)",
+				name: "assistant turn for an unrelated post",
 				seed: []*store.Turn{{
 					ID:             "a1",
 					ConversationID: conversationID,
@@ -1146,7 +1125,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 				want: PostStreamingControlStart,
 			},
 			{
-				name: "user turn for a different post (must NOT trigger continue)",
+				name: "user turn for a different post",
 				seed: []*store.Turn{{
 					ID:             "u1",
 					ConversationID: conversationID,
@@ -1158,7 +1137,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 				want: PostStreamingControlStart,
 			},
 			{
-				name: "assistant turn anchored to this post (the only case that triggers continue)",
+				name: "assistant turn anchored to this post",
 				seed: []*store.Turn{{
 					ID:             "a1",
 					ConversationID: conversationID,
@@ -1208,9 +1187,6 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		}
 	})
 
-	// A lookup error must not crash StreamToPost or hang the stream — it
-	// should fall through to a normal start. Without this guard, a transient
-	// DB blip would corrupt every concurrent stream on the node.
 	t.Run("lookup error falls through to start without crashing", func(t *testing.T) {
 		ts := &fakeTurnStore{lookupErr: fmt.Errorf("transient db error")}
 		client := &fakeStreamingClient{
@@ -1237,16 +1213,11 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 				sawStart = true
 			}
 		}
-		require.True(t, sawStart, "a lookup error must not silence the start control event — the webapp depends on it")
+		require.True(t, sawStart)
 	})
 
-	// On resolved tool calls the WS event ordering must let the webapp
-	// snapshot the round's preamble text BEFORE seeing the resolved
-	// tool_call event. Concretely: between the round's text events and the
-	// resolved tool_call event, no event may clear the message (next: "").
-	// The webapp's live round snapshot reads messageRef.current at the
-	// moment the resolved event arrives — so anything that mutates that
-	// state in between would drop the round's preamble.
+	// The webapp snapshots the round's text when the resolved tool_call
+	// event arrives; no postupdate may broadcast next: "" before that.
 	t.Run("text events for a round are not erased before the resolved tool_call event", func(t *testing.T) {
 		ts := &fakeTurnStore{}
 		client := &fakeStreamingClient{
@@ -1274,11 +1245,6 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 
 		service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
 
-		// Walk the broadcast events and find the resolved tool_call event.
-		// Verify (a) no `next: ""` is broadcast at any point in the stream,
-		// (b) the LAST `next` value before the resolved tool_call carries
-		// the round's preamble — proving the webapp's resolved-event
-		// snapshot would observe it.
 		resolvedIdx := -1
 		var lastNextBeforeResolved string
 		resolvedJSONNeedle := fmt.Sprintf(`"status":%d`, llm.ToolCallStatusAutoApproved)
@@ -1287,8 +1253,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 				continue
 			}
 			if next, ok := ev.payload["next"].(string); ok {
-				require.NotEqual(t, "", next,
-					"no postupdate may carry next: \"\" — that erases the round's text before the webapp can snapshot it on the resolved tool_call event")
+				require.NotEqual(t, "", next)
 				if resolvedIdx == -1 {
 					lastNextBeforeResolved = next
 				}
@@ -1301,24 +1266,16 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 				}
 			}
 		}
-		require.NotEqual(t, -1, resolvedIdx, "expected a resolved tool_call event in the broadcast stream")
-		require.Equal(t, "Let me search.", lastNextBeforeResolved,
-			"the round's preamble must still be the broadcast post message at the moment the resolved tool_call event arrives — otherwise the webapp's snapshot has no text to attribute to this round")
+		require.NotEqual(t, -1, resolvedIdx)
+		require.Equal(t, "Let me search.", lastNextBeforeResolved)
 	})
 
-	// Cross-post isolation: a finalize against post B must not touch post A's
-	// anchor turn even though they share a conversation. The demote logic
-	// keys on post.Id, but a subtle regression (e.g. demoting the first
-	// assistant turn rather than the matching one) would silently break
-	// multi-post threads where each post is the anchor of its own response.
 	t.Run("finalize on one post leaves other posts' anchors intact", func(t *testing.T) {
 		const postA = "post-a"
 		const postB = "post-b"
 
 		ts := &fakeTurnStore{}
 
-		// Seed post A with its own anchor turn — analogous to a prior
-		// response in the same conversation thread.
 		postACopy := postA
 		anchorAContent, mErr := json.Marshal([]conversation.ContentBlock{
 			{Type: conversation.BlockTypeText, Text: "Post A's response."},
@@ -1341,9 +1298,6 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		service := NewMMPostStreamService(client, i18n.Init())
 		service.SetTurnStore(ts)
 
-		// Stream a response to post B. The streaming layer's lookup keys on
-		// post.Id, so finalize must demote nothing for post B (no prior
-		// anchor exists for B) and leave post A's anchor untouched.
 		postBPost := &model.Post{Id: postB, ChannelId: channelID, UserId: botID}
 		postBPost.AddProp(ConversationIDProp, conversationID)
 
@@ -1356,9 +1310,8 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 
 		ts.mu.Lock()
 		defer ts.mu.Unlock()
-		require.Len(t, ts.turns, 2, "expected post A's anchor + post B's new anchor — nothing else demoted")
+		require.Len(t, ts.turns, 2)
 
-		// Post A's anchor must still carry its post link.
 		var aAfter, bAfter *store.Turn
 		for _, tr := range ts.turns {
 			if tr.ID == "anchor-a" {
@@ -1368,27 +1321,21 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 			bAfter = tr
 		}
 		require.NotNil(t, aAfter)
-		require.NotNil(t, aAfter.PostID, "post A's anchor must NOT be demoted by an unrelated post's finalize")
+		require.NotNil(t, aAfter.PostID)
 		require.Equal(t, postA, *aAfter.PostID)
 
 		require.NotNil(t, bAfter)
 		require.NotNil(t, bAfter.PostID)
-		require.Equal(t, postB, *bAfter.PostID, "post B's new anchor carries its own post link")
+		require.Equal(t, postB, *bAfter.PostID)
 	})
 
-	// Operation order: finalize must DEMOTE the prior anchor before creating
-	// the new one. If the order is wrong, two turns with the same post_id
-	// briefly exist; the webapp's findIndex(post_id == postId) lookup
-	// nondeterministically returns one of them, hiding either the new
-	// content or the resolved tool_use blocks. Catching this requires
-	// recording the call sequence into the store, not just the terminal
-	// state.
+	// Demote must precede create; otherwise two turns briefly share a post_id
+	// and the webapp's anchor lookup is nondeterministic.
 	t.Run("finalize demotes the prior anchor before creating the new one", func(t *testing.T) {
 		ts := &fakeOrderingTurnStore{
 			fakeTurnStore: fakeTurnStore{},
 		}
 
-		// Seed a prior anchor.
 		priorPostIDCopy := postID
 		ts.turns = append(ts.turns, &store.Turn{
 			ID:             "prior",
@@ -1420,10 +1367,6 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		ts.mu.Lock()
 		defer ts.mu.Unlock()
 
-		// At minimum: lookup, then demote (UpdateTurnPostID on prior), then
-		// create (CreateTurnAutoSequence) — in that order. The lookup at
-		// stream START is acceptable; what matters is that demote of the
-		// existing turn precedes the create of the new one.
 		demoteIdx, createIdx := -1, -1
 		for i, op := range ts.ops {
 			if op == "demote:prior" && demoteIdx == -1 {
@@ -1433,17 +1376,13 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 				createIdx = i
 			}
 		}
-		require.NotEqual(t, -1, demoteIdx, "expected a demote (UpdateTurnPostID) on prior turn")
-		require.NotEqual(t, -1, createIdx, "expected a create (CreateTurnAutoSequence) of the new anchor")
-		require.Less(t, demoteIdx, createIdx, "demote of prior anchor must run BEFORE creating the new anchor")
+		require.NotEqual(t, -1, demoteIdx)
+		require.NotEqual(t, -1, createIdx)
+		require.Less(t, demoteIdx, createIdx)
 	})
 
-	// After the regen-unification: regen first scrubs the prior anchor and
-	// intermediates via DeleteResponseTurns at the caller, then runs
-	// StreamToPost identically to a first stream. Verify finalize creates a
-	// fresh anchor and never demotes (demote is the continuation flow's job
-	// — taking it on plain regen would resurface the prior response as a
-	// rendered "round" alongside the new one).
+	// Regen scrubs prior turns at the caller, so StreamToPost must create
+	// a fresh anchor and not demote.
 	t.Run("regen via StreamToPost (with no prior anchor present) creates a fresh anchor and does not demote", func(t *testing.T) {
 		ts := &fakeOrderingTurnStore{
 			fakeTurnStore: fakeTurnStore{},
@@ -1471,30 +1410,27 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		ts.mu.Lock()
 		defer ts.mu.Unlock()
 
-		// Exactly one assistant turn for this post — freshly created.
 		var anchors []*store.Turn
 		for _, tr := range ts.turns {
 			if tr.PostID != nil && *tr.PostID == postID && tr.Role == "assistant" {
 				anchors = append(anchors, tr)
 			}
 		}
-		require.Len(t, anchors, 1, "regen must produce exactly one anchor for the post")
+		require.Len(t, anchors, 1)
 		blocks := parseContentBlocks(t, anchors[0].Content)
 		require.Len(t, blocks, 1)
 		require.Equal(t, "Regenerated answer.", blocks[0].Text)
 		require.Equal(t, int64(5), anchors[0].TokensIn)
 		require.Equal(t, int64(10), anchors[0].TokensOut)
 
-		require.Contains(t, ts.ops, "create", "regen must create a fresh anchor")
+		require.Contains(t, ts.ops, "create")
 		for _, op := range ts.ops {
-			require.False(t, strings.HasPrefix(op, "demote:"), "regen via StreamToPost must not demote anything")
+			require.False(t, strings.HasPrefix(op, "demote:"))
 		}
 	})
 }
 
-// fakeOrderingTurnStore extends fakeTurnStore to record the sequence of
-// operations performed against it, so tests can assert on call ordering
-// (e.g. demote-before-create) rather than only terminal state.
+// fakeOrderingTurnStore records the sequence of operations for ordering asserts.
 type fakeOrderingTurnStore struct {
 	fakeTurnStore
 	ops []string

--- a/streaming/turn_persistence_test.go
+++ b/streaming/turn_persistence_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -19,12 +20,14 @@ import (
 )
 
 // fakeTurnStore implements TurnStore and records every created turn.
-// Streaming now creates its assistant turn exactly once, at finalize, so
-// there's no separate update path to mock.
+// Streaming creates its assistant turn at finalize; for continuation streams
+// it also looks up and demotes the prior anchor turn for the same post.
 type fakeTurnStore struct {
 	mu        sync.Mutex
 	turns     []*store.Turn
 	createErr error
+	lookupErr error
+	demoteErr error
 }
 
 func (f *fakeTurnStore) CreateTurnAutoSequence(turn *store.Turn) error {
@@ -42,6 +45,35 @@ func (f *fakeTurnStore) CreateTurnAutoSequence(turn *store.Turn) error {
 	}
 	turn.Sequence = maxSeq + 1
 	f.turns = append(f.turns, turn)
+	return nil
+}
+
+func (f *fakeTurnStore) GetTurnByPostID(postID string) (*store.Turn, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lookupErr != nil {
+		return nil, f.lookupErr
+	}
+	for _, t := range f.turns {
+		if t.PostID != nil && *t.PostID == postID {
+			return t, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeTurnStore) UpdateTurnPostID(id string, postID *string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.demoteErr != nil {
+		return f.demoteErr
+	}
+	for _, t := range f.turns {
+		if t.ID == id {
+			t.PostID = postID
+			return nil
+		}
+	}
 	return nil
 }
 
@@ -971,4 +1003,468 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		require.Equal(t, "I wasn't able to find that channel.", textBlock.Text,
 			"final placeholder turn must contain only the final round's text")
 	})
+
+	// Continuation: when StreamToPost runs against a post that already has an
+	// assistant turn anchored to it (the user just approved tool calls and we
+	// re-stream onto the SAME post), the prior anchor must be demoted at
+	// finalize so the webapp's post→anchor lookup still resolves to exactly
+	// one match.
+	t.Run("continuation stream demotes the prior anchor and emits continue control", func(t *testing.T) {
+		ts := &fakeTurnStore{}
+
+		// Seed a prior anchor turn — analogous to one written by the first
+		// stream's finalize when it ended on pending tool_use blocks.
+		priorPostIDCopy := postID
+		priorContent, mErr := json.Marshal([]conversation.ContentBlock{
+			{Type: conversation.BlockTypeText, Text: "Let me search for that."},
+			{Type: conversation.BlockTypeToolUse, ID: "tc1", Name: "search", Status: conversation.StatusSuccess},
+		})
+		require.NoError(t, mErr)
+		ts.turns = append(ts.turns, &store.Turn{
+			ID:             "prior-anchor",
+			ConversationID: conversationID,
+			PostID:         &priorPostIDCopy,
+			Role:           "assistant",
+			Sequence:       2,
+			Content:        priorContent,
+		})
+
+		client := &fakeStreamingClient{
+			channels: map[string]*model.Channel{
+				channelID: {Id: channelID, Type: model.ChannelTypeDirect, Name: botID + "__" + requesterID},
+			},
+		}
+		service := NewMMPostStreamService(client, i18n.Init())
+		service.SetTurnStore(ts)
+
+		post := &model.Post{Id: postID, ChannelId: channelID, UserId: botID, Message: "Let me search for that."}
+		post.AddProp(ConversationIDProp, conversationID)
+
+		streamChannel := make(chan llm.TextStreamEvent, 2)
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeText, Value: "Found 5 channels."}
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
+		close(streamChannel)
+
+		service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
+
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+
+		// Prior anchor lost its post link.
+		var prior *store.Turn
+		for _, t := range ts.turns {
+			if t.ID == "prior-anchor" {
+				prior = t
+				break
+			}
+		}
+		require.NotNil(t, prior)
+		require.Nil(t, prior.PostID, "prior anchor must be demoted on continuation")
+
+		// New anchor turn carries the post link and the new round's content.
+		require.Len(t, ts.turns, 2)
+		var newAnchor *store.Turn
+		for _, t := range ts.turns {
+			if t.ID != "prior-anchor" {
+				newAnchor = t
+				break
+			}
+		}
+		require.NotNil(t, newAnchor)
+		require.NotNil(t, newAnchor.PostID)
+		require.Equal(t, postID, *newAnchor.PostID)
+		blocks := parseContentBlocks(t, newAnchor.Content)
+		require.Len(t, blocks, 1)
+		require.Equal(t, conversation.BlockTypeText, blocks[0].Type)
+		require.Equal(t, "Found 5 channels.", blocks[0].Text)
+
+		// Continue control event was sent instead of start.
+		var sawContinue, sawStart bool
+		for _, ev := range client.events {
+			if ev.event != "postupdate" {
+				continue
+			}
+			if ctrl, ok := ev.payload["control"].(string); ok {
+				switch ctrl {
+				case PostStreamingControlContinue:
+					sawContinue = true
+				case PostStreamingControlStart:
+					sawStart = true
+				}
+			}
+		}
+		require.True(t, sawContinue, "continuation must emit a continue control event")
+		require.False(t, sawStart, "continuation must not emit start (the webapp would clear tool cards)")
+	})
+
+	// Continuation detection must only fire on a prior ASSISTANT turn for
+	// THIS post. Each of these table cases would silently regress the
+	// detection guard if the role/post-id checks were removed.
+	t.Run("continuation detection guards", func(t *testing.T) {
+		userPostIDCopy := "user-post-id"
+		unrelatedPostIDCopy := "other-post-id"
+		ourPostCopy := postID
+
+		cases := []struct {
+			name string
+			seed []*store.Turn
+			want string
+		}{
+			{
+				name: "empty turn store",
+				seed: nil,
+				want: PostStreamingControlStart,
+			},
+			{
+				name: "user turn with the same post_id (must NOT trigger continue)",
+				seed: []*store.Turn{{
+					ID:             "u1",
+					ConversationID: conversationID,
+					PostID:         &ourPostCopy,
+					Role:           "user",
+					Sequence:       1,
+					Content:        json.RawMessage(`[]`),
+				}},
+				want: PostStreamingControlStart,
+			},
+			{
+				name: "assistant turn for an unrelated post (must NOT trigger continue)",
+				seed: []*store.Turn{{
+					ID:             "a1",
+					ConversationID: conversationID,
+					PostID:         &unrelatedPostIDCopy,
+					Role:           "assistant",
+					Sequence:       1,
+					Content:        json.RawMessage(`[]`),
+				}},
+				want: PostStreamingControlStart,
+			},
+			{
+				name: "user turn for a different post (must NOT trigger continue)",
+				seed: []*store.Turn{{
+					ID:             "u1",
+					ConversationID: conversationID,
+					PostID:         &userPostIDCopy,
+					Role:           "user",
+					Sequence:       1,
+					Content:        json.RawMessage(`[]`),
+				}},
+				want: PostStreamingControlStart,
+			},
+			{
+				name: "assistant turn anchored to this post (the only case that triggers continue)",
+				seed: []*store.Turn{{
+					ID:             "a1",
+					ConversationID: conversationID,
+					PostID:         &ourPostCopy,
+					Role:           "assistant",
+					Sequence:       1,
+					Content:        json.RawMessage(`[]`),
+				}},
+				want: PostStreamingControlContinue,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				ts := &fakeTurnStore{}
+				ts.turns = append(ts.turns, tc.seed...)
+
+				client := &fakeStreamingClient{
+					channels: map[string]*model.Channel{
+						channelID: {Id: channelID, Type: model.ChannelTypeDirect, Name: botID + "__" + requesterID},
+					},
+				}
+				service := NewMMPostStreamService(client, i18n.Init())
+				service.SetTurnStore(ts)
+
+				post := &model.Post{Id: postID, ChannelId: channelID, UserId: botID}
+				post.AddProp(ConversationIDProp, conversationID)
+
+				streamChannel := make(chan llm.TextStreamEvent, 2)
+				streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeText, Value: "Hi"}
+				streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
+				close(streamChannel)
+
+				service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
+
+				var control string
+				for _, ev := range client.events {
+					if ctrl, ok := ev.payload["control"].(string); ok {
+						switch ctrl {
+						case PostStreamingControlStart, PostStreamingControlContinue:
+							control = ctrl
+						}
+					}
+				}
+				require.Equal(t, tc.want, control)
+			})
+		}
+	})
+
+	// A lookup error must not crash StreamToPost or hang the stream — it
+	// should fall through to a normal start. Without this guard, a transient
+	// DB blip would corrupt every concurrent stream on the node.
+	t.Run("lookup error falls through to start without crashing", func(t *testing.T) {
+		ts := &fakeTurnStore{lookupErr: fmt.Errorf("transient db error")}
+		client := &fakeStreamingClient{
+			channels: map[string]*model.Channel{
+				channelID: {Id: channelID, Type: model.ChannelTypeDirect, Name: botID + "__" + requesterID},
+			},
+		}
+		service := NewMMPostStreamService(client, i18n.Init())
+		service.SetTurnStore(ts)
+
+		post := &model.Post{Id: postID, ChannelId: channelID, UserId: botID}
+		post.AddProp(ConversationIDProp, conversationID)
+
+		streamChannel := make(chan llm.TextStreamEvent, 2)
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeText, Value: "Hi"}
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
+		close(streamChannel)
+
+		service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
+
+		var sawStart bool
+		for _, ev := range client.events {
+			if ctrl, ok := ev.payload["control"].(string); ok && ctrl == PostStreamingControlStart {
+				sawStart = true
+			}
+		}
+		require.True(t, sawStart, "a lookup error must not silence the start control event — the webapp depends on it")
+	})
+
+	// On resolved tool calls the WS event ordering must let the webapp
+	// snapshot the round's preamble text BEFORE seeing the resolved
+	// tool_call event. Concretely: between the round's text events and the
+	// resolved tool_call event, no event may clear the message (next: "").
+	// The webapp's live round snapshot reads messageRef.current at the
+	// moment the resolved event arrives — so anything that mutates that
+	// state in between would drop the round's preamble.
+	t.Run("text events for a round are not erased before the resolved tool_call event", func(t *testing.T) {
+		ts := &fakeTurnStore{}
+		client := &fakeStreamingClient{
+			channels: map[string]*model.Channel{
+				channelID: {Id: channelID, Type: model.ChannelTypeDirect, Name: botID + "__" + requesterID},
+			},
+		}
+		service := NewMMPostStreamService(client, i18n.Init())
+		service.SetTurnStore(ts)
+
+		post := &model.Post{Id: postID, ChannelId: channelID, UserId: botID}
+		post.AddProp(ConversationIDProp, conversationID)
+
+		streamChannel := make(chan llm.TextStreamEvent, 5)
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeText, Value: "Let me search."}
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeToolCalls, Value: []llm.ToolCall{
+			{ID: "tc1", Name: "search", Status: llm.ToolCallStatusPending},
+		}}
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeToolCalls, Value: []llm.ToolCall{
+			{ID: "tc1", Name: "search", Status: llm.ToolCallStatusAutoApproved},
+		}}
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeText, Value: "Found 5."}
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
+		close(streamChannel)
+
+		service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
+
+		// Walk the broadcast events and find the resolved tool_call event.
+		// Verify (a) no `next: ""` is broadcast at any point in the stream,
+		// (b) the LAST `next` value before the resolved tool_call carries
+		// the round's preamble — proving the webapp's resolved-event
+		// snapshot would observe it.
+		resolvedIdx := -1
+		var lastNextBeforeResolved string
+		resolvedJSONNeedle := fmt.Sprintf(`"status":%d`, llm.ToolCallStatusAutoApproved)
+		for i, ev := range client.events {
+			if ev.event != "postupdate" {
+				continue
+			}
+			if next, ok := ev.payload["next"].(string); ok {
+				require.NotEqual(t, "", next,
+					"no postupdate may carry next: \"\" — that erases the round's text before the webapp can snapshot it on the resolved tool_call event")
+				if resolvedIdx == -1 {
+					lastNextBeforeResolved = next
+				}
+			}
+			if ctrl, ok := ev.payload["control"].(string); ok && ctrl == "tool_call" {
+				if tcJSON, ok := ev.payload["tool_call"].(string); ok && resolvedIdx == -1 {
+					if strings.Contains(tcJSON, resolvedJSONNeedle) {
+						resolvedIdx = i
+					}
+				}
+			}
+		}
+		require.NotEqual(t, -1, resolvedIdx, "expected a resolved tool_call event in the broadcast stream")
+		require.Equal(t, "Let me search.", lastNextBeforeResolved,
+			"the round's preamble must still be the broadcast post message at the moment the resolved tool_call event arrives — otherwise the webapp's snapshot has no text to attribute to this round")
+	})
+
+	// Cross-post isolation: a finalize against post B must not touch post A's
+	// anchor turn even though they share a conversation. The demote logic
+	// keys on post.Id, but a subtle regression (e.g. demoting the first
+	// assistant turn rather than the matching one) would silently break
+	// multi-post threads where each post is the anchor of its own response.
+	t.Run("finalize on one post leaves other posts' anchors intact", func(t *testing.T) {
+		const postA = "post-a"
+		const postB = "post-b"
+
+		ts := &fakeTurnStore{}
+
+		// Seed post A with its own anchor turn — analogous to a prior
+		// response in the same conversation thread.
+		postACopy := postA
+		anchorAContent, mErr := json.Marshal([]conversation.ContentBlock{
+			{Type: conversation.BlockTypeText, Text: "Post A's response."},
+		})
+		require.NoError(t, mErr)
+		ts.turns = append(ts.turns, &store.Turn{
+			ID:             "anchor-a",
+			ConversationID: conversationID,
+			PostID:         &postACopy,
+			Role:           "assistant",
+			Sequence:       2,
+			Content:        anchorAContent,
+		})
+
+		client := &fakeStreamingClient{
+			channels: map[string]*model.Channel{
+				channelID: {Id: channelID, Type: model.ChannelTypeDirect, Name: botID + "__" + requesterID},
+			},
+		}
+		service := NewMMPostStreamService(client, i18n.Init())
+		service.SetTurnStore(ts)
+
+		// Stream a response to post B. The streaming layer's lookup keys on
+		// post.Id, so finalize must demote nothing for post B (no prior
+		// anchor exists for B) and leave post A's anchor untouched.
+		postBPost := &model.Post{Id: postB, ChannelId: channelID, UserId: botID}
+		postBPost.AddProp(ConversationIDProp, conversationID)
+
+		streamChannel := make(chan llm.TextStreamEvent, 2)
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeText, Value: "Post B's response."}
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
+		close(streamChannel)
+
+		service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, postBPost, "en", requesterID)
+
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		require.Len(t, ts.turns, 2, "expected post A's anchor + post B's new anchor — nothing else demoted")
+
+		// Post A's anchor must still carry its post link.
+		var aAfter, bAfter *store.Turn
+		for _, tr := range ts.turns {
+			if tr.ID == "anchor-a" {
+				aAfter = tr
+				continue
+			}
+			bAfter = tr
+		}
+		require.NotNil(t, aAfter)
+		require.NotNil(t, aAfter.PostID, "post A's anchor must NOT be demoted by an unrelated post's finalize")
+		require.Equal(t, postA, *aAfter.PostID)
+
+		require.NotNil(t, bAfter)
+		require.NotNil(t, bAfter.PostID)
+		require.Equal(t, postB, *bAfter.PostID, "post B's new anchor carries its own post link")
+	})
+
+	// Operation order: finalize must DEMOTE the prior anchor before creating
+	// the new one. If the order is wrong, two turns with the same post_id
+	// briefly exist; the webapp's findIndex(post_id == postId) lookup
+	// nondeterministically returns one of them, hiding either the new
+	// content or the resolved tool_use blocks. Catching this requires
+	// recording the call sequence into the store, not just the terminal
+	// state.
+	t.Run("finalize demotes the prior anchor before creating the new one", func(t *testing.T) {
+		ts := &fakeOrderingTurnStore{
+			fakeTurnStore: fakeTurnStore{},
+		}
+
+		// Seed a prior anchor.
+		priorPostIDCopy := postID
+		ts.turns = append(ts.turns, &store.Turn{
+			ID:             "prior",
+			ConversationID: conversationID,
+			PostID:         &priorPostIDCopy,
+			Role:           "assistant",
+			Sequence:       2,
+			Content:        json.RawMessage(`[]`),
+		})
+
+		client := &fakeStreamingClient{
+			channels: map[string]*model.Channel{
+				channelID: {Id: channelID, Type: model.ChannelTypeDirect, Name: botID + "__" + requesterID},
+			},
+		}
+		service := NewMMPostStreamService(client, i18n.Init())
+		service.SetTurnStore(ts)
+
+		post := &model.Post{Id: postID, ChannelId: channelID, UserId: botID}
+		post.AddProp(ConversationIDProp, conversationID)
+
+		streamChannel := make(chan llm.TextStreamEvent, 2)
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeText, Value: "Continuation."}
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
+		close(streamChannel)
+
+		service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
+
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+
+		// At minimum: lookup, then demote (UpdateTurnPostID on prior), then
+		// create (CreateTurnAutoSequence) — in that order. The lookup at
+		// stream START is acceptable; what matters is that demote of the
+		// existing turn precedes the create of the new one.
+		demoteIdx, createIdx := -1, -1
+		for i, op := range ts.ops {
+			if op == "update:prior" && demoteIdx == -1 {
+				demoteIdx = i
+			}
+			if op == "create" && createIdx == -1 {
+				createIdx = i
+			}
+		}
+		require.NotEqual(t, -1, demoteIdx, "expected a demote (UpdateTurnPostID) on prior turn")
+		require.NotEqual(t, -1, createIdx, "expected a create (CreateTurnAutoSequence) of the new anchor")
+		require.Less(t, demoteIdx, createIdx, "demote of prior anchor must run BEFORE creating the new anchor")
+	})
+}
+
+// fakeOrderingTurnStore extends fakeTurnStore to record the sequence of
+// operations performed against it, so tests can assert on call ordering
+// (e.g. demote-before-create) rather than only terminal state.
+type fakeOrderingTurnStore struct {
+	fakeTurnStore
+	ops []string
+}
+
+func (f *fakeOrderingTurnStore) CreateTurnAutoSequence(turn *store.Turn) error {
+	if err := f.fakeTurnStore.CreateTurnAutoSequence(turn); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	f.ops = append(f.ops, "create")
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeOrderingTurnStore) UpdateTurnPostID(id string, postID *string) error {
+	if err := f.fakeTurnStore.UpdateTurnPostID(id, postID); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	f.ops = append(f.ops, "update:"+id)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeOrderingTurnStore) GetTurnByPostID(postID string) (*store.Turn, error) {
+	turn, err := f.fakeTurnStore.GetTurnByPostID(postID)
+	f.mu.Lock()
+	f.ops = append(f.ops, "lookup")
+	f.mu.Unlock()
+	return turn, err
 }

--- a/streaming/turn_persistence_test.go
+++ b/streaming/turn_persistence_test.go
@@ -77,31 +77,6 @@ func (f *fakeTurnStore) UpdateTurnPostID(id string, postID *string) error {
 	return nil
 }
 
-func (f *fakeTurnStore) UpdateTurnContent(id string, content json.RawMessage) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	for _, t := range f.turns {
-		if t.ID == id {
-			t.Content = content
-			return nil
-		}
-	}
-	return nil
-}
-
-func (f *fakeTurnStore) UpdateTurnTokens(id string, tokensIn, tokensOut int64) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	for _, t := range f.turns {
-		if t.ID == id {
-			t.TokensIn = tokensIn
-			t.TokensOut = tokensOut
-			return nil
-		}
-	}
-	return nil
-}
-
 // parseContentBlocks is a test helper that unmarshals content JSON into content blocks.
 func parseContentBlocks(t *testing.T, raw json.RawMessage) []conversation.ContentBlock {
 	t.Helper()
@@ -1457,33 +1432,16 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		require.Less(t, demoteIdx, createIdx, "demote of prior anchor must run BEFORE creating the new anchor")
 	})
 
-	// Regen on a post that already has an anchor turn must NOT take the
-	// continuation path: it must NOT demote the prior anchor (that would
-	// surface the prior response as a "round" in the rendered post) and it
-	// must NOT create a second anchor (two anchors per post breaks the
-	// webapp's anchor lookup). Instead, the prior turn is updated in place.
-	t.Run("regen via StreamToPost updates the existing anchor in place — no demote, no second anchor", func(t *testing.T) {
+	// After the regen-unification: regen first scrubs the prior anchor and
+	// intermediates via DeleteResponseTurns at the caller, then runs
+	// StreamToPost identically to a first stream. Verify finalize creates a
+	// fresh anchor and never demotes (demote is the continuation flow's job
+	// — taking it on plain regen would resurface the prior response as a
+	// rendered "round" alongside the new one).
+	t.Run("regen via StreamToPost (with no prior anchor present) creates a fresh anchor and does not demote", func(t *testing.T) {
 		ts := &fakeOrderingTurnStore{
 			fakeTurnStore: fakeTurnStore{},
 		}
-
-		// Seed an existing anchor — analogous to the prior response being
-		// regenerated.
-		priorPostIDCopy := postID
-		priorContent, mErr := json.Marshal([]conversation.ContentBlock{
-			{Type: conversation.BlockTypeText, Text: "Old answer."},
-		})
-		require.NoError(t, mErr)
-		ts.turns = append(ts.turns, &store.Turn{
-			ID:             "prior",
-			ConversationID: conversationID,
-			PostID:         &priorPostIDCopy,
-			Role:           "assistant",
-			Sequence:       2,
-			Content:        priorContent,
-			TokensIn:       111,
-			TokensOut:      222,
-		})
 
 		client := &fakeStreamingClient{
 			channels: map[string]*model.Channel{
@@ -1507,27 +1465,24 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		ts.mu.Lock()
 		defer ts.mu.Unlock()
 
-		// Exactly one assistant turn for this post — the prior, updated.
+		// Exactly one assistant turn for this post — freshly created.
 		var anchors []*store.Turn
 		for _, tr := range ts.turns {
 			if tr.PostID != nil && *tr.PostID == postID && tr.Role == "assistant" {
 				anchors = append(anchors, tr)
 			}
 		}
-		require.Len(t, anchors, 1, "regen must keep the post anchored to a single turn — no second anchor created")
-		require.Equal(t, "prior", anchors[0].ID, "the existing turn was kept; not replaced by a new ID")
-
+		require.Len(t, anchors, 1, "regen must produce exactly one anchor for the post")
 		blocks := parseContentBlocks(t, anchors[0].Content)
 		require.Len(t, blocks, 1)
-		require.Equal(t, "Regenerated answer.", blocks[0].Text, "regen overwrote the prior content")
-		require.Equal(t, int64(5), anchors[0].TokensIn, "regen overwrote token usage")
+		require.Equal(t, "Regenerated answer.", blocks[0].Text)
+		require.Equal(t, int64(5), anchors[0].TokensIn)
 		require.Equal(t, int64(10), anchors[0].TokensOut)
 
-		// No demote happened. The prior anchor's PostID was never cleared
-		// — that's the path that would resurface the prior response as a
-		// "round" alongside the new one.
-		require.NotContains(t, ts.ops, "demote:prior", "regen must not demote the prior anchor")
-		require.NotContains(t, ts.ops, "create", "regen must NOT create a second anchor for the same post")
+		require.Contains(t, ts.ops, "create", "regen must create a fresh anchor")
+		for _, op := range ts.ops {
+			require.False(t, strings.HasPrefix(op, "demote:"), "regen via StreamToPost must not demote anything")
+		}
 	})
 }
 
@@ -1555,16 +1510,6 @@ func (f *fakeOrderingTurnStore) UpdateTurnPostID(id string, postID *string) erro
 	}
 	f.mu.Lock()
 	f.ops = append(f.ops, "demote:"+id)
-	f.mu.Unlock()
-	return nil
-}
-
-func (f *fakeOrderingTurnStore) UpdateTurnContent(id string, content json.RawMessage) error {
-	if err := f.fakeTurnStore.UpdateTurnContent(id, content); err != nil {
-		return err
-	}
-	f.mu.Lock()
-	f.ops = append(f.ops, "update:"+id)
 	f.mu.Unlock()
 	return nil
 }

--- a/streaming/turn_persistence_test.go
+++ b/streaming/turn_persistence_test.go
@@ -77,6 +77,31 @@ func (f *fakeTurnStore) UpdateTurnPostID(id string, postID *string) error {
 	return nil
 }
 
+func (f *fakeTurnStore) UpdateTurnContent(id string, content json.RawMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, t := range f.turns {
+		if t.ID == id {
+			t.Content = content
+			return nil
+		}
+	}
+	return nil
+}
+
+func (f *fakeTurnStore) UpdateTurnTokens(id string, tokensIn, tokensOut int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, t := range f.turns {
+		if t.ID == id {
+			t.TokensIn = tokensIn
+			t.TokensOut = tokensOut
+			return nil
+		}
+	}
+	return nil
+}
+
 // parseContentBlocks is a test helper that unmarshals content JSON into content blocks.
 func parseContentBlocks(t *testing.T, raw json.RawMessage) []conversation.ContentBlock {
 	t.Helper()
@@ -1045,7 +1070,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
 		close(streamChannel)
 
-		service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
+		service.StreamContinuationToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
 
 		ts.mu.Lock()
 		defer ts.mu.Unlock()
@@ -1186,7 +1211,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 				streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
 				close(streamChannel)
 
-				service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
+				service.StreamContinuationToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
 
 				var control string
 				for _, ev := range client.events {
@@ -1223,7 +1248,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
 		close(streamChannel)
 
-		service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
+		service.StreamContinuationToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
 
 		var sawStart bool
 		for _, ev := range client.events {
@@ -1409,7 +1434,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
 		close(streamChannel)
 
-		service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
+		service.StreamContinuationToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
 
 		ts.mu.Lock()
 		defer ts.mu.Unlock()
@@ -1420,7 +1445,7 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		// existing turn precedes the create of the new one.
 		demoteIdx, createIdx := -1, -1
 		for i, op := range ts.ops {
-			if op == "update:prior" && demoteIdx == -1 {
+			if op == "demote:prior" && demoteIdx == -1 {
 				demoteIdx = i
 			}
 			if op == "create" && createIdx == -1 {
@@ -1430,6 +1455,79 @@ func TestStreamToPostTurnPersistence(t *testing.T) {
 		require.NotEqual(t, -1, demoteIdx, "expected a demote (UpdateTurnPostID) on prior turn")
 		require.NotEqual(t, -1, createIdx, "expected a create (CreateTurnAutoSequence) of the new anchor")
 		require.Less(t, demoteIdx, createIdx, "demote of prior anchor must run BEFORE creating the new anchor")
+	})
+
+	// Regen on a post that already has an anchor turn must NOT take the
+	// continuation path: it must NOT demote the prior anchor (that would
+	// surface the prior response as a "round" in the rendered post) and it
+	// must NOT create a second anchor (two anchors per post breaks the
+	// webapp's anchor lookup). Instead, the prior turn is updated in place.
+	t.Run("regen via StreamToPost updates the existing anchor in place — no demote, no second anchor", func(t *testing.T) {
+		ts := &fakeOrderingTurnStore{
+			fakeTurnStore: fakeTurnStore{},
+		}
+
+		// Seed an existing anchor — analogous to the prior response being
+		// regenerated.
+		priorPostIDCopy := postID
+		priorContent, mErr := json.Marshal([]conversation.ContentBlock{
+			{Type: conversation.BlockTypeText, Text: "Old answer."},
+		})
+		require.NoError(t, mErr)
+		ts.turns = append(ts.turns, &store.Turn{
+			ID:             "prior",
+			ConversationID: conversationID,
+			PostID:         &priorPostIDCopy,
+			Role:           "assistant",
+			Sequence:       2,
+			Content:        priorContent,
+			TokensIn:       111,
+			TokensOut:      222,
+		})
+
+		client := &fakeStreamingClient{
+			channels: map[string]*model.Channel{
+				channelID: {Id: channelID, Type: model.ChannelTypeDirect, Name: botID + "__" + requesterID},
+			},
+		}
+		service := NewMMPostStreamService(client, i18n.Init())
+		service.SetTurnStore(ts)
+
+		post := &model.Post{Id: postID, ChannelId: channelID, UserId: botID}
+		post.AddProp(ConversationIDProp, conversationID)
+
+		streamChannel := make(chan llm.TextStreamEvent, 3)
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeText, Value: "Regenerated answer."}
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeUsage, Value: llm.TokenUsage{InputTokens: 5, OutputTokens: 10}}
+		streamChannel <- llm.TextStreamEvent{Type: llm.EventTypeEnd}
+		close(streamChannel)
+
+		service.StreamToPost(context.Background(), &llm.TextStreamResult{Stream: streamChannel}, post, "en", requesterID)
+
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+
+		// Exactly one assistant turn for this post — the prior, updated.
+		var anchors []*store.Turn
+		for _, tr := range ts.turns {
+			if tr.PostID != nil && *tr.PostID == postID && tr.Role == "assistant" {
+				anchors = append(anchors, tr)
+			}
+		}
+		require.Len(t, anchors, 1, "regen must keep the post anchored to a single turn — no second anchor created")
+		require.Equal(t, "prior", anchors[0].ID, "the existing turn was kept; not replaced by a new ID")
+
+		blocks := parseContentBlocks(t, anchors[0].Content)
+		require.Len(t, blocks, 1)
+		require.Equal(t, "Regenerated answer.", blocks[0].Text, "regen overwrote the prior content")
+		require.Equal(t, int64(5), anchors[0].TokensIn, "regen overwrote token usage")
+		require.Equal(t, int64(10), anchors[0].TokensOut)
+
+		// No demote happened. The prior anchor's PostID was never cleared
+		// — that's the path that would resurface the prior response as a
+		// "round" alongside the new one.
+		require.NotContains(t, ts.ops, "demote:prior", "regen must not demote the prior anchor")
+		require.NotContains(t, ts.ops, "create", "regen must NOT create a second anchor for the same post")
 	})
 }
 
@@ -1453,6 +1551,16 @@ func (f *fakeOrderingTurnStore) CreateTurnAutoSequence(turn *store.Turn) error {
 
 func (f *fakeOrderingTurnStore) UpdateTurnPostID(id string, postID *string) error {
 	if err := f.fakeTurnStore.UpdateTurnPostID(id, postID); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	f.ops = append(f.ops, "demote:"+id)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeOrderingTurnStore) UpdateTurnContent(id string, content json.RawMessage) error {
+	if err := f.fakeTurnStore.UpdateTurnContent(id, content); err != nil {
 		return err
 	}
 	f.mu.Lock()

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -121,6 +121,13 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     // refetch becomes the trigger to clear local-state for completed rounds.
     const [pendingRefetch, setPendingRefetch] = useState(false);
 
+    // Set true while the user just clicked Regenerate. The persisted round
+    // from the prior generation must NOT render alongside the in-progress
+    // regenerated content — the user expects the post to be replaced, not
+    // appended. Cleared once the post-end refetch lands new content into
+    // persistedRounds.
+    const [regenerating, setRegenerating] = useState(false);
+
     // A single ref mirrors the in-progress round so the WebSocket handler
     // can snapshot it without rebuilding the listener on every keystroke.
     const liveRef = useRef({message, toolCalls, reasoningSummary, annotations});
@@ -172,6 +179,7 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         setMessage((prev: string) => (prev === '' ? prev : ''));
         setReasoningSummary((prev: string) => (prev === '' ? prev : ''));
         setIsReasoningLoading(false);
+        setRegenerating(false);
         setPendingRefetch(false);
     }, [conversation, pendingRefetch]);
 
@@ -274,6 +282,7 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                 setPrecontent(false);
                 setStopped(false);
                 setIsReasoningLoading(false);
+                setRegenerating(false);
                 return;
             }
 
@@ -337,12 +346,18 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     }, [message, toolCalls, reasoningSummary, annotations]);
 
     const renderedRounds = useMemo(() => {
+        if (regenerating) {
+            // The prior generation is being replaced; show only the live
+            // content as it streams in. persistedRounds still holds the
+            // pre-regen turn until the post-end refetch lands.
+            return currentRound ? [currentRound] : [];
+        }
         const out: Round[] = [...stablePersisted, ...liveRounds];
         if (generating && currentRound) {
             out.push(currentRound);
         }
         return out;
-    }, [stablePersisted, liveRounds, generating, currentRound]);
+    }, [regenerating, stablePersisted, liveRounds, generating, currentRound]);
 
     const regnerate = () => {
         setMessage('');
@@ -354,6 +369,7 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         setAnnotations([]);
         setToolCalls([]);
         setLiveRounds([]);
+        setRegenerating(true);
         doRegenerate(props.post.id);
     };
 

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -423,12 +423,10 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
 
     // Approval stage applies only to the post anchor — the latest persisted
     // round. The live in-progress round and any locally-tracked completed
-    // rounds (liveRounds) don't have a server-confirmed approval state, so
-    // they always render as 'done' (no approve / share buttons). This also
-    // covers the brief gap between reasoning_summary_done and the next event,
-    // where `generating` is false but the stream is still active — without
-    // this guard, the cached anchorStage would leak into the live round and
-    // briefly flash the approval UI before auto-execution resolves.
+    // rounds (liveRounds) have no server-confirmed approval state, so they
+    // always render as 'done' (no approve / share buttons). Without this
+    // gate the cached anchorStage would leak into the live round and flash
+    // the approval UI before auto-execution resolves.
     const anchorStage: ToolApprovalStage = conversation ? deriveApprovalStageForPost(conversation, props.post.id) : 'done';
     const lastPersistedIdx = stablePersisted.length - 1;
     const lastRenderedIdx = renderedRounds.length - 1;

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -31,6 +31,10 @@ import {extractPermalinkData} from './permalink_data';
 
 const SearchResultsPropKey = 'search_results';
 
+// Sentinel id for the in-progress streaming round. Distinguishes the live
+// round from persisted (turn-id keyed) rounds in `renderedRounds`.
+const LIVE_ROUND_ID = 'live';
+
 // Types
 export interface PostUpdateWebsocketMessage {
     post_id: string
@@ -88,10 +92,6 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     const isDM = channel?.type === 'D';
     const rootPost = useSelector<GlobalState, any>((state) => state.entities.posts.posts[props.post.root_id]);
 
-    // Local streaming state. These describe the IN-PROGRESS round.
-    // Completed rounds within the current streaming session live in
-    // `liveRounds`; persisted rounds from prior sessions live in
-    // `persistedRounds` (derived from turns).
     const [message, setMessage] = useState(props.post.message);
     const [generating, setGenerating] = useState(false);
     const [toolCalls, setToolCalls] = useState<ToolCall[]>([]);
@@ -105,7 +105,6 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     const stoppedRef = useRef(stopped);
     stoppedRef.current = stopped;
 
-    // Reasoning summary state for the IN-PROGRESS round.
     const [reasoningSummary, setReasoningSummary] = useState('');
     const [isReasoningLoading, setIsReasoningLoading] = useState(false);
 
@@ -122,16 +121,10 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     // refetch becomes the trigger to clear local-state for completed rounds.
     const [pendingRefetch, setPendingRefetch] = useState(false);
 
-    // Refs let the WebSocket handler snapshot the current in-progress round
-    // into liveRounds without recreating the listener on every keystroke.
-    const messageRef = useRef(message);
-    const toolCallsRef = useRef(toolCalls);
-    const reasoningSummaryRef = useRef(reasoningSummary);
-    const annotationsRef = useRef(annotations);
-    messageRef.current = message;
-    toolCallsRef.current = toolCalls;
-    reasoningSummaryRef.current = reasoningSummary;
-    annotationsRef.current = annotations;
+    // A single ref mirrors the in-progress round so the WebSocket handler
+    // can snapshot it without rebuilding the listener on every keystroke.
+    const liveRef = useRef({message, toolCalls, reasoningSummary, annotations});
+    liveRef.current = {message, toolCalls, reasoningSummary, annotations};
 
     // Sync message from post.message changes (e.g. after post update)
     useEffect(() => {
@@ -166,19 +159,22 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     // synchronously after the render that sees the new conversation,
     // before paint, so the user never sees a duplicated frame.
     useLayoutEffect(() => {
-        if (pendingRefetch && conversation) {
-            setLiveRounds([]);
-            setMessage('');
-            setToolCalls([]);
-            setReasoningSummary('');
-            setIsReasoningLoading(false);
-            setAnnotations([]);
-            setPendingRefetch(false);
+        if (!pendingRefetch || !conversation) {
+            return;
         }
+
+        // Reset only what's actually populated. Each setX([]) call would
+        // otherwise allocate a fresh empty array, causing the parent to
+        // re-render even when the round had no content to clear.
+        setLiveRounds((prev: Round[]) => (prev.length === 0 ? prev : []));
+        setToolCalls((prev: ToolCall[]) => (prev.length === 0 ? prev : []));
+        setAnnotations((prev: Annotation[]) => (prev.length === 0 ? prev : []));
+        setMessage((prev: string) => (prev === '' ? prev : ''));
+        setReasoningSummary((prev: string) => (prev === '' ? prev : ''));
+        setIsReasoningLoading(false);
+        setPendingRefetch(false);
     }, [conversation, pendingRefetch]);
 
-    // WebSocket handler. Refs above let us snapshot the in-progress round
-    // without recreating this listener on every state update.
     useEffect(() => {
         if (!props.websocketRegister || !props.websocketUnregister) {
             return undefined; // eslint-disable-line no-undefined
@@ -216,14 +212,15 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                         // round (text/reasoning/annotations + the resolved
                         // tools from this event) into liveRounds, then reset
                         // for the next round to begin streaming below it.
+                        const live = liveRef.current;
                         setLiveRounds((prev) => [
                             ...prev,
                             {
                                 id: `live-${prev.length}-${Date.now()}`,
-                                text: messageRef.current,
+                                text: live.message,
                                 toolCalls: parsedToolCalls,
-                                reasoning: {summary: reasoningSummaryRef.current, signature: ''},
-                                annotations: annotationsRef.current,
+                                reasoning: {summary: live.reasoningSummary, signature: ''},
+                                annotations: live.annotations,
                             },
                         ]);
                         setMessage('');
@@ -322,9 +319,6 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         };
     }, [props.post.id, conversationId]);
 
-    // The in-progress round, derived from local streaming state. Returns
-    // null when there is no live content yet so we don't render an empty
-    // section under the persisted rounds.
     const currentRound: Round | null = useMemo(() => {
         const hasContent = message !== '' ||
             toolCalls.length > 0 ||
@@ -334,7 +328,7 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
             return null;
         }
         return {
-            id: 'live',
+            id: LIVE_ROUND_ID,
             text: message,
             toolCalls,
             reasoning: {summary: reasoningSummary, signature: ''},
@@ -447,7 +441,7 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                 </MinimalReasoningContainer>
             )}
             {renderedRounds.map((round, idx) => {
-                const isLiveRound = round.id === 'live';
+                const isLiveRound = round.id === LIVE_ROUND_ID;
                 const showCursor = generating && isLiveRound && !precontent;
                 const reasoningLoading = isLiveRound && isReasoningLoading;
                 return (

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -31,11 +31,9 @@ import {extractPermalinkData} from './permalink_data';
 
 const SearchResultsPropKey = 'search_results';
 
-// Sentinel id for the in-progress streaming round. Distinguishes the live
-// round from persisted (turn-id keyed) rounds in `renderedRounds`.
+// Sentinel id for the in-progress streaming round; persisted rounds use turn ids.
 const LIVE_ROUND_ID = 'live';
 
-// Types
 export interface PostUpdateWebsocketMessage {
     post_id: string
     next?: string
@@ -51,11 +49,8 @@ interface LLMBotPostProps {
     websocketUnregister?: (postID: string, listenerID: string) => void;
 }
 
-// Treat a tool_call event as the round-complete signal when every tool in
-// the batch has reached a terminal status. ToolRunner emits exactly one such
-// event per round after execution; the pending event preceding it carries
-// status=Pending instead and is treated as a live update on the current
-// round, not a round boundary.
+// ToolRunner emits one tool_call event per round with pending statuses, then one
+// with terminal statuses after execution. The terminal one is the round boundary.
 function isResolvedToolCallEvent(toolCalls: ToolCall[]): boolean {
     if (toolCalls.length === 0) {
         return false;
@@ -71,14 +66,11 @@ function isResolvedToolCallEvent(toolCalls: ToolCall[]): boolean {
 export const LLMBotPost = (props: LLMBotPostProps) => {
     const selectPost = useSelectNotAIPost();
 
-    // Conversation entity data
     const conversationId: string | undefined = props.post.props?.conversation_id;
     const {conversation, loading: conversationLoading, error: conversationError} = useConversation(conversationId);
 
-    // Derive requester check from conversation entity. Meeting summarization
-    // posts currently have no conversation entity; fall back to the legacy
-    // llm_requester_user_id prop for those. Remove the fallback once meeting
-    // flows produce conversation entities.
+    // Meeting summarization posts have no conversation entity yet; fall back to
+    // the legacy llm_requester_user_id prop.
     const currentUserId = useSelector<GlobalState, string>((state) => state.entities.users.currentUserId);
     const legacyRequester: string | undefined = props.post.props?.llm_requester_user_id;
     const requesterIsCurrentUser = Boolean(
@@ -108,28 +100,18 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     const [reasoningSummary, setReasoningSummary] = useState('');
     const [isReasoningLoading, setIsReasoningLoading] = useState(false);
 
-    // Per-round collapse toggle keyed by round id. Defaults to collapsed
-    // for any round not yet expanded.
     const [expandedReasoning, setExpandedReasoning] = useState<Record<string, boolean>>({});
 
-    // Rounds completed during the current streaming session, not yet
-    // reflected in `conversation.turns` (turns are written when the toolrunner
-    // terminates, which is end-of-stream — not between rounds).
+    // Rounds completed during this stream, before turns land via refetch.
     const [liveRounds, setLiveRounds] = useState<Round[]>([]);
 
-    // Set true when an `end` event invalidates the conversation; the next
-    // refetch becomes the trigger to clear local-state for completed rounds.
     const [pendingRefetch, setPendingRefetch] = useState(false);
 
-    // Set true while the user just clicked Regenerate. The persisted round
-    // from the prior generation must NOT render alongside the in-progress
-    // regenerated content — the user expects the post to be replaced, not
-    // appended. Cleared once the post-end refetch lands new content into
-    // persistedRounds.
+    // Suppresses persistedRounds while regenerating so the prior generation
+    // doesn't render alongside the new stream.
     const [regenerating, setRegenerating] = useState(false);
 
-    // A single ref mirrors the in-progress round so the WebSocket handler
-    // can snapshot it without rebuilding the listener on every keystroke.
+    // Lets the WebSocket handler snapshot the live round without re-subscribing.
     const liveRef = useRef({message, toolCalls, reasoningSummary, annotations});
     liveRef.current = {message, toolCalls, reasoningSummary, annotations};
 
@@ -140,9 +122,6 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         }
     }, [props.post.message]);
 
-    // Persisted rounds from turns. Empty for posts without a conversation
-    // entity (legacy meeting summary posts) — those render purely from local
-    // streaming state.
     const persistedRounds: Round[] = useMemo(() => {
         if (!conversation) {
             return [];
@@ -150,8 +129,7 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         return buildRoundsFromTurns(conversation, props.post.id);
     }, [conversation, props.post.id]);
 
-    // Cache the last-known persisted rounds across refetch invalidations so
-    // the UI doesn't briefly empty out while the refetch is in flight.
+    // Keep prior rounds visible during the refetch window after invalidate.
     const lastPersistedRef = useRef<Round[]>([]);
     useEffect(() => {
         if (conversation) {
@@ -160,19 +138,13 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     }, [conversation, persistedRounds]);
     const stablePersisted = conversation ? persistedRounds : lastPersistedRef.current;
 
-    // After an `end` invalidates and the refetch completes, clear the
-    // local-state for completed rounds so we don't double-render them
-    // alongside the freshly-loaded persisted copies. useLayoutEffect runs
-    // synchronously after the render that sees the new conversation,
-    // before paint, so the user never sees a duplicated frame.
+    // Once the refetch lands, clear local state for completed rounds so we
+    // don't double-render. useLayoutEffect prevents a duplicated frame.
     useLayoutEffect(() => {
         if (!pendingRefetch || !conversation) {
             return;
         }
 
-        // Reset only what's actually populated. Each setX([]) call would
-        // otherwise allocate a fresh empty array, causing the parent to
-        // re-render even when the round had no content to clear.
         setLiveRounds((prev: Round[]) => (prev.length === 0 ? prev : []));
         setToolCalls((prev: ToolCall[]) => (prev.length === 0 ? prev : []));
         setAnnotations((prev: Annotation[]) => (prev.length === 0 ? prev : []));
@@ -193,18 +165,13 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         props.websocketRegister(props.post.id, listenerID, (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => {
             const data = msg.data;
 
-            // Ensure we're only processing events for this post
             if (data.post_id !== props.post.id) {
                 return;
             }
 
             if (data.control === 'reasoning_summary' && data.reasoning) {
-                // Keep generating=true: the model is still actively producing
-                // reasoning chunks. Flipping it to false here would hide
-                // currentRound (the `generating && currentRound` gate in
-                // renderedRounds) and the thinking block wouldn't appear
-                // until text or a tool call arrived. isReasoningLoading
-                // separately drives the reasoning spinner state.
+                // Don't clear generating: the `generating && currentRound`
+                // gate in renderedRounds would hide the thinking block.
                 setReasoningSummary(data.reasoning);
                 setIsReasoningLoading(true);
                 setPrecontent(false);
@@ -221,10 +188,7 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                 try {
                     const parsedToolCalls = JSON.parse(data.tool_call) as ToolCall[];
                     if (isResolvedToolCallEvent(parsedToolCalls)) {
-                        // Round complete: snapshot the current in-progress
-                        // round (text/reasoning/annotations + the resolved
-                        // tools from this event) into liveRounds, then reset
-                        // for the next round to begin streaming below it.
+                        // Snapshot the round into liveRounds and reset for the next.
                         const live = liveRef.current;
                         setLiveRounds((prev) => [
                             ...prev,
@@ -242,7 +206,6 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                         setIsReasoningLoading(false);
                         setAnnotations([]);
                     } else {
-                        // Pending: replace the current round's tool calls.
                         setToolCalls(parsedToolCalls);
                     }
                     setPrecontent(false);
@@ -307,10 +270,8 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
             }
 
             if (data.control === 'continue') {
-                // Continuation stream after the user approved pending tool
-                // calls. The prior round's resolved tools come from the
-                // refetched persisted rounds, so reset all local state and
-                // let the next round stream into a clean slate.
+                // Tool-approval resume: prior round comes from refetched
+                // persistedRounds, so reset all local state.
                 setGenerating(true);
                 setPrecontent(true);
                 setStopped(false);
@@ -352,11 +313,8 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
 
     const renderedRounds = useMemo(() => {
         if (regenerating) {
-            // The prior generation is being replaced; suppress the cached
-            // persistedRounds (still holds the pre-regen turn until refetch)
-            // but keep liveRounds — those are this regen's completed rounds
-            // captured between resolved tool_call events. Without them the
-            // post would visually empty out between rounds.
+            // Suppress stablePersisted (still the pre-regen turn) but keep
+            // liveRounds so multi-round regens don't visually empty between rounds.
             const out: Round[] = [...liveRounds];
             if (currentRound) {
                 out.push(currentRound);
@@ -421,12 +379,8 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     const hasContent = renderedRounds.length > 0;
     const showControlsBar = ((showRegenerate || showPostbackButton) && hasContent) || showStopGeneratingButton;
 
-    // Approval stage applies only to the post anchor — the latest persisted
-    // round. The live in-progress round and any locally-tracked completed
-    // rounds (liveRounds) have no server-confirmed approval state, so they
-    // always render as 'done' (no approve / share buttons). Without this
-    // gate the cached anchorStage would leak into the live round and flash
-    // the approval UI before auto-execution resolves.
+    // Only the post anchor (latest persisted round) gets a real approval stage;
+    // live/locally-tracked rounds always render as 'done'.
     const anchorStage: ToolApprovalStage = conversation ? deriveApprovalStageForPost(conversation, props.post.id) : 'done';
     const lastPersistedIdx = stablePersisted.length - 1;
     const lastRenderedIdx = renderedRounds.length - 1;
@@ -524,10 +478,6 @@ interface RoundViewProps {
     onToggleReasoning: (collapsed: boolean) => void;
 }
 
-// One round's worth of LLM output. The vertical order text → tools mirrors
-// what the LLM emits within a round (preamble first, then any tool_use it
-// chose to invoke), so the post reads as the natural back-and-forth of
-// reasoning and action.
 function RoundView(props: RoundViewProps) {
     const {round} = props;
     const showArguments = round.toolCalls.some((tc) => tc.arguments != null);
@@ -567,7 +517,6 @@ function RoundView(props: RoundViewProps) {
     );
 }
 
-// Styled components
 const PostBody = styled.div`
 `;
 

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -347,10 +347,16 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
 
     const renderedRounds = useMemo(() => {
         if (regenerating) {
-            // The prior generation is being replaced; show only the live
-            // content as it streams in. persistedRounds still holds the
-            // pre-regen turn until the post-end refetch lands.
-            return currentRound ? [currentRound] : [];
+            // The prior generation is being replaced; suppress the cached
+            // persistedRounds (still holds the pre-regen turn until refetch)
+            // but keep liveRounds — those are this regen's completed rounds
+            // captured between resolved tool_call events. Without them the
+            // post would visually empty out between rounds.
+            const out: Round[] = [...liveRounds];
+            if (currentRound) {
+                out.push(currentRound);
+            }
+            return out;
         }
         const out: Round[] = [...stablePersisted, ...liveRounds];
         if (generating && currentRound) {

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useSelector} from 'react-redux';
 import styled from 'styled-components';
@@ -11,19 +11,18 @@ import {GlobalState} from '@mattermost/types/store';
 
 import {doPostbackSummary, doRegenerate, doStopGenerating} from '@/client';
 import {useSelectNotAIPost} from '@/hooks';
-import {useConversation, useTurnForPost, invalidateConversation} from '@/hooks/use_conversation';
+import {useConversation, invalidateConversation} from '@/hooks/use_conversation';
 import {PostMessagePreview} from '@/mm_webapp';
 
 import PostText from '../post_text';
 import {SearchSources} from '../search_sources';
 import ToolApprovalSet from '../tool_approval_set';
-import {ToolApprovalStage, ToolCall} from '../tool_types';
+import {ToolApprovalStage, ToolCall, ToolCallStatus} from '../tool_types';
 import {Annotation} from '../citations/types';
 
 import {
-    extractToolCallsForPost,
-    extractReasoningFromTurn,
-    extractAnnotationsFromTurn,
+    Round,
+    buildRoundsFromTurns,
     deriveApprovalStageForPost,
 } from './turn_content_utils';
 import {ReasoningDisplay, LoadingSpinner, MinimalReasoningContainer} from './reasoning_display';
@@ -48,13 +47,29 @@ interface LLMBotPostProps {
     websocketUnregister?: (postID: string, listenerID: string) => void;
 }
 
+// Treat a tool_call event as the round-complete signal when every tool in
+// the batch has reached a terminal status. ToolRunner emits exactly one such
+// event per round after execution; the pending event preceding it carries
+// status=Pending instead and is treated as a live update on the current
+// round, not a round boundary.
+function isResolvedToolCallEvent(toolCalls: ToolCall[]): boolean {
+    if (toolCalls.length === 0) {
+        return false;
+    }
+    return toolCalls.every((tc) =>
+        tc.status === ToolCallStatus.Success ||
+        tc.status === ToolCallStatus.Error ||
+        tc.status === ToolCallStatus.AutoApproved ||
+        tc.status === ToolCallStatus.Rejected,
+    );
+}
+
 export const LLMBotPost = (props: LLMBotPostProps) => {
     const selectPost = useSelectNotAIPost();
 
     // Conversation entity data
     const conversationId: string | undefined = props.post.props?.conversation_id;
     const {conversation, loading: conversationLoading, error: conversationError} = useConversation(conversationId);
-    const turn = useTurnForPost(conversation, props.post.id);
 
     // Derive requester check from conversation entity. Meeting summarization
     // posts currently have no conversation entity; fall back to the legacy
@@ -73,11 +88,13 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     const isDM = channel?.type === 'D';
     const rootPost = useSelector<GlobalState, any>((state) => state.entities.posts.posts[props.post.root_id]);
 
-    // Local state for streaming
+    // Local streaming state. These describe the IN-PROGRESS round.
+    // Completed rounds within the current streaming session live in
+    // `liveRounds`; persisted rounds from prior sessions live in
+    // `persistedRounds` (derived from turns).
     const [message, setMessage] = useState(props.post.message);
     const [generating, setGenerating] = useState(false);
     const [toolCalls, setToolCalls] = useState<ToolCall[]>([]);
-    const [toolApprovalStage, setToolApprovalStage] = useState<ToolApprovalStage>('call');
     const [annotations, setAnnotations] = useState<Annotation[]>([]);
     const [precontent, setPrecontent] = useState(props.post.message === '');
     const [error, setError] = useState('');
@@ -88,46 +105,33 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     const stoppedRef = useRef(stopped);
     stoppedRef.current = stopped;
 
-    // State for reasoning summary display
+    // Reasoning summary state for the IN-PROGRESS round.
     const [reasoningSummary, setReasoningSummary] = useState('');
-    const [showReasoning, setShowReasoning] = useState(false);
-    const [isReasoningCollapsed, setIsReasoningCollapsed] = useState(true);
     const [isReasoningLoading, setIsReasoningLoading] = useState(false);
 
-    // Populate local state from turn data when not streaming.
-    // This overwrites whatever was accumulated during streaming once
-    // the finalized turn arrives from the conversation API.
-    useEffect(() => {
-        if (!turn || generating) {
-            return;
-        }
+    // Per-round collapse toggle keyed by round id. Defaults to collapsed
+    // for any round not yet expanded.
+    const [expandedReasoning, setExpandedReasoning] = useState<Record<string, boolean>>({});
 
-        // Tool calls — aggregate across every turn that belongs to this
-        // post's response so multi-round tool use displays all calls.
-        if (conversation) {
-            const derived = extractToolCallsForPost(conversation, props.post.id);
-            setToolCalls(derived);
-            setToolApprovalStage(deriveApprovalStageForPost(conversation, props.post.id));
-        }
+    // Rounds completed during the current streaming session, not yet
+    // reflected in `conversation.turns` (turns are written when the toolrunner
+    // terminates, which is end-of-stream — not between rounds).
+    const [liveRounds, setLiveRounds] = useState<Round[]>([]);
 
-        // Reasoning
-        const reasoning = extractReasoningFromTurn(turn);
-        if (reasoning.summary) {
-            setReasoningSummary(reasoning.summary);
-            setShowReasoning(true);
-            setIsReasoningLoading(false);
-        } else {
-            setReasoningSummary('');
-            setShowReasoning(false);
-        }
+    // Set true when an `end` event invalidates the conversation; the next
+    // refetch becomes the trigger to clear local-state for completed rounds.
+    const [pendingRefetch, setPendingRefetch] = useState(false);
 
-        // Annotations
-        const turnAnnotations = extractAnnotationsFromTurn(turn);
-        setAnnotations(turnAnnotations);
-
-        // Precontent should be false when we have turn data
-        setPrecontent(false);
-    }, [turn, generating, conversation, props.post.id]);
+    // Refs let the WebSocket handler snapshot the current in-progress round
+    // into liveRounds without recreating the listener on every keystroke.
+    const messageRef = useRef(message);
+    const toolCallsRef = useRef(toolCalls);
+    const reasoningSummaryRef = useRef(reasoningSummary);
+    const annotationsRef = useRef(annotations);
+    messageRef.current = message;
+    toolCallsRef.current = toolCalls;
+    reasoningSummaryRef.current = reasoningSummary;
+    annotationsRef.current = annotations;
 
     // Sync message from post.message changes (e.g. after post update)
     useEffect(() => {
@@ -136,146 +140,226 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         }
     }, [props.post.message]);
 
-    // WebSocket handler for streaming -- largely unchanged
+    // Persisted rounds from turns. Empty for posts without a conversation
+    // entity (legacy meeting summary posts) — those render purely from local
+    // streaming state.
+    const persistedRounds: Round[] = useMemo(() => {
+        if (!conversation) {
+            return [];
+        }
+        return buildRoundsFromTurns(conversation, props.post.id);
+    }, [conversation, props.post.id]);
+
+    // Cache the last-known persisted rounds across refetch invalidations so
+    // the UI doesn't briefly empty out while the refetch is in flight.
+    const lastPersistedRef = useRef<Round[]>([]);
     useEffect(() => {
-        if (props.websocketRegister && props.websocketUnregister) {
-            const listenerID = Math.random().toString(36).substring(7);
+        if (conversation) {
+            lastPersistedRef.current = persistedRounds;
+        }
+    }, [conversation, persistedRounds]);
+    const stablePersisted = conversation ? persistedRounds : lastPersistedRef.current;
 
-            props.websocketRegister(props.post.id, listenerID, (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => {
-                const data = msg.data;
+    // After an `end` invalidates and the refetch completes, clear the
+    // local-state for completed rounds so we don't double-render them
+    // alongside the freshly-loaded persisted copies. useLayoutEffect runs
+    // synchronously after the render that sees the new conversation,
+    // before paint, so the user never sees a duplicated frame.
+    useLayoutEffect(() => {
+        if (pendingRefetch && conversation) {
+            setLiveRounds([]);
+            setMessage('');
+            setToolCalls([]);
+            setReasoningSummary('');
+            setIsReasoningLoading(false);
+            setAnnotations([]);
+            setPendingRefetch(false);
+        }
+    }, [conversation, pendingRefetch]);
 
-                // Ensure we're only processing events for this post
-                if (data.post_id !== props.post.id) {
-                    return;
-                }
-
-                // Handle reasoning summary events
-                if (data.control === 'reasoning_summary' && data.reasoning) {
-                    setReasoningSummary(data.reasoning);
-                    setShowReasoning(true);
-                    setIsReasoningLoading(true);
-                    setGenerating(false);
-                    setPrecontent(false);
-                    return;
-                }
-
-                if (data.control === 'reasoning_summary_done' && data.reasoning) {
-                    setReasoningSummary(data.reasoning);
-                    setIsReasoningLoading(false);
-                    return;
-                }
-
-                // Handle tool call events from the websocket event.
-                // Each round emits its own event; merge by id so live display
-                // shows every round's calls instead of only the last round's.
-                if (data.control === 'tool_call' && data.tool_call) {
-                    try {
-                        const parsedToolCalls = JSON.parse(data.tool_call) as ToolCall[];
-                        setToolCalls((prev) => {
-                            const byID = new Map<string, number>();
-                            const next = [...prev];
-                            for (let i = 0; i < next.length; i++) {
-                                byID.set(next[i].id, i);
-                            }
-                            for (const tc of parsedToolCalls) {
-                                const idx = byID.get(tc.id);
-                                if (idx === undefined) { // eslint-disable-line no-undefined
-                                    byID.set(tc.id, next.length);
-                                    next.push(tc);
-                                } else {
-                                    next[idx] = tc;
-                                }
-                            }
-                            return next;
-                        });
-                        setPrecontent(false);
-                    } catch {
-                        setError('Error parsing tool call data');
-                    }
-                    return;
-                }
-
-                // Handle annotation events from the websocket
-                if (data.control === 'annotations' && data.annotations) {
-                    try {
-                        const parsedAnnotations = JSON.parse(data.annotations);
-                        setAnnotations(parsedAnnotations);
-                        setPrecontent(false);
-                    } catch {
-                        setError('Error parsing annotation data');
-                    }
-                    return;
-                }
-
-                // Handle regular post updates
-                if (data.next && !stoppedRef.current) {
-                    setGenerating(true);
-                    setPrecontent(false);
-                    setMessage(data.next);
-                } else if (data.control === 'end') {
-                    setGenerating(false);
-                    setPrecontent(false);
-                    setStopped(false);
-                    setIsReasoningLoading(false);
-
-                    // Re-fetch the conversation to get finalized turn data
-                    if (conversationId) {
-                        invalidateConversation(conversationId);
-                    }
-                } else if (data.control === 'cancel') {
-                    setGenerating(false);
-                    setPrecontent(false);
-                    setStopped(false);
-                    setIsReasoningLoading(false);
-                } else if (data.control === 'start') {
-                    setGenerating(true);
-                    setPrecontent(true);
-                    setStopped(false);
-
-                    // Clear reasoning when starting new generation
-                    setReasoningSummary('');
-                    setShowReasoning(false);
-                    setIsReasoningCollapsed(true);
-                    setIsReasoningLoading(false);
-
-                    // Clear tool calls and annotations when starting new generation
-                    setToolCalls([]);
-                    setAnnotations([]);
-
-                    if (!message) {
-                        setMessage('');
-                    }
-                }
-            });
-
-            return () => {
-                if (props.websocketUnregister) {
-                    props.websocketUnregister(props.post.id, listenerID);
-                }
-            };
+    // WebSocket handler. Refs above let us snapshot the in-progress round
+    // without recreating this listener on every state update.
+    useEffect(() => {
+        if (!props.websocketRegister || !props.websocketUnregister) {
+            return undefined; // eslint-disable-line no-undefined
         }
 
-        return () => {/* no cleanup */};
+        const listenerID = Math.random().toString(36).substring(7);
+
+        props.websocketRegister(props.post.id, listenerID, (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => {
+            const data = msg.data;
+
+            // Ensure we're only processing events for this post
+            if (data.post_id !== props.post.id) {
+                return;
+            }
+
+            if (data.control === 'reasoning_summary' && data.reasoning) {
+                setReasoningSummary(data.reasoning);
+                setIsReasoningLoading(true);
+                setGenerating(false);
+                setPrecontent(false);
+                return;
+            }
+
+            if (data.control === 'reasoning_summary_done' && data.reasoning) {
+                setReasoningSummary(data.reasoning);
+                setIsReasoningLoading(false);
+                return;
+            }
+
+            if (data.control === 'tool_call' && data.tool_call) {
+                try {
+                    const parsedToolCalls = JSON.parse(data.tool_call) as ToolCall[];
+                    if (isResolvedToolCallEvent(parsedToolCalls)) {
+                        // Round complete: snapshot the current in-progress
+                        // round (text/reasoning/annotations + the resolved
+                        // tools from this event) into liveRounds, then reset
+                        // for the next round to begin streaming below it.
+                        setLiveRounds((prev) => [
+                            ...prev,
+                            {
+                                id: `live-${prev.length}-${Date.now()}`,
+                                text: messageRef.current,
+                                toolCalls: parsedToolCalls,
+                                reasoning: {summary: reasoningSummaryRef.current, signature: ''},
+                                annotations: annotationsRef.current,
+                            },
+                        ]);
+                        setMessage('');
+                        setToolCalls([]);
+                        setReasoningSummary('');
+                        setIsReasoningLoading(false);
+                        setAnnotations([]);
+                    } else {
+                        // Pending: replace the current round's tool calls.
+                        setToolCalls(parsedToolCalls);
+                    }
+                    setPrecontent(false);
+                } catch {
+                    setError('Error parsing tool call data');
+                }
+                return;
+            }
+
+            if (data.control === 'annotations' && data.annotations) {
+                try {
+                    const parsedAnnotations = JSON.parse(data.annotations);
+                    setAnnotations(parsedAnnotations);
+                    setPrecontent(false);
+                } catch {
+                    setError('Error parsing annotation data');
+                }
+                return;
+            }
+
+            if (typeof data.next === 'string' && !stoppedRef.current) {
+                setGenerating(true);
+                setPrecontent(false);
+                setMessage(data.next);
+                return;
+            }
+
+            if (data.control === 'end') {
+                setGenerating(false);
+                setPrecontent(false);
+                setStopped(false);
+                setIsReasoningLoading(false);
+                setPendingRefetch(true);
+                if (conversationId) {
+                    invalidateConversation(conversationId);
+                }
+                return;
+            }
+
+            if (data.control === 'cancel') {
+                setGenerating(false);
+                setPrecontent(false);
+                setStopped(false);
+                setIsReasoningLoading(false);
+                return;
+            }
+
+            if (data.control === 'start') {
+                setGenerating(true);
+                setPrecontent(true);
+                setStopped(false);
+                setReasoningSummary('');
+                setIsReasoningLoading(false);
+                setToolCalls([]);
+                setAnnotations([]);
+                setLiveRounds([]);
+                if (!message) {
+                    setMessage('');
+                }
+                return;
+            }
+
+            if (data.control === 'continue') {
+                // Continuation stream after the user approved pending tool
+                // calls. The prior round's resolved tools come from the
+                // refetched persisted rounds, so reset all local state and
+                // let the next round stream into a clean slate.
+                setGenerating(true);
+                setPrecontent(true);
+                setStopped(false);
+                setMessage('');
+                setReasoningSummary('');
+                setIsReasoningLoading(false);
+                setAnnotations([]);
+                setToolCalls([]);
+                setLiveRounds([]);
+                if (conversationId) {
+                    invalidateConversation(conversationId);
+                }
+            }
+        });
+
+        return () => {
+            if (props.websocketUnregister) {
+                props.websocketUnregister(props.post.id, listenerID);
+            }
+        };
     }, [props.post.id, conversationId]);
+
+    // The in-progress round, derived from local streaming state. Returns
+    // null when there is no live content yet so we don't render an empty
+    // section under the persisted rounds.
+    const currentRound: Round | null = useMemo(() => {
+        const hasContent = message !== '' ||
+            toolCalls.length > 0 ||
+            reasoningSummary !== '' ||
+            annotations.length > 0;
+        if (!hasContent) {
+            return null;
+        }
+        return {
+            id: 'live',
+            text: message,
+            toolCalls,
+            reasoning: {summary: reasoningSummary, signature: ''},
+            annotations,
+        };
+    }, [message, toolCalls, reasoningSummary, annotations]);
+
+    const renderedRounds = useMemo(() => {
+        const out: Round[] = [...stablePersisted, ...liveRounds];
+        if (generating && currentRound) {
+            out.push(currentRound);
+        }
+        return out;
+    }, [stablePersisted, liveRounds, generating, currentRound]);
 
     const regnerate = () => {
         setMessage('');
         setGenerating(false);
         setPrecontent(true);
         setStopped(false);
-
-        // Clear reasoning summary when regenerating
         setReasoningSummary('');
-        setShowReasoning(false);
-        setIsReasoningCollapsed(true);
         setIsReasoningLoading(false);
-
-        // Clear annotations/citations when regenerating
         setAnnotations([]);
-
-        // Clear tool calls when regenerating
         setToolCalls([]);
-
+        setLiveRounds([]);
         doRegenerate(props.post.id);
     };
 
@@ -290,12 +374,6 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         const result = await doPostbackSummary(props.post.id);
         selectPost(result.rootid, result.channelid);
     };
-
-    // Privacy: the API handles filtering. For the requester, all data is present.
-    // For non-requesters, `input` is null on redacted tool_use blocks and `content`
-    // is absent on redacted tool_result blocks. We reflect this directly.
-    const showToolArguments = toolCalls.length > 0 && toolCalls.some((tc) => tc.arguments != null);
-    const showToolResults = toolCalls.length > 0 && toolCalls.some((tc) => tc.result != null);
 
     const isThreadSummaryPost = (props.post.props?.referenced_thread && props.post.props?.referenced_thread !== '');
     const isNoShowRegen = (props.post.props?.no_regen && props.post.props?.no_regen !== '');
@@ -314,14 +392,36 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         }
     }
 
-    // Consider both generating and reasoning loading states for determining if generation is in progress
     const isGenerationInProgress = generating || isReasoningLoading;
 
     const showRegenerate = isDM && !isGenerationInProgress && requesterIsCurrentUser && !isNoShowRegen;
     const showPostbackButton = !isGenerationInProgress && requesterIsCurrentUser && isTranscriptionResult;
     const showStopGeneratingButton = isGenerationInProgress && requesterIsCurrentUser;
-    const hasContent = message !== '' || reasoningSummary !== '';
+    const hasContent = renderedRounds.length > 0;
     const showControlsBar = ((showRegenerate || showPostbackButton) && hasContent) || showStopGeneratingButton;
+
+    // Approval stage applies only to the post anchor — the latest persisted
+    // round. The live in-progress round and any locally-tracked completed
+    // rounds (liveRounds) don't have a server-confirmed approval state, so
+    // they always render as 'done' (no approve / share buttons). This also
+    // covers the brief gap between reasoning_summary_done and the next event,
+    // where `generating` is false but the stream is still active — without
+    // this guard, the cached anchorStage would leak into the live round and
+    // briefly flash the approval UI before auto-execution resolves.
+    const anchorStage: ToolApprovalStage = conversation ? deriveApprovalStageForPost(conversation, props.post.id) : 'done';
+    const lastPersistedIdx = stablePersisted.length - 1;
+    const lastRenderedIdx = renderedRounds.length - 1;
+    const stageForRound = (idx: number): ToolApprovalStage => {
+        if (idx === lastPersistedIdx && idx === lastRenderedIdx) {
+            return anchorStage;
+        }
+        return 'done';
+    };
+
+    const isReasoningCollapsed = (roundId: string): boolean => !expandedReasoning[roundId];
+    const toggleReasoning = (roundId: string, collapsed: boolean) => {
+        setExpandedReasoning((prev) => ({...prev, [roundId]: !collapsed}));
+    };
 
     return (
         <PostBody
@@ -338,15 +438,7 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                 {permalinkView}
             </>
             }
-            {showReasoning && (
-                <ReasoningDisplay
-                    reasoningSummary={reasoningSummary}
-                    isReasoningCollapsed={isReasoningCollapsed}
-                    isReasoningLoading={isReasoningLoading}
-                    onToggleCollapse={setIsReasoningCollapsed}
-                />
-            )}
-            {(precontent || (conversationLoading && !generating && !message)) && (
+            {(precontent || (conversationLoading && !generating && renderedRounds.length === 0)) && (
                 <MinimalReasoningContainer>
                     <SpinnerWrapper><LoadingSpinner/></SpinnerWrapper>
                     <span>
@@ -354,25 +446,27 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                     </span>
                 </MinimalReasoningContainer>
             )}
-            {toolCalls && toolCalls.length > 0 && (
-                <ToolApprovalSet
-                    postID={props.post.id}
-                    conversationID={conversationId}
-                    toolCalls={toolCalls}
-                    approvalStage={toolApprovalStage}
-                    canApprove={requesterIsCurrentUser}
-                    canExpand={requesterIsCurrentUser}
-                    showArguments={showToolArguments}
-                    showResults={showToolResults}
-                />
-            )}
-            <PostText
-                message={message}
-                channelID={props.post.channel_id}
-                postID={props.post.id}
-                showCursor={generating && !precontent}
-                annotations={annotations.length > 0 ? annotations : undefined} // eslint-disable-line no-undefined
-            />
+            {renderedRounds.map((round, idx) => {
+                const isLiveRound = round.id === 'live';
+                const showCursor = generating && isLiveRound && !precontent;
+                const reasoningLoading = isLiveRound && isReasoningLoading;
+                return (
+                    <RoundView
+                        key={round.id}
+                        round={round}
+                        postID={props.post.id}
+                        conversationID={conversationId}
+                        channelID={props.post.channel_id}
+                        approvalStage={stageForRound(idx)}
+                        canApprove={requesterIsCurrentUser}
+                        canExpand={requesterIsCurrentUser}
+                        showCursor={showCursor}
+                        reasoningLoading={reasoningLoading}
+                        reasoningCollapsed={isReasoningCollapsed(round.id)}
+                        onToggleReasoning={(collapsed) => toggleReasoning(round.id, collapsed)}
+                    />
+                );
+            })}
             {props.post.props?.[SearchResultsPropKey] && (
                 <SearchSources
                     sources={JSON.parse(props.post.props[SearchResultsPropKey])}
@@ -397,8 +491,71 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
     );
 };
 
+interface RoundViewProps {
+    round: Round;
+    postID: string;
+    conversationID?: string;
+    channelID: string;
+    approvalStage: ToolApprovalStage;
+    canApprove: boolean;
+    canExpand: boolean;
+    showCursor: boolean;
+    reasoningLoading: boolean;
+    reasoningCollapsed: boolean;
+    onToggleReasoning: (collapsed: boolean) => void;
+}
+
+// One round's worth of LLM output. The vertical order text → tools mirrors
+// what the LLM emits within a round (preamble first, then any tool_use it
+// chose to invoke), so the post reads as the natural back-and-forth of
+// reasoning and action.
+function RoundView(props: RoundViewProps) {
+    const {round} = props;
+    const showArguments = round.toolCalls.some((tc) => tc.arguments != null);
+    const showResults = round.toolCalls.some((tc) => tc.result != null);
+    return (
+        <RoundContainer>
+            {round.reasoning.summary !== '' && (
+                <ReasoningDisplay
+                    reasoningSummary={round.reasoning.summary}
+                    isReasoningCollapsed={props.reasoningCollapsed}
+                    isReasoningLoading={props.reasoningLoading}
+                    onToggleCollapse={props.onToggleReasoning}
+                />
+            )}
+            {round.text !== '' && (
+                <PostText
+                    message={round.text}
+                    channelID={props.channelID}
+                    postID={props.postID}
+                    showCursor={props.showCursor}
+                    annotations={round.annotations.length > 0 ? round.annotations : undefined} // eslint-disable-line no-undefined
+                />
+            )}
+            {round.toolCalls.length > 0 && (
+                <ToolApprovalSet
+                    postID={props.postID}
+                    conversationID={props.conversationID}
+                    toolCalls={round.toolCalls}
+                    approvalStage={props.approvalStage}
+                    canApprove={props.canApprove}
+                    canExpand={props.canExpand}
+                    showArguments={showArguments}
+                    showResults={showResults}
+                />
+            )}
+        </RoundContainer>
+    );
+}
+
 // Styled components
 const PostBody = styled.div`
+`;
+
+const RoundContainer = styled.div`
+    & + & {
+        margin-top: 8px;
+    }
 `;
 
 const SpinnerWrapper = styled.div`

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -358,12 +358,19 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
             }
             return out;
         }
+
+        // Always show currentRound when it has content. Don't gate on
+        // `generating`: reasoning_summary events flip generating=false while
+        // streaming reasoning chunks, so a `generating && currentRound`
+        // guard would hide the thinking block until text or tool calls
+        // arrive. After end+refetch, useLayoutEffect clears the live state
+        // so currentRound naturally falls back to null.
         const out: Round[] = [...stablePersisted, ...liveRounds];
-        if (generating && currentRound) {
+        if (currentRound) {
             out.push(currentRound);
         }
         return out;
-    }, [regenerating, stablePersisted, liveRounds, generating, currentRound]);
+    }, [regenerating, stablePersisted, liveRounds, currentRound]);
 
     const regnerate = () => {
         setMessage('');

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -199,9 +199,14 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
             }
 
             if (data.control === 'reasoning_summary' && data.reasoning) {
+                // Keep generating=true: the model is still actively producing
+                // reasoning chunks. Flipping it to false here would hide
+                // currentRound (the `generating && currentRound` gate in
+                // renderedRounds) and the thinking block wouldn't appear
+                // until text or a tool call arrived. isReasoningLoading
+                // separately drives the reasoning spinner state.
                 setReasoningSummary(data.reasoning);
                 setIsReasoningLoading(true);
-                setGenerating(false);
                 setPrecontent(false);
                 return;
             }
@@ -358,19 +363,12 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
             }
             return out;
         }
-
-        // Always show currentRound when it has content. Don't gate on
-        // `generating`: reasoning_summary events flip generating=false while
-        // streaming reasoning chunks, so a `generating && currentRound`
-        // guard would hide the thinking block until text or tool calls
-        // arrive. After end+refetch, useLayoutEffect clears the live state
-        // so currentRound naturally falls back to null.
         const out: Round[] = [...stablePersisted, ...liveRounds];
-        if (currentRound) {
+        if (generating && currentRound) {
             out.push(currentRound);
         }
         return out;
-    }, [regenerating, stablePersisted, liveRounds, currentRound]);
+    }, [regenerating, stablePersisted, liveRounds, generating, currentRound]);
 
     const regnerate = () => {
         setMessage('');

--- a/webapp/src/components/llmbot_post/turn_content_utils.test.ts
+++ b/webapp/src/components/llmbot_post/turn_content_utils.test.ts
@@ -579,10 +579,7 @@ describe('buildRoundsFromTurns', () => {
         expect(rounds[1].reasoning.summary).toBe('thinking about round 2');
     });
 
-    // User-approval flow: the assistant turn requesting tools is the post
-    // anchor; its tool_result turn is written AFTER approval, at a higher
-    // sequence number. The pairing must still find the result so the
-    // resolved tool card renders with content.
+    // User-approval flow: tool_result is written after the anchor turn.
     test('pairs tool_result that lives at a sequence GREATER than the anchor', () => {
         const userTurn = makeTurn({id: 'u1', role: 'user', sequence: 1, post_id: 'user_post', content: []});
         const anchor = makeTurn({
@@ -595,8 +592,6 @@ describe('buildRoundsFromTurns', () => {
             ],
         });
 
-        // tool_result lives at sequence 3 — AFTER the anchor. This is the
-        // shape produced by HandleToolCall in the user-approval flow.
         const lateResult = makeTurn({
             id: 'tr1',
             role: 'tool_result',
@@ -615,10 +610,6 @@ describe('buildRoundsFromTurns', () => {
         expect(rounds[0].toolCalls[0].result).toBe('late result');
     });
 
-    // A tool_use block that has no matching tool_result (e.g. user rejected
-    // mid-decision, or the tool errored before producing output) must
-    // surface as a card with `result === undefined` rather than silently
-    // dropping the tool call.
     test('renders a tool_use with no matching tool_result and undefined result', () => {
         const anchor = makeTurn({
             id: 'a1',
@@ -633,16 +624,11 @@ describe('buildRoundsFromTurns', () => {
         expect(rounds[0].toolCalls[0].result).toBeUndefined();
     });
 
-    // Continuation flow: the prior anchor turn is demoted (post_id cleared)
-    // when a follow-up stream finalizes. The demoted turn still carries the
-    // round's text and resolved tool_use blocks, and must be picked up by
-    // the back-walk so the per-round visual render reflects the full
-    // back-and-forth — not just the final round.
+    // Continuation: demoted prior anchor (post_id cleared) must still render
+    // as a prior round.
     test('includes a demoted prior anchor turn between the user turn and the new anchor', () => {
         const userTurn = makeTurn({id: 'u1', role: 'user', sequence: 1, post_id: 'user_post', content: []});
 
-        // Demoted prior anchor: post_id is now null, but its content
-        // (text + resolved tool_use) belongs to this response.
         const demoted = makeTurn({
             id: 'a_old',
             post_id: null,
@@ -679,10 +665,7 @@ describe('buildRoundsFromTurns', () => {
         expect(rounds[1].text).toBe('Found 5 channels.');
     });
 
-    // Cross-post isolation: a sibling post in the same conversation must
-    // not contribute its rounds to this post's view. With the demote logic
-    // clearing post_ids on prior rounds, the back-walk can't trust post_id
-    // alone — it has to stop at user turns and at OTHER post anchors.
+    // Sibling posts in the same conversation must not contribute rounds.
     test('does not include rounds belonging to a sibling post anchor', () => {
         const userA = makeTurn({id: 'uA', role: 'user', sequence: 1, post_id: 'user_a', content: []});
         const anchorA = makeTurn({

--- a/webapp/src/components/llmbot_post/turn_content_utils.test.ts
+++ b/webapp/src/components/llmbot_post/turn_content_utils.test.ts
@@ -12,6 +12,7 @@ import {
     extractAnnotationsFromTurn,
     deriveApprovalStageForPost,
     hasAutoApprovedToolsForPost,
+    buildRoundsFromTurns,
 } from './turn_content_utils';
 
 function makeTurn(overrides: Partial<Turn> = {}): Turn {
@@ -486,5 +487,224 @@ describe('hasAutoApprovedToolsForPost', () => {
         });
         const conv = makeConversation([anchor]);
         expect(hasAutoApprovedToolsForPost(conv, 'post_missing')).toBe(false);
+    });
+});
+
+describe('buildRoundsFromTurns', () => {
+    test('returns one round per assistant turn in the response, preserving sequence', () => {
+        const userTurn = makeTurn({id: 'u1', role: 'user', sequence: 1, post_id: 'user_post', content: []});
+        const round1 = makeTurn({
+            id: 'r1',
+            post_id: null,
+            sequence: 2,
+            content: [
+                {type: 'text', text: 'Let me search.'},
+                {type: 'tool_use', id: 'tc_1', name: 'search', status: 'auto_approved'},
+            ],
+        });
+        const toolResult1 = makeTurn({
+            id: 'tr1',
+            role: 'tool_result',
+            post_id: null,
+            sequence: 3,
+            content: [{type: 'tool_result', tool_use_id: 'tc_1', content: 'channel data'}],
+        });
+        const round2 = makeTurn({
+            id: 'r2',
+            post_id: 'post_1',
+            sequence: 4,
+            content: [{type: 'text', text: 'Found 5 channels.'}],
+        });
+        const conv = makeConversation([userTurn, round1, toolResult1, round2]);
+
+        const rounds = buildRoundsFromTurns(conv, 'post_1');
+        expect(rounds).toHaveLength(2);
+        expect(rounds[0].id).toBe('r1');
+        expect(rounds[0].text).toBe('Let me search.');
+        expect(rounds[0].toolCalls).toHaveLength(1);
+        expect(rounds[0].toolCalls[0].id).toBe('tc_1');
+        expect(rounds[0].toolCalls[0].result).toBe('channel data');
+        expect(rounds[0].toolCalls[0].status).toBe(ToolCallStatus.AutoApproved);
+        expect(rounds[1].id).toBe('r2');
+        expect(rounds[1].text).toBe('Found 5 channels.');
+        expect(rounds[1].toolCalls).toHaveLength(0);
+    });
+
+    test('omits tool_result turns from the round list — they pair to tool_use blocks by id', () => {
+        const round1 = makeTurn({
+            id: 'r1',
+            post_id: 'post_1',
+            sequence: 1,
+            content: [{type: 'tool_use', id: 'tc_x', name: 'lookup', status: 'success'}],
+        });
+        const result = makeTurn({
+            id: 'tr1',
+            role: 'tool_result',
+            post_id: null,
+            sequence: 2,
+            content: [{type: 'tool_result', tool_use_id: 'tc_x', content: 'ok'}],
+        });
+        const rounds = buildRoundsFromTurns(makeConversation([round1, result]), 'post_1');
+        expect(rounds).toHaveLength(1);
+        expect(rounds[0].toolCalls[0].result).toBe('ok');
+    });
+
+    test('returns empty when the post has no anchor turn', () => {
+        const turn = makeTurn({post_id: 'post_other', content: []});
+        const rounds = buildRoundsFromTurns(makeConversation([turn]), 'post_missing');
+        expect(rounds).toEqual([]);
+    });
+
+    test('extracts reasoning per round, not aggregated across the response', () => {
+        const round1 = makeTurn({
+            id: 'r1',
+            post_id: null,
+            sequence: 1,
+            content: [
+                {type: 'thinking', text: 'thinking about round 1'},
+                {type: 'text', text: 'preamble'},
+            ],
+        });
+        const round2 = makeTurn({
+            id: 'r2',
+            post_id: 'post_1',
+            sequence: 2,
+            content: [
+                {type: 'thinking', text: 'thinking about round 2'},
+                {type: 'text', text: 'final answer'},
+            ],
+        });
+        const rounds = buildRoundsFromTurns(makeConversation([round1, round2]), 'post_1');
+        expect(rounds[0].reasoning.summary).toBe('thinking about round 1');
+        expect(rounds[1].reasoning.summary).toBe('thinking about round 2');
+    });
+
+    // User-approval flow: the assistant turn requesting tools is the post
+    // anchor; its tool_result turn is written AFTER approval, at a higher
+    // sequence number. The pairing must still find the result so the
+    // resolved tool card renders with content.
+    test('pairs tool_result that lives at a sequence GREATER than the anchor', () => {
+        const userTurn = makeTurn({id: 'u1', role: 'user', sequence: 1, post_id: 'user_post', content: []});
+        const anchor = makeTurn({
+            id: 'a1',
+            post_id: 'post_1',
+            sequence: 2,
+            content: [
+                {type: 'text', text: 'I need to call this.'},
+                {type: 'tool_use', id: 'tc_after', name: 'lookup', status: 'success'},
+            ],
+        });
+
+        // tool_result lives at sequence 3 — AFTER the anchor. This is the
+        // shape produced by HandleToolCall in the user-approval flow.
+        const lateResult = makeTurn({
+            id: 'tr1',
+            role: 'tool_result',
+            post_id: null,
+            sequence: 3,
+            content: [{type: 'tool_result', tool_use_id: 'tc_after', content: 'late result'}],
+        });
+
+        const rounds = buildRoundsFromTurns(
+            makeConversation([userTurn, anchor, lateResult]),
+            'post_1',
+        );
+        expect(rounds).toHaveLength(1);
+        expect(rounds[0].toolCalls).toHaveLength(1);
+        expect(rounds[0].toolCalls[0].id).toBe('tc_after');
+        expect(rounds[0].toolCalls[0].result).toBe('late result');
+    });
+
+    // A tool_use block that has no matching tool_result (e.g. user rejected
+    // mid-decision, or the tool errored before producing output) must
+    // surface as a card with `result === undefined` rather than silently
+    // dropping the tool call.
+    test('renders a tool_use with no matching tool_result and undefined result', () => {
+        const anchor = makeTurn({
+            id: 'a1',
+            post_id: 'post_1',
+            sequence: 1,
+            content: [{type: 'tool_use', id: 'tc_lonely', name: 'search', status: 'pending'}],
+        });
+        const rounds = buildRoundsFromTurns(makeConversation([anchor]), 'post_1');
+        expect(rounds).toHaveLength(1);
+        expect(rounds[0].toolCalls).toHaveLength(1);
+        expect(rounds[0].toolCalls[0].id).toBe('tc_lonely');
+        expect(rounds[0].toolCalls[0].result).toBeUndefined();
+    });
+
+    // Continuation flow: the prior anchor turn is demoted (post_id cleared)
+    // when a follow-up stream finalizes. The demoted turn still carries the
+    // round's text and resolved tool_use blocks, and must be picked up by
+    // the back-walk so the per-round visual render reflects the full
+    // back-and-forth — not just the final round.
+    test('includes a demoted prior anchor turn between the user turn and the new anchor', () => {
+        const userTurn = makeTurn({id: 'u1', role: 'user', sequence: 1, post_id: 'user_post', content: []});
+
+        // Demoted prior anchor: post_id is now null, but its content
+        // (text + resolved tool_use) belongs to this response.
+        const demoted = makeTurn({
+            id: 'a_old',
+            post_id: null,
+            sequence: 2,
+            content: [
+                {type: 'text', text: 'Let me look that up.'},
+                {type: 'tool_use', id: 'tc1', name: 'search', status: 'success'},
+            ],
+        });
+        const result = makeTurn({
+            id: 'tr1',
+            role: 'tool_result',
+            post_id: null,
+            sequence: 3,
+            content: [{type: 'tool_result', tool_use_id: 'tc1', content: 'channel data'}],
+        });
+        const newAnchor = makeTurn({
+            id: 'a_new',
+            post_id: 'post_1',
+            sequence: 4,
+            content: [{type: 'text', text: 'Found 5 channels.'}],
+        });
+
+        const rounds = buildRoundsFromTurns(
+            makeConversation([userTurn, demoted, result, newAnchor]),
+            'post_1',
+        );
+        expect(rounds).toHaveLength(2);
+        expect(rounds[0].id).toBe('a_old');
+        expect(rounds[0].text).toBe('Let me look that up.');
+        expect(rounds[0].toolCalls).toHaveLength(1);
+        expect(rounds[0].toolCalls[0].result).toBe('channel data');
+        expect(rounds[1].id).toBe('a_new');
+        expect(rounds[1].text).toBe('Found 5 channels.');
+    });
+
+    // Cross-post isolation: a sibling post in the same conversation must
+    // not contribute its rounds to this post's view. With the demote logic
+    // clearing post_ids on prior rounds, the back-walk can't trust post_id
+    // alone — it has to stop at user turns and at OTHER post anchors.
+    test('does not include rounds belonging to a sibling post anchor', () => {
+        const userA = makeTurn({id: 'uA', role: 'user', sequence: 1, post_id: 'user_a', content: []});
+        const anchorA = makeTurn({
+            id: 'aA',
+            post_id: 'post_a',
+            sequence: 2,
+            content: [{type: 'text', text: 'Response A.'}],
+        });
+        const userB = makeTurn({id: 'uB', role: 'user', sequence: 3, post_id: 'user_b', content: []});
+        const anchorB = makeTurn({
+            id: 'aB',
+            post_id: 'post_b',
+            sequence: 4,
+            content: [{type: 'text', text: 'Response B.'}],
+        });
+
+        const conv = makeConversation([userA, anchorA, userB, anchorB]);
+        const roundsA = buildRoundsFromTurns(conv, 'post_a');
+        const roundsB = buildRoundsFromTurns(conv, 'post_b');
+        expect(roundsA).toHaveLength(1);
+        expect(roundsA[0].text).toBe('Response A.');
+        expect(roundsB).toHaveLength(1);
+        expect(roundsB[0].text).toBe('Response B.');
     });
 });

--- a/webapp/src/components/llmbot_post/turn_content_utils.ts
+++ b/webapp/src/components/llmbot_post/turn_content_utils.ts
@@ -79,9 +79,10 @@ function collectResponseTurns(
     return out;
 }
 
-// Results may land in any turn — most commonly the assistant turn that
-// requested them, but for the user-approval flow they land in a tool_result
-// turn AFTER the anchor. Indexing every turn keeps both shapes covered.
+// Tool results can land in different turns depending on how the tool was
+// resolved (auto-run vs. user-approved), and the post's anchor shifts on
+// continuation. Indexing every turn in the conversation pairs each
+// tool_use with its result by id regardless of where either lives.
 function buildToolResultMap(conversation: ConversationResponse): Map<string, ContentBlock> {
     const resultMap = new Map<string, ContentBlock>();
     for (const t of conversation.turns) {

--- a/webapp/src/components/llmbot_post/turn_content_utils.ts
+++ b/webapp/src/components/llmbot_post/turn_content_utils.ts
@@ -223,3 +223,77 @@ export function hasAutoApprovedToolsForPost(
         ),
     );
 }
+
+/**
+ * One round of the LLM's response — what was emitted between two tool
+ * boundaries (or between the user turn and the first tool boundary). The
+ * post is rendered as a vertical sequence of rounds so the user sees the
+ * back-and-forth: text → tools → text → tools → final text.
+ */
+export interface Round {
+
+    /** Stable React key. */
+    id: string;
+    text: string;
+    toolCalls: ToolCall[];
+    reasoning: {summary: string; signature: string};
+    annotations: Annotation[];
+}
+
+/**
+ * Build the per-round view from the persisted turns of a response. Each
+ * assistant turn in the response is one round; tool_use blocks are paired
+ * with their tool_result block by id (results may live in a tool_result turn
+ * later in the sequence — for the user-approval flow, results are written
+ * after the assistant turn that requested them).
+ */
+export function buildRoundsFromTurns(
+    conversation: ConversationResponse,
+    postId: string,
+): Round[] {
+    const turns = collectResponseTurns(conversation, postId);
+    if (turns.length === 0) {
+        return [];
+    }
+
+    const resultMap = new Map<string, ContentBlock>();
+    for (const t of conversation.turns) {
+        for (const block of t.content) {
+            if (block.type === BlockTypeToolResult && block.tool_use_id) {
+                resultMap.set(block.tool_use_id, block);
+            }
+        }
+    }
+
+    const rounds: Round[] = [];
+    for (const turn of turns) {
+        if (turn.role !== 'assistant') {
+            continue;
+        }
+        const text = turn.content.
+            filter((b) => b.type === BlockTypeText).
+            map((b) => b.text ?? '').
+            join('');
+        const toolCalls: ToolCall[] = turn.content.
+            filter((b) => b.type === BlockTypeToolUse).
+            map((block): ToolCall => {
+                const resultBlock = block.id ? resultMap.get(block.id) : undefined; // eslint-disable-line no-undefined
+                return {
+                    id: block.id ?? '',
+                    name: block.name ?? '',
+                    description: '',
+                    arguments: (block.input as ToolCall['arguments']) ?? undefined, // eslint-disable-line no-undefined
+                    result: resultBlock?.content ?? undefined, // eslint-disable-line no-undefined
+                    status: statusStringToEnum(block.status),
+                };
+            });
+        rounds.push({
+            id: turn.id,
+            text,
+            toolCalls,
+            reasoning: extractReasoningFromTurn(turn),
+            annotations: extractAnnotationsFromTurn(turn),
+        });
+    }
+    return rounds;
+}

--- a/webapp/src/components/llmbot_post/turn_content_utils.ts
+++ b/webapp/src/components/llmbot_post/turn_content_utils.ts
@@ -79,6 +79,33 @@ function collectResponseTurns(
     return out;
 }
 
+// Results may land in any turn — most commonly the assistant turn that
+// requested them, but for the user-approval flow they land in a tool_result
+// turn AFTER the anchor. Indexing every turn keeps both shapes covered.
+function buildToolResultMap(conversation: ConversationResponse): Map<string, ContentBlock> {
+    const resultMap = new Map<string, ContentBlock>();
+    for (const t of conversation.turns) {
+        for (const block of t.content) {
+            if (block.type === BlockTypeToolResult && block.tool_use_id) {
+                resultMap.set(block.tool_use_id, block);
+            }
+        }
+    }
+    return resultMap;
+}
+
+function toolUseBlockToToolCall(block: ContentBlock, resultMap: Map<string, ContentBlock>): ToolCall {
+    const resultBlock = block.id ? resultMap.get(block.id) : undefined; // eslint-disable-line no-undefined
+    return {
+        id: block.id ?? '',
+        name: block.name ?? '',
+        description: '',
+        arguments: (block.input as ToolCall['arguments']) ?? undefined, // eslint-disable-line no-undefined
+        result: resultBlock?.content ?? undefined, // eslint-disable-line no-undefined
+        status: statusStringToEnum(block.status),
+    };
+}
+
 /**
  * Build a ToolCall[] from every tool_use block across the turns that belong
  * to a given post's response, pairing each with its matching tool_result by
@@ -107,29 +134,8 @@ export function extractToolCallsForPost(
         return [];
     }
 
-    // Results may land AFTER the anchor when the user just approved
-    // previously pending tool calls, so search every turn by tool_use_id
-    // rather than only the collected response range.
-    const resultMap = new Map<string, ContentBlock>();
-    for (const t of conversation.turns) {
-        for (const block of t.content) {
-            if (block.type === BlockTypeToolResult && block.tool_use_id) {
-                resultMap.set(block.tool_use_id, block);
-            }
-        }
-    }
-
-    return toolUseBlocks.map((block: ContentBlock): ToolCall => {
-        const resultBlock = block.id ? resultMap.get(block.id) : undefined; // eslint-disable-line no-undefined
-        return {
-            id: block.id ?? '',
-            name: block.name ?? '',
-            description: '',
-            arguments: (block.input as ToolCall['arguments']) ?? undefined, // eslint-disable-line no-undefined
-            result: resultBlock?.content ?? undefined, // eslint-disable-line no-undefined
-            status: statusStringToEnum(block.status),
-        };
-    });
+    const resultMap = buildToolResultMap(conversation);
+    return toolUseBlocks.map((block) => toolUseBlockToToolCall(block, resultMap));
 }
 
 /** Extract reasoning summary text and signature from thinking content blocks. */
@@ -256,15 +262,7 @@ export function buildRoundsFromTurns(
         return [];
     }
 
-    const resultMap = new Map<string, ContentBlock>();
-    for (const t of conversation.turns) {
-        for (const block of t.content) {
-            if (block.type === BlockTypeToolResult && block.tool_use_id) {
-                resultMap.set(block.tool_use_id, block);
-            }
-        }
-    }
-
+    const resultMap = buildToolResultMap(conversation);
     const rounds: Round[] = [];
     for (const turn of turns) {
         if (turn.role !== 'assistant') {
@@ -274,19 +272,9 @@ export function buildRoundsFromTurns(
             filter((b) => b.type === BlockTypeText).
             map((b) => b.text ?? '').
             join('');
-        const toolCalls: ToolCall[] = turn.content.
+        const toolCalls = turn.content.
             filter((b) => b.type === BlockTypeToolUse).
-            map((block): ToolCall => {
-                const resultBlock = block.id ? resultMap.get(block.id) : undefined; // eslint-disable-line no-undefined
-                return {
-                    id: block.id ?? '',
-                    name: block.name ?? '',
-                    description: '',
-                    arguments: (block.input as ToolCall['arguments']) ?? undefined, // eslint-disable-line no-undefined
-                    result: resultBlock?.content ?? undefined, // eslint-disable-line no-undefined
-                    status: statusStringToEnum(block.status),
-                };
-            });
+            map((block) => toolUseBlockToToolCall(block, resultMap));
         rounds.push({
             id: turn.id,
             text,

--- a/webapp/src/components/llmbot_post/turn_content_utils.ts
+++ b/webapp/src/components/llmbot_post/turn_content_utils.ts
@@ -79,10 +79,8 @@ function collectResponseTurns(
     return out;
 }
 
-// Tool results can land in different turns depending on how the tool was
-// resolved (auto-run vs. user-approved), and the post's anchor shifts on
-// continuation. Indexing every turn in the conversation pairs each
-// tool_use with its result by id regardless of where either lives.
+// Index every tool_result block in the conversation by tool_use_id so a
+// tool_use can be paired regardless of which turn its result lives in.
 function buildToolResultMap(conversation: ConversationResponse): Map<string, ContentBlock> {
     const resultMap = new Map<string, ContentBlock>();
     for (const t of conversation.turns) {
@@ -231,15 +229,9 @@ export function hasAutoApprovedToolsForPost(
     );
 }
 
-/**
- * One round of the LLM's response — what was emitted between two tool
- * boundaries (or between the user turn and the first tool boundary). The
- * post is rendered as a vertical sequence of rounds so the user sees the
- * back-and-forth: text → tools → text → tools → final text.
- */
+// One assistant turn in a response. The post renders these as a vertical
+// sequence: text → tools → text → tools → final text.
 export interface Round {
-
-    /** Stable React key. */
     id: string;
     text: string;
     toolCalls: ToolCall[];
@@ -247,13 +239,6 @@ export interface Round {
     annotations: Annotation[];
 }
 
-/**
- * Build the per-round view from the persisted turns of a response. Each
- * assistant turn in the response is one round; tool_use blocks are paired
- * with their tool_result block by id (results may live in a tool_result turn
- * later in the sequence — for the user-approval flow, results are written
- * after the assistant turn that requested them).
- */
 export function buildRoundsFromTurns(
     conversation: ConversationResponse,
     postId: string,

--- a/webapp/src/hooks/use_conversation.test.ts
+++ b/webapp/src/hooks/use_conversation.test.ts
@@ -269,11 +269,7 @@ describe('useConversation', () => {
         expect(result.current.error).toBeNull();
     });
 
-    // Regression: a tool-approval continuation triggers two close-together
-    // invalidates ('continue' then 'end'). Without the inflight-identity
-    // guard, the older fetch can resolve AFTER the newer one and overwrite
-    // the freshly-finalized conversation with its pre-finalize snapshot,
-    // leaving the post visually stuck on the prior round.
+    // Two close-together invalidates can race; stale fetch must not clobber.
     test('a stale fetch resolving after a newer fetch must not overwrite cache', async () => {
         const stale = makeConversation({title: 'stale'});
         const fresh = makeConversation({title: 'fresh'});
@@ -291,12 +287,10 @@ describe('useConversation', () => {
         const {result} = renderHook(() => useConversation('conv_123'));
         expect(result.current.loading).toBe(true);
 
-        // Drop the first inflight, kick a second fetch.
         act(() => {
             invalidateConversation('conv_123');
         });
 
-        // Resolve the FRESH (second) fetch first — cache should pick this up.
         await act(async () => {
             resolveFresh!(fresh);
         });
@@ -304,8 +298,6 @@ describe('useConversation', () => {
             expect(result.current.conversation).toEqual(fresh);
         });
 
-        // Stale (first) fetch resolves later; its result must be discarded so
-        // the cache stays on the fresh data.
         await act(async () => {
             resolveStale!(stale);
         });

--- a/webapp/src/hooks/use_conversation.test.ts
+++ b/webapp/src/hooks/use_conversation.test.ts
@@ -268,6 +268,50 @@ describe('useConversation', () => {
         });
         expect(result.current.error).toBeNull();
     });
+
+    // Regression: a tool-approval continuation triggers two close-together
+    // invalidates ('continue' then 'end'). Without the inflight-identity
+    // guard, the older fetch can resolve AFTER the newer one and overwrite
+    // the freshly-finalized conversation with its pre-finalize snapshot,
+    // leaving the post visually stuck on the prior round.
+    test('a stale fetch resolving after a newer fetch must not overwrite cache', async () => {
+        const stale = makeConversation({title: 'stale'});
+        const fresh = makeConversation({title: 'fresh'});
+
+        let resolveStale: (data: ConversationResponse) => void;
+        let resolveFresh: (data: ConversationResponse) => void;
+        getConversation.
+            mockReturnValueOnce(new Promise<ConversationResponse>((r) => {
+                resolveStale = r;
+            })).
+            mockReturnValueOnce(new Promise<ConversationResponse>((r) => {
+                resolveFresh = r;
+            }));
+
+        const {result} = renderHook(() => useConversation('conv_123'));
+        expect(result.current.loading).toBe(true);
+
+        // Drop the first inflight, kick a second fetch.
+        act(() => {
+            invalidateConversation('conv_123');
+        });
+
+        // Resolve the FRESH (second) fetch first — cache should pick this up.
+        await act(async () => {
+            resolveFresh!(fresh);
+        });
+        await waitFor(() => {
+            expect(result.current.conversation).toEqual(fresh);
+        });
+
+        // Stale (first) fetch resolves later; its result must be discarded so
+        // the cache stays on the fresh data.
+        await act(async () => {
+            resolveStale!(stale);
+        });
+        await new Promise((r) => setTimeout(r, 0));
+        expect(result.current.conversation).toEqual(fresh);
+    });
 });
 
 describe('useTurnForPost', () => {

--- a/webapp/src/hooks/use_conversation.ts
+++ b/webapp/src/hooks/use_conversation.ts
@@ -43,13 +43,8 @@ function fetchConversation(id: string): Promise<ConversationResponse> {
         return existing;
     }
 
-    // Capture the promise reference so a later resolution can detect that
-    // invalidateConversation evicted us mid-flight and skip writing stale
-    // data into the cache. Without this, two close-together invalidations
-    // (e.g. 'continue' then 'end' on a tool-approval continuation stream)
-    // can race: the older fetch resolves AFTER the newer fetch has updated
-    // the cache, overwriting fresh data with the pre-finalize snapshot —
-    // leaving the post visually stuck on the prior round.
+    // Identity-check the inflight promise so a fetch evicted mid-flight by
+    // invalidateConversation can't overwrite the newer fetch's result.
     const settle = (data: ConversationResponse) => {
         if (inflightRequests.get(id) !== promise) {
             return data;

--- a/webapp/src/hooks/use_conversation.ts
+++ b/webapp/src/hooks/use_conversation.ts
@@ -42,13 +42,28 @@ function fetchConversation(id: string): Promise<ConversationResponse> {
     if (existing) {
         return existing;
     }
-    const promise = getConversation(id).then((data) => {
+
+    // Capture the promise reference so a later resolution can detect that
+    // invalidateConversation evicted us mid-flight and skip writing stale
+    // data into the cache. Without this, two close-together invalidations
+    // (e.g. 'continue' then 'end' on a tool-approval continuation stream)
+    // can race: the older fetch resolves AFTER the newer fetch has updated
+    // the cache, overwriting fresh data with the pre-finalize snapshot —
+    // leaving the post visually stuck on the prior round.
+    const settle = (data: ConversationResponse) => {
+        if (inflightRequests.get(id) !== promise) {
+            return data;
+        }
         conversationCache.set(id, data);
         errorCache.delete(id);
         inflightRequests.delete(id);
         notifySubscribers();
         return data;
-    }).catch((err) => {
+    };
+    const fail = (err: Error): never => {
+        if (inflightRequests.get(id) !== promise) {
+            throw err;
+        }
         errorCache.set(id, err);
         inflightRequests.delete(id);
 
@@ -57,7 +72,8 @@ function fetchConversation(id: string): Promise<ConversationResponse> {
         // loading=true since the dedup path made them skip their own fetch.
         notifySubscribers();
         throw err;
-    });
+    };
+    const promise: Promise<ConversationResponse> = getConversation(id).then(settle, fail);
     inflightRequests.set(id, promise);
     return promise;
 }


### PR DESCRIPTION
#### Summary

Previously, when an agent responded across tool-approval gates the plugin created a fresh post for each follow-up stream — an artifact of the old conversation-tracking system. This PR combines the entire LLM conversation turn (auto-run rounds + every user-approval continuation) into a single post and renders the back-and-forth as a sequence of rounds (Reasoning → Text → Tools per round).

**Backend**
- New `Store.UpdateTurnPostID` (with real-DB integration tests) so the streaming layer can demote a prior anchor turn before creating the new one — preserves the "exactly one assistant turn anchored per post" invariant the webapp's anchor lookup depends on.
- New `Store.DeleteResponseTurns` (with real-DB integration tests) — used by the regen flow to scrub the prior response (anchor + auto-run intermediates + tool_results) so the stream that follows is byte-for-byte equivalent to a first stream. No special update-in-place path.
- Split `streaming.StreamToPost` (first stream + regen) from `streaming.StreamContinuationToPost` (tool-approval resume). The two paths used to be auto-detected from "is there a prior anchor?", which mis-classified a regen of a continuation post as another continuation. The split makes the caller's intent explicit.
- `finalizeTurn` is now two cases:
  - fresh stream / regen → create anchor (the regen caller scrubbed prior turns first, so there's nothing to update)
  - continuation → demote prior anchor (`PostID = nil`), then create new anchor at the back of the conversation
- New `PostStreamingControlContinue = "continue"` control event so the webapp keeps resolved tool cards visible across the user-approval gap.
- `conversation.BuildCompletionRequest` with `ExcludeAfterPostID` now walks back from the anchor to the originating user turn and truncates after it. This stops bifrost models that disallow assistant prefill from rejecting the request when regenerating a tool-approval continuation post.
- `conversations.regenerateViaConversation` builds the completion request **before** scrubbing — `ExcludeAfterPostID` walks back from the anchor that `DeleteResponseTurns` is about to remove.
- `conversations.streamToolFollowUp` calls `streamContinuationToExistingPost` (the gated continuation path), no longer creates a new post.
- Removed the `next: ""` broadcast on resolved tool calls — the empty event used to clear the round's preamble before the webapp could attribute it to its round.

**Webapp**
- New `Round` type and `buildRoundsFromTurns(conversation, postId)` in `turn_content_utils.ts`, sharing extraction helpers (`buildToolResultMap`, `toolUseBlockToToolCall`) with `extractToolCallsForPost`.
- `llmbot_post.tsx` rebuilt around `persistedRounds + liveRounds + currentRound`. Resolved tool_call events snapshot the in-progress round into `liveRounds` (toolrunner persists tool turns mid-stream but the anchor isn't written until end-of-stream, so local state bridges the gap until the post-end refetch lands). A `pendingRefetch` flag with `useLayoutEffect` clears local state synchronously after the refetch so persisted and live copies don't double-render.
- `regenerating` flag with a dedicated render branch: while a regen is in flight, suppress the cached `persistedRounds` (still holds the pre-regen turn until refetch) and render `liveRounds + currentRound`, so the post doesn't visually empty out between rounds.
- `currentRound` is rendered whenever it has content. The earlier `generating && currentRound` guard hid the thinking block on first generate, because `reasoning_summary` events flip `generating` to false while reasoning chunks stream.
- Approval stage applies only when the last rendered round is also the last persisted round — the live round never inherits a cached `'call'` stage, so auto-approved tools no longer flash open with approve buttons.
- Accepts empty-string `next` updates so server-side message clears propagate properly.

**Tests**
- New `streaming/turn_persistence_test.go` cases: continuation demote-then-create ordering; multi-post cross-post isolation; table-driven continuation-detection guards; lookup-error fall-through; regen via `StreamToPost` creates a fresh anchor and never demotes; event-ordering invariant for the round preamble.
- New `store/turns_test.go: TestUpdateTurnPostID` (real-DB) covering clear / reassign / others-untouched / non-existent-id.
- New `store/turns_test.go: TestDeleteResponseTurns` (real-DB) covering anchor + intermediates removal, leaves earlier turns untouched, no-op when the post has no anchor.
- New `conversation/service_test.go: TestBuildCompletionRequest_ExcludeAfterPostID_ToolApprovalContinuationLeavesUserTail` regression for the bifrost prefill bug.
- New `turn_content_utils.test.ts: buildRoundsFromTurns` cases including the user-approval shape (tool_result at sequence > anchor), missing tool_result, demoted prior anchor, sibling-post isolation.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-66990

#### Screenshots

<img width="578" height="1175" alt="image" src="https://github.com/user-attachments/assets/49e63419-e3c9-4e86-a1e8-82d381686dc6" />

#### Release Note
```release-note
Multi-round agent responses (auto-run tool rounds and post-approval continuations) now land in a single post that renders the LLM's back-and-forth round by round, instead of creating a separate post per continuation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool approval continuations now stream responses into the existing post instead of creating new posts, providing a more streamlined approval workflow.
  * Multi-round responses are now displayed with improved round-by-round organization within a single post.

* **Bug Fixes**
  * Fixed cache synchronization race condition when multiple conversation refreshes occur in quick succession, ensuring the latest data is always displayed.

* **Improvements**
  * Enhanced conversation state handling for tool approval workflows and improved error recovery during continuation operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-agents/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->