### PR TITLE
MM-68710: Fix native web search citations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,7 @@ Mattermost server plugin (`mattermost-ai`) that integrates LLM providers. Go 1.2
 - Lint only: `make check-style`
 - All unit tests: `make test`
 - Single Go test: `go test -v ./<pkg> -run TestName`
-- Build & deploy plugin to a running Mattermost (linux-amd64 only by default): `make deploy`
-  Set `MAKE_ALL_PLATFORMS=1` only if you're deploying to a Mac- or Windows-native server.
+- Build & deploy plugin to a running Mattermost: `make deploy`
 - E2E (self-contained, no env setup needed; slow, defer to CI when possible): `make e2e`
 - Single e2e spec: `cd e2e && npx playwright test tests/path/spec.ts --reporter=list`
 - Prompt evals (non-interactive): `make evals-ci`

--- a/Makefile
+++ b/Makefile
@@ -370,16 +370,9 @@ dist: apply server webapp bundle
 .PHONY: dist-ci
 dist-ci: apply server-ci webapp bundle
 
-## Builds and installs the plugin to a server. Builds linux-amd64 only by
-## default (the platform of most Mattermost server deployments). Set
-## MAKE_ALL_PLATFORMS=1 to build all supported OS/arch combinations — needed
-## when deploying to a Mac- or Windows-native Mattermost.
+## Builds and installs the plugin to a server.
 .PHONY: deploy
-ifeq ($(MAKE_ALL_PLATFORMS),)
-deploy: dist-ci
-else
 deploy: dist
-endif
 	./build/bin/pluginctl deploy $(PLUGIN_ID) dist/$(BUNDLE_NAME)
 
 ## Builds the MCP server binary.
@@ -589,7 +582,7 @@ help:
 	@printf "  \033[36m%-22s\033[0m %s\n" "check-style-fix" "Lint and auto-fix what's fixable; re-extracts i18n strings"
 	@printf "  \033[36m%-22s\033[0m %s\n" "test" "Run all unit tests"
 	@printf "  \033[36m%-22s\033[0m %s\n" "e2e" "Run Playwright e2e suite (slow, defer to CI when possible)"
-	@printf "  \033[36m%-22s\033[0m %s\n" "deploy" "Build linux-amd64 and deploy to a running Mattermost"
+	@printf "  \033[36m%-22s\033[0m %s\n" "deploy" "Build and deploy to a running Mattermost"
 	@printf "\nAll documented targets:\n\n"
 	@awk '/^## / { sub(/^## /, "", $$0); if (doc == "") doc=$$0; next } \
 	      /^## *$$/ { next } \

--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -32,6 +32,19 @@ const (
 	DefaultStreamingTimeout = 5 * time.Minute
 )
 
