### PR TITLE
fix: preserve image data across tool rounds

### DIFF
--- a/api/api_llm_bridge.go
+++ b/api/api_llm_bridge.go
@@ -55,6 +55,13 @@ func (a *API) convertBridgePostsToInternal(req bridgeclient.CompletionRequest) (
 				if err != nil {
 					return nil, fmt.Errorf("failed to get file info for file ID %s: %w", fileID, err)
 				}
+				if !llm.IsSupportedImageMimeType(fileInfo.MimeType) {
+					files[j] = llm.File{
+						MimeType: fileInfo.MimeType,
+						Size:     fileInfo.Size,
+					}
+					continue
+				}
 
 				// Get file reader
 				fileReader, err := a.mmClient.GetFile(fileID)

--- a/api/api_llm_bridge.go
+++ b/api/api_llm_bridge.go
@@ -4,9 +4,11 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -59,11 +61,19 @@ func (a *API) convertBridgePostsToInternal(req bridgeclient.CompletionRequest) (
 				if err != nil {
 					return nil, fmt.Errorf("failed to get file for file ID %s: %w", fileID, err)
 				}
+				data, err := io.ReadAll(fileReader)
+				if closeErr := fileReader.Close(); closeErr != nil {
+					a.mmClient.LogError("failed to close bridge file reader", "error", closeErr)
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed to read file for file ID %s: %w", fileID, err)
+				}
 
 				files[j] = llm.File{
 					MimeType: fileInfo.MimeType,
 					Size:     fileInfo.Size,
-					Reader:   fileReader,
+					Data:     data,
+					Reader:   bytes.NewReader(data),
 				}
 			}
 		}

--- a/api/api_llm_bridge_test.go
+++ b/api/api_llm_bridge_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/llmcontext"
 	"github.com/mattermost/mattermost-plugin-agents/mcp"
+	mmapimocks "github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
 	"github.com/mattermost/mattermost-plugin-agents/public/bridgeclient"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
@@ -65,6 +66,33 @@ func (m *mockEmbeddedMCPServer) CreateClientTransport(userID, sessionID string, 
 }
 
 // Full-stack integration tests using bridge client → real API → fake LLM
