### PR TITLE
MM-68772: fix path-scoped MCP OAuth registration

### DIFF
--- a/mcp/dcrp.go
+++ b/mcp/dcrp.go
@@ -126,8 +126,8 @@ func RegisterClient(ctx context.Context, httpClient *http.Client, registrationEn
 		return nil, fmt.Errorf("failed to read response body from %s: %w", registrationEndpoint, err)
 	}
 
-	// Check for success status (RFC 7591 requires 201 Created)
-	if resp.StatusCode == http.StatusCreated {
+	// Some authorization servers return 200 OK with a valid registration response.
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 		var registrationResp RegistrationResponse
 		if err := json.Unmarshal(responseBody, &registrationResp); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal registration response: %w", err)

--- a/mcp/dcrp_test.go
+++ b/mcp/dcrp_test.go
@@ -67,6 +67,29 @@ func TestRegisterClient_Success(t *testing.T) {
 	assert.Equal(t, "Test Client", response.ClientName)
 }
 
+func TestRegisterClient_SuccessOK(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		response := RegistrationResponse{
+			ClientID:     "client123",
+			ClientSecret: "secret456",
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	request := DefaultRegistrationRequest("https://example.com/callback", "Test Client")
+
+	response, err := RegisterClient(context.Background(), http.DefaultClient, server.URL, request, "")
+	require.NoError(t, err)
+	assert.Equal(t, "client123", response.ClientID)
+	assert.Equal(t, "secret456", response.ClientSecret)
+}
+
 func TestRegisterClient_WithInitialAccessToken(t *testing.T) {
 	// Create mock server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/mcp/dcrp_test.go
+++ b/mcp/dcrp_test.go
@@ -29,65 +29,56 @@ func TestDefaultRegistrationRequest(t *testing.T) {
 }
 
 func TestRegisterClient_Success(t *testing.T) {
-	// Create mock server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify request method and headers
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{
+			name:       "created",
+			statusCode: http.StatusCreated,
+		},
+		{
+			name:       "ok",
+			statusCode: http.StatusOK,
+		},
+	}
 
-		// Verify request body
-		var req RegistrationRequest
-		err := json.NewDecoder(r.Body).Decode(&req)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"https://example.com/callback"}, req.RedirectURIs)
-		assert.Equal(t, "Test Client", req.ClientName)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "POST", r.Method)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				assert.Equal(t, "application/json", r.Header.Get("Accept"))
 
-		// Send success response
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
+				var req RegistrationRequest
+				err := json.NewDecoder(r.Body).Decode(&req)
+				require.NoError(t, err)
+				assert.Equal(t, []string{"https://example.com/callback"}, req.RedirectURIs)
+				assert.Equal(t, "Test Client", req.ClientName)
 
-		response := RegistrationResponse{
-			ClientID:     "client123",
-			ClientSecret: "secret456",
-			RedirectURIs: req.RedirectURIs,
-			ClientName:   req.ClientName,
-		}
-		_ = json.NewEncoder(w).Encode(response)
-	}))
-	defer server.Close()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
 
-	request := DefaultRegistrationRequest("https://example.com/callback", "Test Client")
+				response := RegistrationResponse{
+					ClientID:     "client123",
+					ClientSecret: "secret456",
+					RedirectURIs: req.RedirectURIs,
+					ClientName:   req.ClientName,
+				}
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
 
-	response, err := RegisterClient(context.Background(), http.DefaultClient, server.URL, request, "")
-	require.NoError(t, err)
-	assert.Equal(t, "client123", response.ClientID)
-	assert.Equal(t, "secret456", response.ClientSecret)
-	assert.Equal(t, []string{"https://example.com/callback"}, response.RedirectURIs)
-	assert.Equal(t, "Test Client", response.ClientName)
-}
+			request := DefaultRegistrationRequest("https://example.com/callback", "Test Client")
 