+type webSearchFallbackSource struct {
+	URL   string
+	Title string
+}
+
+type pendingAnnotationPosition struct {
+	index        int
+	missingStart bool
+	missingEnd   bool
+}
+
+const missingContentIndex = -1
+
 // LLM implements the llm.LanguageModel interface using the Bifrost gateway.
 type LLM struct {
 	client           *bifrostcore.Bifrost
@@ -1572,8 +1585,10 @@ func (b *LLM) streamResponses(ctx context.Context, request llm.CompletionRequest
 
 	// Annotation buffer and text position tracking
 	var annotations []llm.Annotation
-	var textLen int       // cumulative byte length of all streamed text
-	var blockStartPos int // byte position where current text block started
+	var fallbackSources []webSearchFallbackSource
+	pendingAnnotationPositions := make(map[int][]pendingAnnotationPosition)
+	var textLen int       // cumulative UTF-16 length of all streamed text
+	var blockStartPos int // UTF-16 position where current text block started
 
 	// Watchdog timer for streaming timeout
 	watchdog := make(chan struct{})
@@ -1644,7 +1659,7 @@ func (b *LLM) streamResponses(ctx context.Context, request llm.CompletionRequest
 						Type:  llm.EventTypeText,
 						Value: *resp.Delta,
 					}
-					textLen += len(*resp.Delta)
+					textLen += llm.UTF16CodeUnitCount(*resp.Delta)
 				}
 
 			case schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta:
@@ -1675,8 +1690,10 @@ func (b *LLM) streamResponses(ctx context.Context, request llm.CompletionRequest
 				if resp.Annotation != nil {
 					if ann := convertBifrostAnnotation(resp.Annotation, len(annotations)+1); ann != nil {
 						// Bifrost doesn't provide output-text positions during Anthropic streaming.
-						// Compute them from tracked block boundaries, matching the approach used by
-						// the old Anthropic SDK implementation (extractAnnotations).
+						// Attach those citations to the current text block and correct the end
+						// position when output_text.done arrives.
+						missingStart := resp.Annotation.StartIndex == nil
+						missingEnd := resp.Annotation.EndIndex == nil
 						if resp.Annotation.StartIndex == nil {
 							ann.StartIndex = blockStartPos
 						}
@@ -1684,6 +1701,20 @@ func (b *LLM) streamResponses(ctx context.Context, request llm.CompletionRequest
 							ann.EndIndex = textLen
 						}
 						annotations = append(annotations, *ann)
+						if missingStart || missingEnd {
+							contentIndex := missingContentIndex
+							if resp.ContentIndex != nil {
+								contentIndex = *resp.ContentIndex
+							}
+							pendingAnnotationPositions[contentIndex] = append(
+								pendingAnnotationPositions[contentIndex],
+								pendingAnnotationPosition{
+									index:        len(annotations) - 1,
+									missingStart: missingStart,
+									missingEnd:   missingEnd,
+								},
+							)
+						}
 					}
 				}
 
@@ -1694,6 +1725,15 @@ func (b *LLM) streamResponses(ctx context.Context, request llm.CompletionRequest
 				// Text block complete - emit accumulated annotations and advance block position.
 				// Keep the annotation buffer so subsequent output_text_done events can include
 				// citations accumulated across the full response.
+				if resp.ContentIndex != nil {
+					applyPendingAnnotationPositions(
+						annotations,
+						pendingAnnotationPositions[*resp.ContentIndex],
+						blockStartPos,
+						textLen,
+					)
+					delete(pendingAnnotationPositions, *resp.ContentIndex)
+				}
 				if len(annotations) > 0 {
 					output <- llm.TextStreamEvent{
 						Type:  llm.EventTypeAnnotations,
@@ -1772,6 +1812,7 @@ func (b *LLM) streamResponses(ctx context.Context, request llm.CompletionRequest
 				}
 
 			case schemas.ResponsesStreamResponseTypeOutputItemDone:
+				fallbackSources = appendFirstWebSearchFallbackSource(fallbackSources, resp.Item)
 				// Output item completed - finalize function call if any
 				if resp.Item != nil && resp.Item.Type != nil {
 					if *resp.Item.Type == schemas.ResponsesMessageTypeFunctionCall && resp.Item.ResponsesToolMessage != nil {
@@ -1808,6 +1849,13 @@ func (b *LLM) streamResponses(ctx context.Context, request llm.CompletionRequest
 				}
 
 				// Emit any accumulated annotations
+				for contentIndex, positions := range pendingAnnotationPositions {
+					applyPendingAnnotationPositions(annotations, positions, blockStartPos, textLen)
+					delete(pendingAnnotationPositions, contentIndex)
+				}
+				if len(annotations) == 0 && len(fallbackSources) > 0 {
+					annotations = buildFallbackAnnotations(fallbackSources, textLen)
+				}
 				if len(annotations) > 0 {
 					output <- llm.TextStreamEvent{
 						Type:  llm.EventTypeAnnotations,
@@ -1928,4 +1976,68 @@ func convertBifrostAnnotation(ann *schemas.ResponsesOutputMessageContentTextAnno
 	}
 
 	return result
+}
+
+func appendFirstWebSearchFallbackSource(sources []webSearchFallbackSource, item *schemas.ResponsesMessage) []webSearchFallbackSource {
+	if item == nil || item.Type == nil || *item.Type != schemas.ResponsesMessageTypeWebSearchCall {
+		return sources
+	}
+	if item.ResponsesToolMessage == nil ||
+		item.ResponsesToolMessage.Action == nil ||
+		item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction == nil {
+		return sources
+	}
+
+	for _, source := range item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Sources {
+		if source.URL == "" || hasFallbackSource(sources, source.URL) {
+			continue
+		}
+		title := ""
+		if source.Title != nil {
+			title = *source.Title
+		}
+		return append(sources, webSearchFallbackSource{
+			URL:   source.URL,
+			Title: title,
+		})
+	}
+	return sources
+}
+
+func hasFallbackSource(sources []webSearchFallbackSource, url string) bool {
+	for _, source := range sources {
+		if source.URL == url {
+			return true
+		}
+	}
+	return false
+}
+
+func buildFallbackAnnotations(sources []webSearchFallbackSource, endIndex int) []llm.Annotation {
+	annotations := make([]llm.Annotation, 0, len(sources))
+	for i, source := range sources {
+		annotations = append(annotations, llm.Annotation{
+			Type:       llm.AnnotationTypeURLCitation,
+			StartIndex: endIndex,
+			EndIndex:   endIndex,
+			URL:        source.URL,
+			Title:      source.Title,
+			Index:      i + 1,
+		})
+	}
+	return annotations
+}
+
+func applyPendingAnnotationPositions(annotations []llm.Annotation, positions []pendingAnnotationPosition, startIndex, endIndex int) {
+	for _, position := range positions {
+		if position.index < 0 || position.index >= len(annotations) {
+			continue
+		}
+		if position.missingStart {
+			annotations[position.index].StartIndex = startIndex
+		}
+		if position.missingEnd {
+			annotations[position.index].EndIndex = endIndex
+		}
+	}
 }

--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -1725,15 +1725,17 @@ func (b *LLM) streamResponses(ctx context.Context, request llm.CompletionRequest
 				// Text block complete - emit accumulated annotations and advance block position.
 				// Keep the annotation buffer so subsequent output_text_done events can include
 				// citations accumulated across the full response.
+				contentIndex := missingContentIndex
 				if resp.ContentIndex != nil {
-					applyPendingAnnotationPositions(
-						annotations,
-						pendingAnnotationPositions[*resp.ContentIndex],
-						blockStartPos,
-						textLen,
-					)
-					delete(pendingAnnotationPositions, *resp.ContentIndex)
+					contentIndex = *resp.ContentIndex
 				}
+				flushPendingAnnotationPositions(
+					annotations,
+					pendingAnnotationPositions,
+					contentIndex,
+					blockStartPos,
+					textLen,
+				)
 				if len(annotations) > 0 {
 					output <- llm.TextStreamEvent{
 						Type:  llm.EventTypeAnnotations,
@@ -1982,13 +1984,11 @@ func appendFirstWebSearchFallbackSource(sources []webSearchFallbackSource, item 
 	if item == nil || item.Type == nil || *item.Type != schemas.ResponsesMessageTypeWebSearchCall {
 		return sources
 	}
-	if item.ResponsesToolMessage == nil ||
-		item.ResponsesToolMessage.Action == nil ||
-		item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction == nil {
+	if item.Action == nil || item.Action.ResponsesWebSearchToolCallAction == nil {
 		return sources
 	}
 
-	for _, source := range item.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Sources {
+	for _, source := range item.Action.ResponsesWebSearchToolCallAction.Sources {
 		if source.URL == "" || hasFallbackSource(sources, source.URL) {
 			continue
 		}
@@ -1996,7 +1996,7 @@ func appendFirstWebSearchFallbackSource(sources []webSearchFallbackSource, item 
 		if source.Title != nil {
 			title = *source.Title
 		}
-		return append(sources, webSearchFallbackSource{
+		sources = append(sources, webSearchFallbackSource{
 			URL:   source.URL,
 			Title: title,
 		})
@@ -2040,4 +2040,13 @@ func applyPendingAnnotationPositions(annotations []llm.Annotation, positions []p
 			annotations[position.index].EndIndex = endIndex
 		}
 	}
+}
+
+func flushPendingAnnotationPositions(
+	annotations []llm.Annotation,
+	pending map[int][]pendingAnnotationPosition,
+	contentIndex, startIndex, endIndex int,
+) {
+	applyPendingAnnotationPositions(annotations, pending[contentIndex], startIndex, endIndex)
+	delete(pending, contentIndex)
 }

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -847,6 +847,97 @@ func TestConvertBifrostAnnotation(t *testing.T) {
 	}
 }
 
+func TestAppendFirstWebSearchFallbackSource(t *testing.T) {
+	sourceTitle := "Example Source"
+	item := &schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			Action: &schemas.ResponsesToolMessageActionStruct{
+				ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
+					Sources: []schemas.ResponsesWebSearchToolCallActionSearchSource{
+						{Type: "url", URL: "https://example.com/one", Title: &sourceTitle},
+						{Type: "url", URL: "https://example.com/two"},
+					},
+				},
+			},
+		},
+	}
+
+	sources := appendFirstWebSearchFallbackSource(nil, item)
+	require.Len(t, sources, 1)
+	assert.Equal(t, webSearchFallbackSource{
+		URL:   "https://example.com/one",
+		Title: "Example Source",
+	}, sources[0])
+
+	sources = appendFirstWebSearchFallbackSource(sources, item)
+	require.Len(t, sources, 2)
+	assert.Equal(t, "https://example.com/two", sources[1].URL)
+}
+
+func TestBuildFallbackAnnotations(t *testing.T) {
+	annotations := buildFallbackAnnotations([]webSearchFallbackSource{
+		{URL: "https://example.com/one", Title: "One"},
+		{URL: "https://example.com/two", Title: "Two"},
+	}, 42)
+
+	require.Len(t, annotations, 2)
+	assert.Equal(t, llm.Annotation{
+		Type:       llm.AnnotationTypeURLCitation,
+		StartIndex: 42,
+		EndIndex:   42,
+		URL:        "https://example.com/one",
+		Title:      "One",
+		Index:      1,
+	}, annotations[0])
+	assert.Equal(t, llm.Annotation{
+		Type:       llm.AnnotationTypeURLCitation,
+		StartIndex: 42,
+		EndIndex:   42,
+		URL:        "https://example.com/two",
+		Title:      "Two",
+		Index:      2,
+	}, annotations[1])
+}
+
+func TestApplyPendingAnnotationPositions(t *testing.T) {
+	annotations := []llm.Annotation{
+		{Type: llm.AnnotationTypeURLCitation, StartIndex: 0, EndIndex: 0, URL: "https://example.com/one", Index: 1},
+		{Type: llm.AnnotationTypeURLCitation, StartIndex: 5, EndIndex: 10, URL: "https://example.com/two", Index: 2},
+	}
+
+	applyPendingAnnotationPositions(annotations, []pendingAnnotationPosition{
+		{index: 0, missingStart: true, missingEnd: true},
+		{index: 1, missingEnd: true},
+	}, 20, 42)
+
+	assert.Equal(t, 20, annotations[0].StartIndex)
+	assert.Equal(t, 42, annotations[0].EndIndex)
+	assert.Equal(t, 5, annotations[1].StartIndex)
+	assert.Equal(t, 42, annotations[1].EndIndex)
+}
+
+func TestPendingAnnotationPositionsWithoutContentIndex(t *testing.T) {
+	pending := map[int][]pendingAnnotationPosition{}
+	annotations := []llm.Annotation{
+		{Type: llm.AnnotationTypeURLCitation, StartIndex: 0, EndIndex: 0, URL: "https://example.com", Index: 1},
+	}
+
+	pending[missingContentIndex] = append(pending[missingContentIndex], pendingAnnotationPosition{
+		index:        0,
+		missingStart: true,
+		missingEnd:   true,
+	})
+	for contentIndex, positions := range pending {
+		applyPendingAnnotationPositions(annotations, positions, 0, 42)
+		delete(pending, contentIndex)
+	}
+
+	assert.Empty(t, pending)
+	assert.Equal(t, 0, annotations[0].StartIndex)
+	assert.Equal(t, 42, annotations[0].EndIndex)
+}
+
 type testStructuredOutput struct {
 	Name  string `json:"name"`
 	Score int    `json:"score"`

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -864,15 +864,28 @@ func TestAppendFirstWebSearchFallbackSource(t *testing.T) {
 	}
 
 	sources := appendFirstWebSearchFallbackSource(nil, item)
-	require.Len(t, sources, 1)
+	require.Len(t, sources, 2)
 	assert.Equal(t, webSearchFallbackSource{
 		URL:   "https://example.com/one",
 		Title: "Example Source",
 	}, sources[0])
+	assert.Equal(t, webSearchFallbackSource{
+		URL:   "https://example.com/two",
+		Title: "",
+	}, sources[1])
 
 	sources = appendFirstWebSearchFallbackSource(sources, item)
 	require.Len(t, sources, 2)
-	assert.Equal(t, "https://example.com/two", sources[1].URL)
+	assert.Equal(t, []webSearchFallbackSource{
+		{
+			URL:   "https://example.com/one",
+			Title: "Example Source",
+		},
+		{
+			URL:   "https://example.com/two",
+			Title: "",
+		},
+	}, sources)
 }
 
 func TestBuildFallbackAnnotations(t *testing.T) {
@@ -928,10 +941,7 @@ func TestPendingAnnotationPositionsWithoutContentIndex(t *testing.T) {
 		missingStart: true,
 		missingEnd:   true,
 	})
-	for contentIndex, positions := range pending {
-		applyPendingAnnotationPositions(annotations, positions, 0, 42)
-		delete(pending, contentIndex)
-	}
+	flushPendingAnnotationPositions(annotations, pending, missingContentIndex, 0, 42)
 
 	assert.Empty(t, pending)
 	assert.Equal(t, 0, annotations[0].StartIndex)

--- a/telemetry/integration_test.go
+++ b/telemetry/integration_test.go
@@ -119,7 +119,9 @@ func (f *fakeLLM) CountTokens(text string) int { return len(text) / 4 }
 func (f *fakeLLM) InputTokenLimit() int        { return 100000 }
 
 // fakeLLMError simulates an LLM that produces an error span.
-type fakeLLMError struct{}
+type fakeLLMError struct {
+	wg sync.WaitGroup
+}
 
 func (f *fakeLLMError) ChatCompletion(ctx context.Context, request llm.CompletionRequest, _ ...llm.LanguageModelOption) (*llm.TextStreamResult, error) {
 	_, span := telemetry.Tracer().Start(ctx, "llm chat completion",
@@ -127,7 +129,9 @@ func (f *fakeLLMError) ChatCompletion(ctx context.Context, request llm.Completio
 	)
 
 	stream := make(chan llm.TextStreamEvent)
+	f.wg.Add(1)
 	go func() {
+		defer f.wg.Done()
 		defer close(stream)
 		defer span.End()
 
@@ -218,6 +222,7 @@ func TestLLMChatCompletionErrorSpan(t *testing.T) {
 
 	// Drain the stream (should contain the error event)
 	_, _ = result.ReadAll()
+	model.wg.Wait()
 
 	spans := exporter.GetSpans()
 	if len(spans) != 1 {

--- a/webapp/src/components/citations/citation_processor.test.tsx
+++ b/webapp/src/components/citations/citation_processor.test.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {insertAnnotationMarkers} from './citation_processor';
+import {Annotation} from './types';
+
+describe('insertAnnotationMarkers', () => {
+    it('inserts markers by end index descending', () => {
+        const annotations: Annotation[] = [
+            {
+                type: 'url_citation',
+                start_index: 0,
+                end_index: 2,
+                url: 'https://example.com/early',
+                index: 1,
+            },
+            {
+                type: 'url_citation',
+                start_index: 0,
+                end_index: 4,
+                url: 'https://example.com/late',
+                index: 2,
+            },
+        ];
+
+        expect(insertAnnotationMarkers('abcdef', annotations)).toBe('ab!!CITE1!!cd!!CITE2!!ef');
+    });
+
+    it('preserves citation order for identical insertion points', () => {
+        const annotations: Annotation[] = [
+            {
+                type: 'url_citation',
+                start_index: 6,
+                end_index: 6,
+                url: 'https://example.com/one',
+                index: 1,
+            },
+            {
+                type: 'url_citation',
+                start_index: 6,
+                end_index: 6,
+                url: 'https://example.com/two',
+                index: 2,
+            },
+        ];
+
+        expect(insertAnnotationMarkers('abcdef', annotations)).toBe('abcdef!!CITE1!!!!CITE2!!');
+    });
+});

--- a/webapp/src/components/citations/citation_processor.tsx
+++ b/webapp/src/components/citations/citation_processor.tsx
@@ -10,7 +10,15 @@ const openAICitationRegex = /\([^\s:]+\s*:\s*https?:\/\/[\S^)]*\)/g;
 
 // Insert special markers in the text that will survive markdown processing
 export function insertAnnotationMarkers(message: string, annotations: Annotation[]): string {
-    const sortedAnnotations = [...annotations].sort((a, b) => b.start_index - a.start_index);
+    const sortedAnnotations = [...annotations].sort((a, b) => {
+        if (b.end_index !== a.end_index) {
+            return b.end_index - a.end_index;
+        }
+        if (b.index !== a.index) {
+            return b.index - a.index;
+        }
+        return b.start_index - a.start_index;
+    });
     let result = message;
 
     // Insert markers from end to start to preserve indices


### PR DESCRIPTION
#### Summary
- Fixed Anthropic native web search citations when Sonnet 4.6 returns sources on web search call items instead of output text annotation events.
- Corrected citation placement by tracking streamed text offsets in UTF-16 code units and updating provider-missing annotation positions at text block completion.
- Added focused backend and frontend tests for citation fallback and marker insertion ordering.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-68710

#### Screenshots
Verified locally on http://localhost:8065 with anthropic-45 and anthropic-46. Citations now render inline near cited stock price facts instead of at the start of the response.

#### Release Note
```release-note
Fixed Anthropic native web search citations for Sonnet 4.6 and improved citation icon placement for streamed citations.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of citation/annotation positions in streamed responses using UTF-16–based tracking
  * Handles missing annotation boundaries during streaming and applies corrected positions when available
  * Synthesizes fallback URL citations from web-search tool outputs when annotations are absent
  * Adjusted client-side marker insertion ordering to preserve correct citation placement

* **Tests**
  * Added unit and component tests for citation/annotation and fallback-source behaviours

* **Documentation**
  * Clarified deploy guidance in AGENTS documentation

* **Chores**
  * Simplified deploy target to always perform a full build

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-agents/pull/736)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->