+
+func TestConvertBridgePostsToInternalUnsupportedImageDoesNotReadFile(t *testing.T) {
+	mmClient := mmapimocks.NewMockClient(t)
+	mmClient.On("GetFileInfo", "svg1").Return(&model.FileInfo{
+		Id:       "svg1",
+		Name:     "vector.svg",
+		MimeType: "image/svg+xml",
+		Size:     1234,
+	}, nil)
+
+	api := &API{mmClient: mmClient}
+	posts, err := api.convertBridgePostsToInternal(bridgeclient.CompletionRequest{
+		Posts: []bridgeclient.Post{{
+			Role:    "user",
+			Message: "see attached",
+			FileIDs: []string{"svg1"},
+		}},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, posts, 1)
+	require.Len(t, posts[0].Files, 1)
+	mmClient.AssertNotCalled(t, "GetFile", "svg1")
+	require.Equal(t, "image/svg+xml", posts[0].Files[0].MimeType)
+	require.Empty(t, posts[0].Files[0].Data)
+	require.Nil(t, posts[0].Files[0].Reader)
+}
 
 func TestBridgeClientAgentCompletion(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)

--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -1220,13 +1220,7 @@ func buildResponsesTextConfig(schema *jsonschema.Schema) (*schemas.ResponsesText
 
 // isValidImageType checks if the MIME type is supported.
 func isValidImageType(mimeType string) bool {
-	validTypes := map[string]bool{
-		"image/jpeg": true,
-		"image/png":  true,
-		"image/gif":  true,
-		"image/webp": true,
-	}
-	return validTypes[mimeType]
+	return llm.IsSupportedImageMimeType(mimeType)
 }
 
 // Ptr is a helper function to create a pointer to a value.

--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -201,6 +201,16 @@ func toolArgsToJSON(s string) json.RawMessage {
 	return json.RawMessage(s)
 }
 
+func readFileData(file llm.File) ([]byte, error) {
+	if len(file.Data) > 0 {
+		return file.Data, nil
+	}
+	if file.Reader == nil {
+		return nil, fmt.Errorf("file reader is nil")
+	}
+	return io.ReadAll(file.Reader)
+}
+
 // New creates a new LLM instance with the given configuration.
 func New(cfg Config) (*LLM, error) {
 	account := &providerAccount{
@@ -1054,7 +1064,7 @@ func (b *LLM) createMultimodalContent(post llm.Post) []schemas.ChatContentBlock 
 			continue
 		}
 
-		data, err := io.ReadAll(file.Reader)
+		data, err := readFileData(file)
 		if err != nil {
 			parts = append(parts, schemas.ChatContentBlock{
 				Type: schemas.ChatContentBlockTypeText,
@@ -1355,7 +1365,7 @@ func (b *LLM) createResponsesMultimodalContent(post llm.Post) []schemas.Response
 			continue
 		}
 
-		data, err := io.ReadAll(file.Reader)
+		data, err := readFileData(file)
 		if err != nil {
 			parts = append(parts, schemas.ResponsesMessageContentBlock{
 				Type: schemas.ResponsesInputMessageContentBlockTypeText,

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -4,6 +4,7 @@
 package bifrost
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -186,6 +187,31 @@ func TestBuildChatReasoning(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateMultimodalContentUsesReusableFileData(t *testing.T) {
+	b := &LLM{}
+	imageData := []byte("PNGDATA")
+	post := llm.Post{
+		Role:    llm.PostRoleUser,
+		Message: "look at this",
+		Files: []llm.File{{
+			MimeType: "image/png",
+			Size:     int64(len(imageData)),
+			Data:     imageData,
+			Reader:   bytes.NewReader(imageData),
+		}},
+	}
+
+	first := b.createMultimodalContent(post)
+	second := b.createMultimodalContent(post)
+
+	require.Len(t, first, 2)
+	require.Len(t, second, 2)
+	require.NotNil(t, first[1].ImageURLStruct)
+	require.NotNil(t, second[1].ImageURLStruct)
+	assert.Equal(t, first[1].ImageURLStruct.URL, second[1].ImageURLStruct.URL)
+	assert.Contains(t, second[1].ImageURLStruct.URL, "UE5HREFUQQ==")
 }
 
 // TestConvertToBifrostRequestOpus47Reasoning verifies that when our

--- a/conversation/convert.go
+++ b/conversation/convert.go
@@ -4,6 +4,7 @@
 package conversation
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"strings"
@@ -110,10 +111,19 @@ func BlocksToPost(
 				mmClient.LogError("failed to get file for image attachment", "error", err)
 				continue
 			}
+			data, err := io.ReadAll(reader)
+			if closeErr := reader.Close(); closeErr != nil {
+				mmClient.LogError("failed to close image attachment reader", "error", closeErr)
+			}
+			if err != nil {
+				mmClient.LogError("failed to read image attachment", "error", err)
+				continue
+			}
 			post.Files = append(post.Files, llm.File{
 				MimeType: fileInfo.MimeType,
 				Size:     fileInfo.Size,
-				Reader:   reader,
+				Data:     data,
+				Reader:   bytes.NewReader(data),
 			})
 
 		case BlockTypeFile:

--- a/conversation/convert.go
+++ b/conversation/convert.go
@@ -106,6 +106,13 @@ func BlocksToPost(
 				mmClient.LogError("failed to get file info for image attachment", "error", err)
 				continue
 			}
+			if !llm.IsSupportedImageMimeType(fileInfo.MimeType) {
+				post.Files = append(post.Files, llm.File{
+					MimeType: fileInfo.MimeType,
+					Size:     fileInfo.Size,
+				})
+				continue
+			}
 			reader, err := mmClient.GetFile(block.FileID)
 			if err != nil {
 				mmClient.LogError("failed to get file for image attachment", "error", err)

--- a/conversation/convert_test.go
+++ b/conversation/convert_test.go
@@ -524,6 +524,28 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 		assert.Empty(t, post.Files, "image block must be silently dropped when vision is disabled")
 	})
 
+	t.Run("unsupported image MIME is passed through without reading blob", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
+			Id:       "img1",
+			Name:     "vector.svg",
+			MimeType: "image/svg+xml",
+			Size:     1234,
+		}, nil)
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeImage, FileID: "img1", Filename: "vector.svg", MimeType: "image/svg+xml"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		require.Len(t, post.Files, 1)
+		mmClient.AssertNotCalled(t, "GetFile", "img1")
+		assert.Equal(t, "image/svg+xml", post.Files[0].MimeType)
+		assert.Empty(t, post.Files[0].Data)
+		assert.Nil(t, post.Files[0].Reader)
+	})
+
 	t.Run("text/plain file block reads content via GetFile and appends Attached File Contents", func(t *testing.T) {
 		mmClient := mmapimocks.NewMockClient(t)
 		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{

--- a/conversation/convert_test.go
+++ b/conversation/convert_test.go
@@ -498,6 +498,7 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 		require.Len(t, post.Files, 1, "an image block with vision enabled must produce exactly one entry in Post.Files")
 		assert.Equal(t, "image/png", post.Files[0].MimeType)
 		assert.Equal(t, int64(1234), post.Files[0].Size)
+		assert.Equal(t, []byte("PNGDATA"), post.Files[0].Data)
 		require.NotNil(t, post.Files[0].Reader)
 
 		// Read the bytes back and pin them to what the mock returned.

--- a/llm/completion_request.go
+++ b/llm/completion_request.go
@@ -12,6 +12,7 @@ import (
 type File struct {
 	MimeType string
 	Size     int64
+	Data     []byte
 	Reader   io.Reader
 }
 

--- a/llm/completion_request.go
+++ b/llm/completion_request.go
@@ -16,6 +16,15 @@ type File struct {
 	Reader   io.Reader
 }
 
+func IsSupportedImageMimeType(mimeType string) bool {
+	switch mimeType {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return true
+	default:
+		return false
+	}
+}
+
 type PostRole int
 
 const (

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -677,6 +677,7 @@ func TestRunSearch(t *testing.T) {
 	t.Run("successful RunSearch returns post info", func(t *testing.T) {
 		mockEmbedding := mocks.NewMockEmbeddingSearch(t)
 		mockClient := mmapimocks.NewMockClient(t)
+		searchDone := make(chan struct{})
 
 		// First DM is for question post (synchronous)
 		mockClient.On("DM", "user1", "bot1", mock.Anything).
@@ -697,8 +698,13 @@ func TestRunSearch(t *testing.T) {
 		mockEmbedding.On("Search", mock.Anything, mock.Anything, mock.Anything).
 			Return([]embeddings.SearchResult{}, nil).Maybe()
 
-		// If zero results, UpdatePost is called
-		mockClient.On("UpdatePost", mock.Anything).Return(nil).Maybe()
+		// If zero results, UpdatePost is called. Wait for it so the async
+		// search goroutine cannot leak into following tests.
+		mockClient.On("UpdatePost", mock.Anything).
+			Run(func(_ mock.Arguments) {
+				close(searchDone)
+			}).
+			Return(nil).Once()
 
 		s := New(func() embeddings.EmbeddingSearch { return mockEmbedding }, mockClient, nil, nil, nil, nil)
 		bot := bots.NewBot(llm.BotConfig{}, llm.ServiceConfig{}, &model.Bot{UserId: "bot1"}, nil)
@@ -708,6 +714,14 @@ func TestRunSearch(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "question_post_id", result["postid"])
 		require.Equal(t, "dm_channel_id", result["channelid"])
+		require.Eventually(t, func() bool {
+			select {
+			case <-searchDone:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, 5*time.Millisecond)
 	})
 }
 


### PR DESCRIPTION
#### Summary
Fixes image attachments being consumed during the first LLM request when a tool call causes a second request with the same completion payload. Image bytes are now cached on `llm.File` and reused by Bifrost multimodal conversion so tool follow-up rounds preserve the original image data.

QA:
- `go test ./bifrost ./conversation ./api`
- Locally deployed with `MM_SERVICESETTINGS_SITEURL=http://localhost:8065 MAKE_ALL_PLATFORMS=1 make deploy`
- Reproduced the thread image + Atlassian tool-call failure before the effective deploy and confirmed the original `Only HTTPS URLs are supported` path no longer appeared after deploying the fix.

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
Fixed image attachments being lost across LLM tool-call follow-up rounds.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Files can carry in-memory contents so image data is reused consistently across repeated operations.

* **Behavioral Changes**
  * Unsupported image types are detected and left unbuffered to avoid unnecessary reads; supported images are fully buffered for reliable reuse.

* **Tests**
  * Added and extended tests to verify reusable image data, correct handling of unsupported image types, and synchronized async search behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-agents/pull/741)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->