-func TestRegisterClient_SuccessOK(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-
-		response := RegistrationResponse{
-			ClientID:     "client123",
-			ClientSecret: "secret456",
-		}
-		_ = json.NewEncoder(w).Encode(response)
-	}))
-	defer server.Close()
-
-	request := DefaultRegistrationRequest("https://example.com/callback", "Test Client")
-
-	response, err := RegisterClient(context.Background(), http.DefaultClient, server.URL, request, "")
-	require.NoError(t, err)
-	assert.Equal(t, "client123", response.ClientID)
-	assert.Equal(t, "secret456", response.ClientSecret)
+			response, err := RegisterClient(context.Background(), http.DefaultClient, server.URL, request, "")
+			require.NoError(t, err)
+			assert.Equal(t, "client123", response.ClientID)
+			assert.Equal(t, "secret456", response.ClientSecret)
+			assert.Equal(t, []string{"https://example.com/callback"}, response.RedirectURIs)
+			assert.Equal(t, "Test Client", response.ClientName)
+		})
+	}
 }
 
 func TestRegisterClient_WithInitialAccessToken(t *testing.T) {

--- a/mcp/oauth_manager.go
+++ b/mcp/oauth_manager.go
@@ -96,7 +96,7 @@ type StaticOAuthCredentials struct {
 
 // loadOrCreateClientCredentials gets existing client credentials or creates new ones using dynamic client registration.
 // If staticCreds is non-nil and has a ClientID, those credentials are used directly (skipping DCR).
-func (m *OAuthManager) loadOrCreateClientCredentials(ctx context.Context, serverURL string, staticCreds *StaticOAuthCredentials) (*ClientCredentials, error) {
+func (m *OAuthManager) loadOrCreateClientCredentials(ctx context.Context, serverURL string, staticCreds *StaticOAuthCredentials, registrationEndpoint string) (*ClientCredentials, error) {
 	if staticCreds != nil && staticCreds.ClientID != "" {
 		return &ClientCredentials{
 			ClientID:     staticCreds.ClientID,
@@ -115,8 +115,17 @@ func (m *OAuthManager) loadOrCreateClientCredentials(ctx context.Context, server
 		return creds, nil
 	}
 
-	// Perform complete client registration flow
-	response, err := DiscoverAndRegisterClient(ctx, m.httpClient, serverURL, m.callbackURL, clientID, "")
+	var response *RegistrationResponse
+	if registrationEndpoint != "" {
+		request := DefaultRegistrationRequest(m.callbackURL, clientID)
+		response, err = RegisterClient(ctx, m.httpClient, registrationEndpoint, request, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to register OAuth client with server %s (registration endpoint: %s): %w", serverURL, registrationEndpoint, err)
+		}
+	} else {
+		// Perform complete client registration flow
+		response, err = DiscoverAndRegisterClient(ctx, m.httpClient, serverURL, m.callbackURL, clientID, "")
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -149,6 +158,7 @@ func (m *OAuthManager) createOAuthConfig(ctx context.Context, serverURL, metadat
 	authURL := baseURL + "/authorize" // Fallback
 	tokenURL := baseURL + "/token"    // Fallback
 	authServerURL := baseURL          // Fallback - per MCP spec, auth server is at base URL (path stripped)
+	registrationEndpoint := ""
 	var scopes []string
 
 	// Attempt discovery (best effort, fall back to hardcoded endpoints if it fails).
@@ -164,6 +174,7 @@ func (m *OAuthManager) createOAuthConfig(ctx context.Context, serverURL, metadat
 				tokenURL = authMetadata.TokenEndpoint
 				// Per OAuth best practices, credentials are registered with the authorization server
 				authServerURL = authServerIssuer
+				registrationEndpoint = authMetadata.RegistrationEndpoint
 			}
 		}
 	} else {
@@ -174,6 +185,7 @@ func (m *OAuthManager) createOAuthConfig(ctx context.Context, serverURL, metadat
 		if authMetadata, authErr := discoverAuthorizationServerMetadata(ctx, m.httpClient, baseURL); authErr == nil {
 			authURL = authMetadata.AuthorizationEndpoint
 			tokenURL = authMetadata.TokenEndpoint
+			registrationEndpoint = authMetadata.RegistrationEndpoint
 			// authServerURL already set to baseURL above
 		}
 	}
@@ -182,7 +194,7 @@ func (m *OAuthManager) createOAuthConfig(ctx context.Context, serverURL, metadat
 	// Per OAuth 2.0 best practices, client credentials are registered with and belong to
 	// the authorization server, not the protected resource.
 	// If static credentials are provided, they are used directly (skipping DCR).
-	clientCreds, err := m.loadOrCreateClientCredentials(ctx, authServerURL, staticCreds)
+	clientCreds, err := m.loadOrCreateClientCredentials(ctx, authServerURL, staticCreds, registrationEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client credentials: %w", err)
 	}

--- a/mcp/oauth_manager_test.go
+++ b/mcp/oauth_manager_test.go
@@ -149,7 +149,7 @@ func TestLoadOrCreateClientCredentials_ExistingCredentials(t *testing.T) {
 	}).Return(nil)
 
 	ctx := context.Background()
-	creds, err := manager.loadOrCreateClientCredentials(ctx, serverURL, nil)
+	creds, err := manager.loadOrCreateClientCredentials(ctx, serverURL, nil, "")
 
 	require.NoError(t, err)
 	require.NotNil(t, creds)
@@ -168,7 +168,7 @@ func TestLoadOrCreateClientCredentials_StaticCredentials(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	creds, err := manager.loadOrCreateClientCredentials(ctx, serverURL, staticCreds)
+	creds, err := manager.loadOrCreateClientCredentials(ctx, serverURL, staticCreds, "")
 
 	require.NoError(t, err)
 	require.NotNil(t, creds)
@@ -187,7 +187,7 @@ func TestLoadOrCreateClientCredentials_StaticCredentialsSkipKVStore(t *testing.T
 	}
 
 	ctx := context.Background()
-	creds, err := manager.loadOrCreateClientCredentials(ctx, serverURL, staticCreds)
+	creds, err := manager.loadOrCreateClientCredentials(ctx, serverURL, staticCreds, "")
 
 	require.NoError(t, err)
 	require.NotNil(t, creds)
@@ -213,7 +213,7 @@ func TestLoadOrCreateClientCredentials_NilStaticCredsFallsBackToKVStore(t *testi
 	}).Return(nil)
 
 	ctx := context.Background()
-	creds, err := manager.loadOrCreateClientCredentials(ctx, serverURL, nil)
+	creds, err := manager.loadOrCreateClientCredentials(ctx, serverURL, nil, "")
 
 	require.NoError(t, err)
 	require.NotNil(t, creds)
@@ -239,7 +239,7 @@ func TestLoadOrCreateClientCredentials_EmptyStaticCredsFallsBackToKVStore(t *tes
 	}).Return(nil)
 
 	ctx := context.Background()
-	creds, err := manager.loadOrCreateClientCredentials(ctx, serverURL, &StaticOAuthCredentials{})
+	creds, err := manager.loadOrCreateClientCredentials(ctx, serverURL, &StaticOAuthCredentials{}, "")
 
 	require.NoError(t, err)
 	require.NotNil(t, creds)
@@ -285,6 +285,60 @@ func TestCreateOAuthConfig_FallbackStripsPathFromServerURL(t *testing.T) {
 	require.Equal(t, "https://auth.example.com/authorize", config.Endpoint.AuthURL)
 	require.Equal(t, "https://auth.example.com/token", config.Endpoint.TokenURL)
 	require.Equal(t, "test-client", config.ClientID)
+}
+
+func TestCreateOAuthConfig_UsesDiscoveredRegistrationEndpoint(t *testing.T) {
+	var serverURL string
+	registrationCalled := false
+	hostMetadataCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource/mcp":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+				Resource:             serverURL + "/mcp",
+				AuthorizationServers: []string{serverURL + "/resources/res_123"},
+			})
+		case "/.well-known/oauth-authorization-server/resources/res_123":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+				Issuer:                serverURL,
+				AuthorizationEndpoint: serverURL + "/authorize",
+				TokenEndpoint:         serverURL + "/token",
+				RegistrationEndpoint:  serverURL + "/resources/res_123/register",
+			})
+		case "/resources/res_123/register":
+			registrationCalled = true
+			require.Equal(t, http.MethodPost, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(RegistrationResponse{
+				ClientID:     "registered-client",
+				ClientSecret: "registered-secret",
+			})
+		case "/.well-known/oauth-authorization-server":
+			hostMetadataCalled = true
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	manager, mockClient := setupTestOAuthManagerFull(t, nil, server.Client())
+	mockClient.On("KVGet", mock.AnythingOfType("string"), mock.AnythingOfType("*mcp.ClientCredentials")).Return(nil).Once()
+	mockClient.On("KVSet", mock.AnythingOfType("string"), mock.Anything).Return(nil).Once()
+	mockClient.On("LogDebug", mock.Anything, mock.Anything).Return().Once()
+
+	config, err := manager.createOAuthConfig(context.Background(), serverURL+"/mcp", serverURL+"/.well-known/oauth-protected-resource/mcp", nil)
+
+	require.NoError(t, err)
+	require.True(t, registrationCalled)
+	require.False(t, hostMetadataCalled)
+	require.Equal(t, "registered-client", config.ClientID)
+	require.Equal(t, serverURL+"/authorize", config.Endpoint.AuthURL)
+	require.Equal(t, serverURL+"/token", config.Endpoint.TokenURL)
 }
 
 func TestStaticCredsHelpers(t *testing.T) {


### PR DESCRIPTION
#### Summary
Fixed MCP OAuth dynamic client registration for providers that advertise path-scoped authorization issuer URLs by reusing the discovered `registration_endpoint` instead of rediscovering from a host-only URL.

Also accepts valid 2xx dynamic client registration responses, covering providers that return `200 OK` with a registration payload.

Validated with `go test ./mcp` and local Rocket Lane OAuth flow verification.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-68772

#### Screenshots
N/A

#### Release Note
```release-note
Fixed MCP OAuth dynamic client registration for servers with path-scoped authorization issuers or 200 OK registration responses.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth client registration can use discovered registration endpoints for more flexible credential creation.

* **Bug Fixes**
  * Treats any HTTP 2xx response as a successful client registration (not limited to 201 Created).

* **Tests**
  * Expanded tests cover 200 OK registration responses and verify behaviour when a discovered registration endpoint is used.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-agents/pull/745)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->