### PR TITLE
fix(bifrost): skip unsigned reasoning history

### DIFF
--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -932,8 +932,9 @@ func (b *LLM) convertMessages(posts []llm.Post) []schemas.ChatMessage {
 			// Anthropic requires historical thinking blocks to include a valid
 			// provider-issued signature. If a previous stream failed before the
 			// signature arrived, we persist partial reasoning for display only; do
-			// not replay it to the provider as an unsigned thinking block.
-			if post.Reasoning != "" && post.ReasoningSignature != "" {
+			// not replay it to Anthropic as an unsigned thinking block. Other
+			// providers may accept unsigned reasoning, so preserve it for them.
+			if post.Reasoning != "" && (b.provider != schemas.Anthropic || post.ReasoningSignature != "") {
 				if msg.ChatAssistantMessage == nil {
 					msg.ChatAssistantMessage = &schemas.ChatAssistantMessage{}
 				}

--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -928,8 +928,12 @@ func (b *LLM) convertMessages(posts []llm.Post) []schemas.ChatMessage {
 				},
 			}
 
-			// Add reasoning details for thinking-enabled conversations
-			if post.Reasoning != "" {
+			// Add reasoning details for thinking-enabled conversations.
+			// Anthropic requires historical thinking blocks to include a valid
+			// provider-issued signature. If a previous stream failed before the
+			// signature arrived, we persist partial reasoning for display only; do
+			// not replay it to the provider as an unsigned thinking block.
+			if post.Reasoning != "" && post.ReasoningSignature != "" {
 				if msg.ChatAssistantMessage == nil {
 					msg.ChatAssistantMessage = &schemas.ChatAssistantMessage{}
 				}

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -189,34 +189,54 @@ func TestBuildChatReasoning(t *testing.T) {
 	}
 }
 
-func TestConvertMessagesSkipsUnsignedReasoning(t *testing.T) {
-	b := &LLM{}
+func TestConvertMessagesReasoningDetails(t *testing.T) {
+	tests := []struct {
+		name              string
+		posts             []llm.Post
+		expectedLen       int
+		expectedReasoning string
+		expectedSignature string
+	}{
+		{
+			name: "skips unsigned reasoning",
+			posts: []llm.Post{{
+				Role:               llm.PostRoleBot,
+				Message:            "partial response",
+				Reasoning:          "partial thinking captured before stream error",
+				ReasoningSignature: "",
+			}},
+			expectedLen: 1,
+		},
+		{
+			name: "includes signed reasoning",
+			posts: []llm.Post{{
+				Role:               llm.PostRoleBot,
+				Message:            "response",
+				Reasoning:          "thinking",
+				ReasoningSignature: "sig123",
+			}},
+			expectedLen:       1,
+			expectedReasoning: "thinking",
+			expectedSignature: "sig123",
+		},
+	}
 
-	messages := b.convertMessages([]llm.Post{{
-		Role:               llm.PostRoleBot,
-		Message:            "partial response",
-		Reasoning:          "partial thinking captured before stream error",
-		ReasoningSignature: "",
-	}})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &LLM{}
 
-	require.Len(t, messages, 1)
-	assert.Nil(t, messages[0].ChatAssistantMessage)
-}
+			messages := b.convertMessages(tt.posts)
 
-func TestConvertMessagesIncludesSignedReasoning(t *testing.T) {
-	b := &LLM{}
-
-	messages := b.convertMessages([]llm.Post{{
-		Role:               llm.PostRoleBot,
-		Message:            "response",
-		Reasoning:          "thinking",
-		ReasoningSignature: "sig123",
-	}})
-
-	require.Len(t, messages, 1)
-	require.Len(t, messages[0].ReasoningDetails, 1)
-	assert.Equal(t, "thinking", *messages[0].ReasoningDetails[0].Text)
-	assert.Equal(t, "sig123", *messages[0].ReasoningDetails[0].Signature)
+			require.Len(t, messages, tt.expectedLen)
+			if tt.expectedReasoning == "" {
+				assert.Nil(t, messages[0].ChatAssistantMessage)
+				return
+			}
+			require.Len(t, messages[0].ReasoningDetails, 1)
+			assert.Equal(t, tt.expectedReasoning, *messages[0].ReasoningDetails[0].Text)
+			assert.Equal(t, tt.expectedSignature, *messages[0].ReasoningDetails[0].Signature)
+		})
+	}
 }
 
 func TestCreateMultimodalContentUsesReusableFileData(t *testing.T) {

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -192,13 +192,15 @@ func TestBuildChatReasoning(t *testing.T) {
 func TestConvertMessagesReasoningDetails(t *testing.T) {
 	tests := []struct {
 		name              string
+		provider          schemas.ModelProvider
 		posts             []llm.Post
 		expectedLen       int
 		expectedReasoning string
 		expectedSignature string
 	}{
 		{
-			name: "skips unsigned reasoning",
+			name:     "skips unsigned reasoning for Anthropic",
+			provider: schemas.Anthropic,
 			posts: []llm.Post{{
 				Role:               llm.PostRoleBot,
 				Message:            "partial response",
@@ -208,7 +210,20 @@ func TestConvertMessagesReasoningDetails(t *testing.T) {
 			expectedLen: 1,
 		},
 		{
-			name: "includes signed reasoning",
+			name:     "preserves unsigned reasoning for non-Anthropic",
+			provider: schemas.OpenAI,
+			posts: []llm.Post{{
+				Role:               llm.PostRoleBot,
+				Message:            "partial response",
+				Reasoning:          "partial thinking",
+				ReasoningSignature: "",
+			}},
+			expectedLen:       1,
+			expectedReasoning: "partial thinking",
+		},
+		{
+			name:     "includes signed reasoning",
+			provider: schemas.Anthropic,
 			posts: []llm.Post{{
 				Role:               llm.PostRoleBot,
 				Message:            "response",
@@ -223,7 +238,7 @@ func TestConvertMessagesReasoningDetails(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := &LLM{}
+			b := &LLM{provider: tt.provider}
 
 			messages := b.convertMessages(tt.posts)
 

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -189,6 +189,36 @@ func TestBuildChatReasoning(t *testing.T) {
 	}
 }
 
+func TestConvertMessagesSkipsUnsignedReasoning(t *testing.T) {
+	b := &LLM{}
+
+	messages := b.convertMessages([]llm.Post{{
+		Role:               llm.PostRoleBot,
+		Message:            "partial response",
+		Reasoning:          "partial thinking captured before stream error",
+		ReasoningSignature: "",
+	}})
+
+	require.Len(t, messages, 1)
+	assert.Nil(t, messages[0].ChatAssistantMessage)
+}
+
+func TestConvertMessagesIncludesSignedReasoning(t *testing.T) {
+	b := &LLM{}
+
+	messages := b.convertMessages([]llm.Post{{
+		Role:               llm.PostRoleBot,
+		Message:            "response",
+		Reasoning:          "thinking",
+		ReasoningSignature: "sig123",
+	}})
+
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].ReasoningDetails, 1)
+	assert.Equal(t, "thinking", *messages[0].ReasoningDetails[0].Text)
+	assert.Equal(t, "sig123", *messages[0].ReasoningDetails[0].Signature)
+}
+
 func TestCreateMultimodalContentUsesReusableFileData(t *testing.T) {
 	b := &LLM{}
 	imageData := []byte("PNGDATA")


### PR DESCRIPTION
#### Summary
when working with the Playbook's MCP, I run consistently onto an error about the response not being signed.

```
{"timestamp":"2026-05-15 16:27:54.237 +02:00","level":"error","msg":"Streaming result to post failed partway","caller":"app/plugin_api.go:1148","plugin_id":"mattermost-ai","error":"bifrost error: messages.1.content.4: Invalid `signature` in `thinking` block"}
```

Digged a bit with the agent and this is the result:

 ### What happened

 Some models return “thinking” / reasoning content. For Anthropic, historical thinking blocks are special: if we send previous thinking back to the model, Anthropic
 expects that thinking block to include a valid provider-issued signature.

 The plugin stores reasoning like this internally:

 ```go
   llm.Post{
       Reasoning: "some thinking text",
       ReasoningSignature: "provider signature",
   }
 ```

 But if streaming fails partway through, we may have partial reasoning text without the final signature. The plugin stores that partial reasoning so the UI can show
 what was generated before the failure.

 The bug was that later, during a tool-result follow-up, we rebuilt the conversation and sent that partial unsigned reasoning back to the LLM as if it were a valid
 Anthropic thinking block.

 Anthropic rejected it:

 ```text
   Invalid `signature` in `thinking` block
 ```

#### Screenshots
<img width="982" height="166" alt="CleanShot 2026-05-15 at 16 52 12@2x" src="https://github.com/user-attachments/assets/95700689-12dd-4f08-ac8e-9e3e9c6a7a8a" />

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
skip unsigned reasoning history
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened conversion so assistant reasoning details are attached only when both reasoning text and a provider-issued signature are present, preventing unsigned partial reasoning from being replayed.

* **Tests**
  * Added unit tests covering signed vs unsigned reasoning scenarios to ensure correct handling across provider types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-agents/pull/748)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->