### PR TITLE
Wire agent bridge completions to full LLM context

### DIFF
--- a/api/api_llm_bridge.go
+++ b/api/api_llm_bridge.go
@@ -107,7 +107,7 @@ func (a *API) convertLLMBridgeRequestToInternal(bot *bots.Bot, req bridgeclient.
 	}, nil
 }
 
-// buildLLMBridgeContext builds the LLM context for bridge requests (service path).
+// buildLLMBridgeContext builds the LLM context for bridge completion requests (service and agent paths).
 func (a *API) buildLLMBridgeContext(bot *bots.Bot, req bridgeclient.CompletionRequest) (*llm.Context, error) {
 	var context *llm.Context
 	if a.contextBuilder != nil {
@@ -152,8 +152,10 @@ func (a *API) convertAgentBridgeRequestToInternal(bot *bots.Bot, req bridgeclien
 		return llm.CompletionRequest{}, err
 	}
 
-	bridgeContext := llm.NewContext()
-	bridgeContext.RequestingUser = &model.User{Id: req.UserID}
+	bridgeContext, err := a.buildLLMBridgeContext(bot, req)
+	if err != nil {
+		return llm.CompletionRequest{}, err
+	}
 	if includeTools && a.contextBuilder != nil {
 		a.contextBuilder.WithLLMContextTools(bot)(bridgeContext)
 	}

--- a/api/api_llm_bridge_test.go
+++ b/api/api_llm_bridge_test.go
@@ -1678,6 +1678,80 @@ func TestPrepareAgentBridgeCompletionAllowedToolsRequiresUserID(t *testing.T) {
 	require.Contains(t, err.Error(), "allowed_tools requires user_id")
 }
 
+func TestPrepareAgentBridgeCompletionIncludesAgentCustomInstructions(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	const custom = "Use formal tone in every reply."
+
+	t.Run("without_allowed_tools", func(t *testing.T) {
+		e := SetupTestEnvironment(t)
+		defer e.Cleanup(t)
+
+		botConfig := llm.BotConfig{
+			Name:               "testbot",
+			DisplayName:        "Test Bot",
+			UserAccessLevel:    llm.UserAccessLevelAll,
+			CustomInstructions: custom,
+		}
+		e.setupTestBot(botConfig)
+
+		_, llmRequest, _, _, _, statusCode, err := e.api.prepareAgentBridgeCompletion(
+			testBotUserID,
+			bridgeclient.CompletionRequest{
+				Posts: []bridgeclient.Post{
+					{Role: "user", Message: "Hi"},
+				},
+				UserID: testUserID,
+			},
+			"",
+			llm.OperationBridgeAgent,
+			llm.SubTypeNoStream,
+		)
+		require.NoError(t, err)
+		require.Equal(t, 0, statusCode)
+		require.NotNil(t, llmRequest.Context)
+		require.Equal(t, custom, llmRequest.Context.CustomInstructions)
+		require.Equal(t, "Test Bot", llmRequest.Context.BotName)
+		require.Equal(t, "testbot", llmRequest.Context.BotUsername)
+	})
+
+	t.Run("with_allowed_tools", func(t *testing.T) {
+		e := SetupTestEnvironment(t)
+		defer e.Cleanup(t)
+
+		server := e.setupMCPWithEligibleTools(t, []string{"eligible_tool"})
+		defer server.Close()
+
+		botConfig := llm.BotConfig{
+			Name:               "testbot",
+			DisplayName:        "Test Bot",
+			UserAccessLevel:    llm.UserAccessLevelAll,
+			CustomInstructions: custom,
+		}
+		e.setupTestBot(botConfig)
+
+		_, llmRequest, _, _, _, statusCode, err := e.api.prepareAgentBridgeCompletion(
+			testBotUserID,
+			bridgeclient.CompletionRequest{
+				Posts: []bridgeclient.Post{
+					{Role: "user", Message: "Hi"},
+				},
+				UserID:       testUserID,
+				AllowedTools: []string{"eligible_tool"},
+			},
+			"",
+			llm.OperationBridgeAgent,
+			llm.SubTypeNoStream,
+		)
+		require.NoError(t, err)
+		require.Equal(t, 0, statusCode)
+		require.NotNil(t, llmRequest.Context)
+		require.Equal(t, custom, llmRequest.Context.CustomInstructions)
+		require.NotNil(t, llmRequest.Context.Tools.GetTool("eligible_tool"))
+	})
+}
+
 func TestPrepareAgentBridgeCompletionToolHooksRequiresPluginID(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DefaultWriter = io.Discard


### PR DESCRIPTION
#### Summary

Agent bridge completion handlers now reuse `buildLLMBridgeContext` when converting requests, so the same LLM context enrichment as service bridge applies: agent custom instructions, bot display fields, server metadata, and optional `channel_id` / `user_id` context reach the model (including the standard personality template).

When `allowed_tools` is set, `WithLLMContextTools` still runs after that shared context so allowlisted tools are scoped as before.

**QA:** `go test ./api/... -run TestPrepareAgentBridgeCompletionIncludesAgentCustomInstructions`. For manual checks, issue an inter-plugin agent completion and confirm the agent's custom instructions affect responses.

#### Ticket Link
N/A

#### Screenshots
N/A (backend-only change)

#### Release Note

```release-note
Fixed agent bridge completions so the selected agent's custom instructions and related bridge LLM context fields are included in requests to the model, consistent with service bridge completions.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of bridge completion requests by gracefully handling cases where channel information cannot be resolved. Requests now continue with available context instead of failing.

* **Tests**
  * Added verification tests to ensure custom instructions are properly propagated in bridge completion contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->