### PR TITLE
fix: serialize concurrent embedding writes per post_id

### DIFF
--- a/indexer/indexer_job.go
+++ b/indexer/indexer_job.go
@@ -489,8 +489,7 @@ func (s *Indexer) runCatchUpPass(ctx context.Context, jobStatus *JobStatus, sear
 	lastID := ""
 
 	for {
-		// Skip posts the live hook has already indexed, so catch-up
-		// doesn't redo their embeddings.
+		// Skip posts the live hook has already indexed so catch-up doesn't redo them.
 		query := `SELECT
 			Posts.Id as id,
 			Posts.Message as message,

--- a/indexer/indexer_job.go
+++ b/indexer/indexer_job.go
@@ -489,7 +489,8 @@ func (s *Indexer) runCatchUpPass(ctx context.Context, jobStatus *JobStatus, sear
 	lastID := ""
 
 	for {
-		// Query posts created after the cutoff
+		// Skip posts the live hook has already indexed, so catch-up
+		// doesn't redo their embeddings.
 		query := `SELECT
 			Posts.Id as id,
 			Posts.Message as message,
@@ -507,6 +508,9 @@ func (s *Indexer) runCatchUpPass(ctx context.Context, jobStatus *JobStatus, sear
 			AND Posts.Type = ''
 			AND (Posts.CreateAt, Posts.Id) > ($1, $2)
 			AND Posts.CreateAt <= $3
+			AND NOT EXISTS (
+				SELECT 1 FROM llm_posts_embeddings e WHERE e.post_id = Posts.Id
+			)
 		ORDER BY Posts.CreateAt ASC, Posts.Id ASC
 		LIMIT $4`
 

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -3707,3 +3707,104 @@ func TestSaveJobStatusPreservesCancelRequested(t *testing.T) {
 	assert.Equal(t, JobStatusCancelRequested, worker.Status,
 		"saveJobStatus must propagate cancel_requested to the worker's local status so it observes the cancel on the next loop iteration")
 }
+
+// TestCatchUpPassSkipsAlreadyIndexedPosts verifies the catch-up SELECT
+// excludes posts already present in llm_posts_embeddings.
+func TestCatchUpPassSkipsAlreadyIndexedPosts(t *testing.T) {
+	type seedPost struct {
+		id      string
+		offset  int64
+		indexed bool
+	}
+	cases := []struct {
+		name              string
+		seed              []seedPost
+		expectedStoredIDs []string
+	}{
+		{
+			// Interleaved timestamps so the cursor would advance through
+			// both sets in a single page absent the NOT EXISTS filter.
+			name: "mixed indexed and unseen",
+			seed: []seedPost{
+				{"indexed-1", 100, true},
+				{"unseen-1", 200, false},
+				{"indexed-2", 300, true},
+				{"unseen-2", 400, false},
+			},
+			expectedStoredIDs: []string{"unseen-1", "unseen-2"},
+		},
+		{
+			name: "all posts already indexed",
+			seed: []seedPost{
+				{"already-1", 100, true},
+				{"already-2", 200, true},
+				{"already-3", 300, true},
+				{"already-4", 400, true},
+			},
+			expectedStoredIDs: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := testDB(t)
+			defer cleanupDB(t, db)
+
+			mockClient := mocks.NewMockClient(t)
+			mockSearch := embeddingsmocks.NewMockEmbeddingSearch(t)
+			mockBots := &bots.MMBots{}
+
+			_, err := db.Exec("INSERT INTO Channels (Id, Type, Name, TeamId) VALUES ('channel1', 'O', 'town-square', 'team1')")
+			require.NoError(t, err)
+
+			cutoffTime := model.GetMillis() - 5000
+
+			for _, p := range tc.seed {
+				_, err = db.Exec(
+					"INSERT INTO Posts (Id, CreateAt, DeleteAt, Message, Type, ChannelId, UserId) VALUES ($1, $2, 0, $3, '', 'channel1', 'user1')",
+					p.id, cutoffTime+p.offset, "content for "+p.id)
+				require.NoError(t, err)
+				if p.indexed {
+					_, err = db.Exec(
+						"INSERT INTO llm_posts_embeddings (id, post_id, content, embedding) VALUES ($1, $1, $2, '[0.1, 0.2, 0.3]')",
+						p.id, "live-hook content for "+p.id)
+					require.NoError(t, err)
+				}
+			}
+
+			var storedPostIDs []string
+			if len(tc.expectedStoredIDs) > 0 {
+				mockSearch.On("Store", mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						docs := args.Get(1).([]embeddings.PostDocument)
+						for _, doc := range docs {
+							storedPostIDs = append(storedPostIDs, doc.PostID)
+						}
+					}).
+					Return(nil).Once()
+			}
+			// When expectedStoredIDs is empty, no Store expectation is set;
+			// a Store call would fail the test with "unexpected call".
+
+			mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+			mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
+			mockClient.On("KVCompareAndSet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
+			mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
+			mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
+			mockClient.On("LogError", mock.Anything, mock.Anything).Return().Maybe()
+
+			indexer := New(func() embeddings.EmbeddingSearch { return mockSearch }, nil, mockClient, mockBots, db, nil)
+
+			jobStatus := &JobStatus{
+				Status:    JobStatusRunning,
+				StartedAt: time.Now(),
+				CutoffAt:  cutoffTime,
+			}
+
+			count, _, err := indexer.runCatchUpPass(context.Background(), jobStatus, mockSearch)
+			require.NoError(t, err)
+			assert.Equal(t, int64(len(tc.expectedStoredIDs)), count)
+			assert.ElementsMatch(t, tc.expectedStoredIDs, storedPostIDs)
+		})
+	}
+}

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -3708,8 +3708,6 @@ func TestSaveJobStatusPreservesCancelRequested(t *testing.T) {
 		"saveJobStatus must propagate cancel_requested to the worker's local status so it observes the cancel on the next loop iteration")
 }
 
-// TestCatchUpPassSkipsAlreadyIndexedPosts verifies the catch-up SELECT
-// excludes posts already present in llm_posts_embeddings.
 func TestCatchUpPassSkipsAlreadyIndexedPosts(t *testing.T) {
 	type seedPost struct {
 		id      string
@@ -3722,7 +3720,7 @@ func TestCatchUpPassSkipsAlreadyIndexedPosts(t *testing.T) {
 		expectedStoredIDs []string
 	}{
 		{
-			// Interleaved timestamps so the cursor would advance through
+			// Interleaved timestamps so the keyset cursor would pass through
 			// both sets in a single page absent the NOT EXISTS filter.
 			name: "mixed indexed and unseen",
 			seed: []seedPost{
@@ -3783,8 +3781,8 @@ func TestCatchUpPassSkipsAlreadyIndexedPosts(t *testing.T) {
 					}).
 					Return(nil).Once()
 			}
-			// When expectedStoredIDs is empty, no Store expectation is set;
-			// a Store call would fail the test with "unexpected call".
+			// No Store expectation when expectedStoredIDs is empty — an
+			// unexpected Store call will then fail the test.
 
 			mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
 			mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()

--- a/postgres/pgvector.go
+++ b/postgres/pgvector.go
@@ -347,44 +347,19 @@ func scanSearchResults(rows *sqlx.Rows, minScore float32) ([]embeddings.SearchRe
 }
 
 func (pv *PGVector) Delete(ctx context.Context, postIDs []string) error {
-	if len(postIDs) == 0 {
-		return nil
-	}
-
-	seen := make(map[string]struct{}, len(postIDs))
-	for _, id := range postIDs {
-		seen[id] = struct{}{}
-	}
-	sortedIDs := make([]string, 0, len(seen))
-	for id := range seen {
-		sortedIDs = append(sortedIDs, id)
-	}
-	slices.Sort(sortedIDs)
-
-	tx, err := pv.db.BeginTxx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-
-	// Lock so an in-flight Store for the same post commits before we delete,
-	// preventing it from resurrecting rows for a now-deleted post.
-	if lockErr := lockPostIDs(ctx, tx, sortedIDs); lockErr != nil {
-		return lockErr
-	}
-
 	query, args, err := sq.
 		Delete("llm_posts_embeddings").
-		Where(sq.Eq{"post_id": sortedIDs}).
+		Where(sq.Eq{"post_id": postIDs}).
 		PlaceholderFormat(sq.Dollar).
 		ToSql()
 	if err != nil {
 		return fmt.Errorf("failed to create query: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+	_, err = pv.db.ExecContext(ctx, query, args...)
+	if err != nil {
 		return fmt.Errorf("failed to delete vectors: %w", err)
 	}
-	return tx.Commit()
+	return nil
 }
 
 func (pv *PGVector) Clear(ctx context.Context) error {

--- a/postgres/pgvector.go
+++ b/postgres/pgvector.go
@@ -123,8 +123,8 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 	}
 
 	// Drop any prior rows for these posts so chunk-count shrinks don't leave
-	// orphans. ON CONFLICT below is a safety net for callers that bypass the
-	// lock.
+	// orphans. ON CONFLICT DO NOTHING below preserves existing rows if any
+	// caller ever bypasses the advisory lock.
 	deleteQuery, deleteArgs, err := sq.
 		Delete("llm_posts_embeddings").
 		Where(sq.Eq{"post_id": postIDs}).
@@ -151,17 +151,7 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 				:id, :post_id, :team_id, :channel_id, :user_id, :content, :embedding, :created_at,
 				:is_chunk, :chunk_index, :total_chunks
 			)
-			ON CONFLICT (id) DO UPDATE SET
-				post_id = EXCLUDED.post_id,
-				team_id = EXCLUDED.team_id,
-				channel_id = EXCLUDED.channel_id,
-				user_id = EXCLUDED.user_id,
-				content = EXCLUDED.content,
-				embedding = EXCLUDED.embedding,
-				created_at = EXCLUDED.created_at,
-				is_chunk = EXCLUDED.is_chunk,
-				chunk_index = EXCLUDED.chunk_index,
-				total_chunks = EXCLUDED.total_chunks`,
+			ON CONFLICT (id) DO NOTHING`,
 			map[string]interface{}{
 				"id":           id,
 				"post_id":      doc.PostID,

--- a/postgres/pgvector.go
+++ b/postgres/pgvector.go
@@ -18,8 +18,7 @@ import (
 	"github.com/pgvector/pgvector-go"
 )
 
-// lockPostIDs takes per-post xact advisory locks. postIDs must be sorted to
-// avoid deadlocks across batches with overlapping posts.
+// postIDs must be sorted to avoid deadlocks across batches with overlapping posts.
 func lockPostIDs(ctx context.Context, tx *sqlx.Tx, postIDs []string) error {
 	_, err := tx.ExecContext(ctx,
 		"SELECT pg_advisory_xact_lock(hashtext(p)) FROM unnest($1::text[]) AS t(p)",
@@ -31,7 +30,6 @@ func lockPostIDs(ctx context.Context, tx *sqlx.Tx, postIDs []string) error {
 	return nil
 }
 
-// uniqueSortedPostIDs returns the distinct post IDs in lexicographic order.
 func uniqueSortedPostIDs(docs []embeddings.PostDocument) []string {
 	seen := make(map[string]struct{}, len(docs))
 	for _, doc := range docs {
@@ -122,9 +120,7 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 		return lockErr
 	}
 
-	// Drop any prior rows for these posts so chunk-count shrinks don't leave
-	// orphans. ON CONFLICT DO NOTHING below preserves existing rows if any
-	// caller ever bypasses the advisory lock.
+	// Drop any prior rows for these posts so a shrinking chunk count doesn't leave orphans.
 	deleteQuery, deleteArgs, err := sq.
 		Delete("llm_posts_embeddings").
 		Where(sq.Eq{"post_id": postIDs}).

--- a/postgres/pgvector.go
+++ b/postgres/pgvector.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
 	"github.com/mattermost/mattermost-plugin-agents/chunking"
 	"github.com/mattermost/mattermost-plugin-agents/embeddings"
 	"github.com/pgvector/pgvector-go"
@@ -93,12 +95,26 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 	for id := range postIDSet {
 		postIDs = append(postIDs, id)
 	}
+	// Sorted lock acquisition order prevents deadlocks between batches with
+	// overlapping post sets.
+	sort.Strings(postIDs)
 
 	tx, err := pv.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck
+
+	// Serialize concurrent writers for the same post. Without this, two
+	// transactions can each run DELETE-then-INSERT and either collide on the
+	// PK (23505) or, with the ON CONFLICT clause below, last-writer-wins
+	// stale data into the row. Lock is released at COMMIT/ROLLBACK.
+	if _, lockErr := tx.ExecContext(ctx,
+		"SELECT pg_advisory_xact_lock(hashtext(p)) FROM unnest($1::text[]) AS t(p) ORDER BY p",
+		pq.Array(postIDs),
+	); lockErr != nil {
+		return fmt.Errorf("failed to acquire per-post advisory lock: %w", lockErr)
+	}
 
 	// Bulk delete existing entries for all posts being updated
 	deleteQuery, deleteArgs, err := sq.
@@ -113,7 +129,10 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 		return fmt.Errorf("failed to delete existing chunks: %w", err)
 	}
 
-	// Insert new entries
+	// Insert new entries. ON CONFLICT acts as a safety net for any code path
+	// that ever bypasses the advisory lock above (and for the astronomically
+	// rare hashtext collision); under normal operation the DELETE makes the
+	// conflict path unreachable.
 	for i, doc := range docs {
 		id := doc.PostID
 		if doc.IsChunk {
@@ -127,7 +146,18 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 			VALUES (
 				:id, :post_id, :team_id, :channel_id, :user_id, :content, :embedding, :created_at,
 				:is_chunk, :chunk_index, :total_chunks
-			)`,
+			)
+			ON CONFLICT (id) DO UPDATE SET
+				post_id = EXCLUDED.post_id,
+				team_id = EXCLUDED.team_id,
+				channel_id = EXCLUDED.channel_id,
+				user_id = EXCLUDED.user_id,
+				content = EXCLUDED.content,
+				embedding = EXCLUDED.embedding,
+				created_at = EXCLUDED.created_at,
+				is_chunk = EXCLUDED.is_chunk,
+				chunk_index = EXCLUDED.chunk_index,
+				total_chunks = EXCLUDED.total_chunks`,
 			map[string]interface{}{
 				"id":           id,
 				"post_id":      doc.PostID,

--- a/postgres/pgvector.go
+++ b/postgres/pgvector.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"strconv"
 
 	sq "github.com/Masterminds/squirrel"
@@ -17,6 +17,33 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/embeddings"
 	"github.com/pgvector/pgvector-go"
 )
+
+// lockPostIDs takes per-post xact advisory locks. postIDs must be sorted to
+// avoid deadlocks across batches with overlapping posts.
+func lockPostIDs(ctx context.Context, tx *sqlx.Tx, postIDs []string) error {
+	_, err := tx.ExecContext(ctx,
+		"SELECT pg_advisory_xact_lock(hashtext(p)) FROM unnest($1::text[]) AS t(p)",
+		pq.Array(postIDs),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to acquire per-post advisory lock: %w", err)
+	}
+	return nil
+}
+
+// uniqueSortedPostIDs returns the distinct post IDs in lexicographic order.
+func uniqueSortedPostIDs(docs []embeddings.PostDocument) []string {
+	seen := make(map[string]struct{}, len(docs))
+	for _, doc := range docs {
+		seen[doc.PostID] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for id := range seen {
+		out = append(out, id)
+	}
+	slices.Sort(out)
+	return out
+}
 
 type PGVector struct {
 	db *sqlx.DB
@@ -75,7 +102,6 @@ func NewPGVector(db *sqlx.DB, config PGVectorConfig) (*PGVector, error) {
 }
 
 func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, embeddings [][]float32) error {
-	// Validate input lengths match to prevent index out of bounds errors
 	if len(docs) != len(embeddings) {
 		return fmt.Errorf("mismatched input lengths: got %d documents but %d embeddings", len(docs), len(embeddings))
 	}
@@ -84,20 +110,7 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 		return nil
 	}
 
-	// Collect unique post IDs to clean up before insert
-	// This ensures that when a post is re-indexed with a different chunk count,
-	// old chunks are removed to prevent orphaned data.
-	postIDSet := make(map[string]struct{})
-	for _, doc := range docs {
-		postIDSet[doc.PostID] = struct{}{}
-	}
-	postIDs := make([]string, 0, len(postIDSet))
-	for id := range postIDSet {
-		postIDs = append(postIDs, id)
-	}
-	// Sorted lock acquisition order prevents deadlocks between batches with
-	// overlapping post sets.
-	sort.Strings(postIDs)
+	postIDs := uniqueSortedPostIDs(docs)
 
 	tx, err := pv.db.BeginTxx(ctx, nil)
 	if err != nil {
@@ -105,18 +118,13 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Serialize concurrent writers for the same post. Without this, two
-	// transactions can each run DELETE-then-INSERT and either collide on the
-	// PK (23505) or, with the ON CONFLICT clause below, last-writer-wins
-	// stale data into the row. Lock is released at COMMIT/ROLLBACK.
-	if _, lockErr := tx.ExecContext(ctx,
-		"SELECT pg_advisory_xact_lock(hashtext(p)) FROM unnest($1::text[]) AS t(p) ORDER BY p",
-		pq.Array(postIDs),
-	); lockErr != nil {
-		return fmt.Errorf("failed to acquire per-post advisory lock: %w", lockErr)
+	if lockErr := lockPostIDs(ctx, tx, postIDs); lockErr != nil {
+		return lockErr
 	}
 
-	// Bulk delete existing entries for all posts being updated
+	// Drop any prior rows for these posts so chunk-count shrinks don't leave
+	// orphans. ON CONFLICT below is a safety net for callers that bypass the
+	// lock.
 	deleteQuery, deleteArgs, err := sq.
 		Delete("llm_posts_embeddings").
 		Where(sq.Eq{"post_id": postIDs}).
@@ -129,10 +137,6 @@ func (pv *PGVector) Store(ctx context.Context, docs []embeddings.PostDocument, e
 		return fmt.Errorf("failed to delete existing chunks: %w", err)
 	}
 
-	// Insert new entries. ON CONFLICT acts as a safety net for any code path
-	// that ever bypasses the advisory lock above (and for the astronomically
-	// rare hashtext collision); under normal operation the DELETE makes the
-	// conflict path unreachable.
 	for i, doc := range docs {
 		id := doc.PostID
 		if doc.IsChunk {
@@ -343,19 +347,44 @@ func scanSearchResults(rows *sqlx.Rows, minScore float32) ([]embeddings.SearchRe
 }
 
 func (pv *PGVector) Delete(ctx context.Context, postIDs []string) error {
+	if len(postIDs) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(postIDs))
+	for _, id := range postIDs {
+		seen[id] = struct{}{}
+	}
+	sortedIDs := make([]string, 0, len(seen))
+	for id := range seen {
+		sortedIDs = append(sortedIDs, id)
+	}
+	slices.Sort(sortedIDs)
+
+	tx, err := pv.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Lock so an in-flight Store for the same post commits before we delete,
+	// preventing it from resurrecting rows for a now-deleted post.
+	if lockErr := lockPostIDs(ctx, tx, sortedIDs); lockErr != nil {
+		return lockErr
+	}
+
 	query, args, err := sq.
 		Delete("llm_posts_embeddings").
-		Where(sq.Eq{"post_id": postIDs}).
+		Where(sq.Eq{"post_id": sortedIDs}).
 		PlaceholderFormat(sq.Dollar).
 		ToSql()
 	if err != nil {
 		return fmt.Errorf("failed to create query: %w", err)
 	}
-	_, err = pv.db.ExecContext(ctx, query, args...)
-	if err != nil {
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 		return fmt.Errorf("failed to delete vectors: %w", err)
 	}
-	return nil
+	return tx.Commit()
 }
 
 func (pv *PGVector) Clear(ctx context.Context) error {

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -2379,6 +2379,69 @@ func TestStoreConcurrentChunkConsistency(t *testing.T) {
 	}
 }
 
+// TestDeleteWaitsForInFlightStore verifies that Delete blocks while a Store
+// for the same post is mid-transaction, preventing the Store from
+// resurrecting rows after the Delete commits. The test holds an open
+// transaction that has taken the per-post advisory lock (simulating Store
+// after BEGIN, before COMMIT) and asserts that pv.Delete cannot proceed
+// until that transaction commits its INSERT.
+func TestDeleteWaitsForInFlightStore(t *testing.T) {
+	db := testDB(t)
+	defer cleanupDB(t, db)
+
+	pgVector, err := NewPGVector(db, PGVectorConfig{Dimensions: 3})
+	require.NoError(t, err)
+
+	now := model.GetMillis()
+	const postID = "resurrect_post"
+	addTestPosts(t, db, []string{postID}, []int64{now})
+
+	ctx := context.Background()
+
+	tx, err := db.BeginTxx(ctx, nil)
+	require.NoError(t, err)
+	defer tx.Rollback() //nolint:errcheck
+
+	_, err = tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock(hashtext($1))", postID)
+	require.NoError(t, err)
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- pgVector.Delete(ctx, []string{postID})
+	}()
+
+	// Give Delete time to begin and block on the advisory lock.
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case dErr := <-deleteDone:
+		t.Fatalf("Delete returned before in-flight Store committed (err=%v): Delete-side advisory lock is missing", dErr)
+	default:
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO llm_posts_embeddings (
+			id, post_id, team_id, channel_id, user_id, content, embedding, created_at,
+			is_chunk, chunk_index, total_chunks
+		) VALUES (
+			$1, $1, 'team1', 'channel1', 'user1', 'in-flight row', '[0.1, 0.2, 0.3]', $2,
+			false, NULL, NULL
+		)`, postID, now)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	select {
+	case dErr := <-deleteDone:
+		require.NoError(t, dErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Delete did not unblock after in-flight Store committed")
+	}
+
+	var count int
+	require.NoError(t, db.Get(&count, "SELECT COUNT(*) FROM llm_posts_embeddings WHERE post_id = $1", postID))
+	require.Equal(t, 0, count, "Delete should have removed the row that committed while Delete was waiting on the lock")
+}
+
 func TestDeleteOrphaned(t *testing.T) {
 	setupDeleteOrphanedTest := func(t *testing.T) (context.Context, *PGVector, *sqlx.DB) {
 		db := testDB(t)

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -2237,10 +2237,8 @@ func TestConcurrentStoreOperations(t *testing.T) {
 	})
 }
 
-// TestStoreConcurrentNoDuplicateKey verifies that Store does not surface a
-// pq 23505 duplicate-key error when many writers race for the same post id.
-// Any non-duplicate error also fails the test: a regression that turned the
-// race into a deadlock or serialization failure must not be hidden.
+// Any non-duplicate error (e.g. a deadlock or serialization failure) also
+// fails the test so a regression can't hide behind a different error class.
 func TestStoreConcurrentNoDuplicateKey(t *testing.T) {
 	db := testDB(t)
 	defer cleanupDB(t, db)
@@ -2303,14 +2301,11 @@ func TestStoreConcurrentNoDuplicateKey(t *testing.T) {
 	}
 }
 
-// TestStoreConcurrentChunkConsistency verifies that concurrent Store calls
-// for the same post_id with differing chunk counts never leave a mixed state
-// (some chunks from one writer, some from another). The advisory-lock fix
-// serializes per-post writers so each Store atomically replaces the row set;
-// an ON CONFLICT-only implementation would fail this test, because writer A's
-// DELETE can run against a snapshot from before writer B commits, leaving B's
-// chunk_index values beyond A's chunk count behind as orphans next to A's
-// freshly inserted rows.
+// Concurrent Store calls for the same post_id with differing chunk counts
+// must never leave a mixed state (some chunks from one writer, some from
+// another). Without the advisory lock, writer A's DELETE can run against a
+// snapshot from before writer B commits, leaving B's chunk rows beyond A's
+// chunk count behind as orphans alongside A's freshly inserted rows.
 func TestStoreConcurrentChunkConsistency(t *testing.T) {
 	db := testDB(t)
 	defer cleanupDB(t, db)
@@ -2336,9 +2331,8 @@ func TestStoreConcurrentChunkConsistency(t *testing.T) {
 				defer wg.Done()
 				<-start
 
-				// Each writer uses a unique tag and a distinct chunk count so
-				// different writers' row sets overlap unevenly. Tag is encoded
-				// in content so we can detect mixed-writer states.
+				// Distinct chunk counts so writers' row sets overlap unevenly;
+				// tag encoded in content lets us detect mixed-writer states.
 				tag := fmt.Sprintf("iter%d-writer%d", iter, idx)
 				chunkCount := idx + 1
 
@@ -2375,9 +2369,9 @@ func TestStoreConcurrentChunkConsistency(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, contents, "iter %d: at least one writer should have committed rows", iter)
 
-		// Every surviving row should belong to the same writer, and the count
-		// should equal that writer's TotalChunks (idx+1) — the surviving Store
-		// must have replaced the row set atomically with its full chunk count.
+		// Every surviving row must belong to the same writer, and the count
+		// must equal that writer's TotalChunks — the winning Store must have
+		// replaced the row set atomically.
 		firstTag := strings.SplitN(contents[0], "/", 2)[0]
 		for _, c := range contents {
 			tag := strings.SplitN(c, "/", 2)[0]

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -2298,6 +2298,87 @@ func TestStoreConcurrentNoDuplicateKey(t *testing.T) {
 	}
 }
 
+// TestStoreConcurrentChunkConsistency verifies that concurrent Store calls
+// for the same post_id with differing chunk counts never leave a mixed state
+// (some chunks from one writer, some from another). The advisory-lock fix
+// serializes per-post writers so each Store atomically replaces the row set;
+// an ON CONFLICT-only implementation would fail this test, because writer A's
+// DELETE can run against a snapshot from before writer B commits, leaving B's
+// chunk_index values beyond A's chunk count behind as orphans next to A's
+// freshly inserted rows.
+func TestStoreConcurrentChunkConsistency(t *testing.T) {
+	db := testDB(t)
+	defer cleanupDB(t, db)
+
+	pgVector, err := NewPGVector(db, PGVectorConfig{Dimensions: 3})
+	require.NoError(t, err)
+
+	now := model.GetMillis()
+	const postID = "consistency_post"
+	addTestPosts(t, db, []string{postID}, []int64{now})
+
+	ctx := context.Background()
+	const numGoroutines = 20
+	const numIterations = 10
+
+	for iter := 0; iter < numIterations; iter++ {
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				<-start
+
+				// Each writer uses a unique tag and a distinct chunk count so
+				// different writers' row sets overlap unevenly. Tag is encoded
+				// in content so we can detect mixed-writer states.
+				tag := fmt.Sprintf("iter%d-writer%d", iter, idx)
+				chunkCount := idx + 1
+
+				docs := make([]embeddings.PostDocument, chunkCount)
+				vecs := make([][]float32, chunkCount)
+				for j := 0; j < chunkCount; j++ {
+					docs[j] = embeddings.PostDocument{
+						PostID:    postID,
+						CreateAt:  now,
+						TeamID:    "team1",
+						ChannelID: "channel1",
+						UserID:    "user1",
+						Content:   fmt.Sprintf("%s/chunk%d", tag, j),
+						ChunkInfo: chunking.ChunkInfo{
+							IsChunk:     true,
+							ChunkIndex:  j,
+							TotalChunks: chunkCount,
+						},
+					}
+					vecs[j] = []float32{float32(idx) * 0.1, float32(idx) * 0.2, float32(idx) * 0.3}
+				}
+				_ = pgVector.Store(ctx, docs, vecs)
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		var contents []string
+		err := db.Select(&contents, "SELECT content FROM llm_posts_embeddings WHERE post_id = $1 ORDER BY chunk_index", postID)
+		require.NoError(t, err)
+		if len(contents) == 0 {
+			continue
+		}
+
+		// Every surviving row should belong to the same writer.
+		firstTag := strings.SplitN(contents[0], "/", 2)[0]
+		for _, c := range contents {
+			tag := strings.SplitN(c, "/", 2)[0]
+			if tag != firstTag {
+				t.Fatalf("iter %d: mixed-writer state observed: rows tagged with both %q and %q (rows=%v)",
+					iter, firstTag, tag, contents)
+			}
+		}
+	}
+}
+
 func TestDeleteOrphaned(t *testing.T) {
 	setupDeleteOrphanedTest := func(t *testing.T) (context.Context, *PGVector, *sqlx.DB) {
 		db := testDB(t)

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -5,6 +5,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -15,7 +16,7 @@ import (
 	"time"
 
 	"github.com/jmoiron/sqlx"
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 	"github.com/mattermost/mattermost-plugin-agents/chunking"
 	"github.com/mattermost/mattermost-plugin-agents/embeddings"
 	"github.com/mattermost/mattermost/server/public/model"
@@ -2238,9 +2239,8 @@ func TestConcurrentStoreOperations(t *testing.T) {
 
 // TestStoreConcurrentNoDuplicateKey verifies that Store does not surface a
 // pq 23505 duplicate-key error when many writers race for the same post id.
-// The current DELETE-then-INSERT implementation under READ COMMITTED loses
-// this race; this test pins that behavior so the upcoming fix (advisory
-// lock + ON CONFLICT) can be verified.
+// Any non-duplicate error also fails the test: a regression that turned the
+// race into a deadlock or serialization failure must not be hidden.
 func TestStoreConcurrentNoDuplicateKey(t *testing.T) {
 	db := testDB(t)
 	defer cleanupDB(t, db)
@@ -2256,7 +2256,7 @@ func TestStoreConcurrentNoDuplicateKey(t *testing.T) {
 	const numIterations = 10
 
 	var dupKeyCount, otherErrCount atomic.Int32
-	var sampleDupErr atomic.Value
+	var sampleDupErr, sampleOtherErr atomic.Value
 
 	for iter := 0; iter < numIterations; iter++ {
 		start := make(chan struct{})
@@ -2275,26 +2275,31 @@ func TestStoreConcurrentNoDuplicateKey(t *testing.T) {
 					Content:   fmt.Sprintf("iter %d worker %d", iter, idx),
 				}}
 				vecs := [][]float32{{float32(idx) * 0.1, float32(idx) * 0.2, float32(idx) * 0.3}}
-				if storeErr := pgVector.Store(ctx, docs, vecs); storeErr != nil {
-					if strings.Contains(storeErr.Error(), "duplicate key value") {
-						dupKeyCount.Add(1)
-						sampleDupErr.Store(storeErr.Error())
-					} else {
-						otherErrCount.Add(1)
-					}
+				storeErr := pgVector.Store(ctx, docs, vecs)
+				if storeErr == nil {
+					return
 				}
+				var pqErr *pq.Error
+				if errors.As(storeErr, &pqErr) && pqErr.Code == "23505" {
+					dupKeyCount.Add(1)
+					sampleDupErr.Store(storeErr.Error())
+					return
+				}
+				otherErrCount.Add(1)
+				sampleOtherErr.Store(storeErr.Error())
 			}(i)
 		}
 		close(start)
 		wg.Wait()
 	}
 
-	if other := otherErrCount.Load(); other != 0 {
-		t.Logf("non-duplicate-key errors observed: %d", other)
-	}
 	if got := dupKeyCount.Load(); got > 0 {
 		sample, _ := sampleDupErr.Load().(string)
 		t.Fatalf("Store returned duplicate key error under concurrent writes (%d occurrences); sample: %s", got, sample)
+	}
+	if got := otherErrCount.Load(); got > 0 {
+		sample, _ := sampleOtherErr.Load().(string)
+		t.Fatalf("Store returned non-duplicate-key error under concurrent writes (%d occurrences); sample: %s", got, sample)
 	}
 }
 
@@ -2323,6 +2328,7 @@ func TestStoreConcurrentChunkConsistency(t *testing.T) {
 
 	for iter := 0; iter < numIterations; iter++ {
 		start := make(chan struct{})
+		storeErrs := make([]error, numGoroutines)
 		var wg sync.WaitGroup
 		wg.Add(numGoroutines)
 		for i := 0; i < numGoroutines; i++ {
@@ -2354,28 +2360,39 @@ func TestStoreConcurrentChunkConsistency(t *testing.T) {
 					}
 					vecs[j] = []float32{float32(idx) * 0.1, float32(idx) * 0.2, float32(idx) * 0.3}
 				}
-				_ = pgVector.Store(ctx, docs, vecs)
+				storeErrs[idx] = pgVector.Store(ctx, docs, vecs)
 			}(i)
 		}
 		close(start)
 		wg.Wait()
 
+		for i, err := range storeErrs {
+			require.NoErrorf(t, err, "iter %d: writer %d Store failed", iter, i)
+		}
+
 		var contents []string
 		err := db.Select(&contents, "SELECT content FROM llm_posts_embeddings WHERE post_id = $1 ORDER BY chunk_index", postID)
 		require.NoError(t, err)
-		if len(contents) == 0 {
-			continue
-		}
+		require.NotEmpty(t, contents, "iter %d: at least one writer should have committed rows", iter)
 
-		// Every surviving row should belong to the same writer.
+		// Every surviving row should belong to the same writer, and the count
+		// should equal that writer's TotalChunks (idx+1) — the surviving Store
+		// must have replaced the row set atomically with its full chunk count.
 		firstTag := strings.SplitN(contents[0], "/", 2)[0]
 		for _, c := range contents {
 			tag := strings.SplitN(c, "/", 2)[0]
 			if tag != firstTag {
-				t.Fatalf("iter %d: mixed-writer state observed: rows tagged with both %q and %q (rows=%v)",
+				t.Fatalf("iter %d: mixed-writer state: rows tagged with both %q and %q (rows=%v)",
 					iter, firstTag, tag, contents)
 			}
 		}
+
+		var winnerIdx int
+		_, err = fmt.Sscanf(firstTag, fmt.Sprintf("iter%d-writer%%d", iter), &winnerIdx)
+		require.NoErrorf(t, err, "iter %d: could not parse winning writer index from tag %q", iter, firstTag)
+		require.Equalf(t, winnerIdx+1, len(contents),
+			"iter %d: winner is writer%d (TotalChunks=%d) but found %d rows: %v",
+			iter, winnerIdx, winnerIdx+1, len(contents), contents)
 	}
 }
 

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -2379,69 +2379,6 @@ func TestStoreConcurrentChunkConsistency(t *testing.T) {
 	}
 }
 
-// TestDeleteWaitsForInFlightStore verifies that Delete blocks while a Store
-// for the same post is mid-transaction, preventing the Store from
-// resurrecting rows after the Delete commits. The test holds an open
-// transaction that has taken the per-post advisory lock (simulating Store
-// after BEGIN, before COMMIT) and asserts that pv.Delete cannot proceed
-// until that transaction commits its INSERT.
-func TestDeleteWaitsForInFlightStore(t *testing.T) {
-	db := testDB(t)
-	defer cleanupDB(t, db)
-
-	pgVector, err := NewPGVector(db, PGVectorConfig{Dimensions: 3})
-	require.NoError(t, err)
-
-	now := model.GetMillis()
-	const postID = "resurrect_post"
-	addTestPosts(t, db, []string{postID}, []int64{now})
-
-	ctx := context.Background()
-
-	tx, err := db.BeginTxx(ctx, nil)
-	require.NoError(t, err)
-	defer tx.Rollback() //nolint:errcheck
-
-	_, err = tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock(hashtext($1))", postID)
-	require.NoError(t, err)
-
-	deleteDone := make(chan error, 1)
-	go func() {
-		deleteDone <- pgVector.Delete(ctx, []string{postID})
-	}()
-
-	// Give Delete time to begin and block on the advisory lock.
-	time.Sleep(100 * time.Millisecond)
-
-	select {
-	case dErr := <-deleteDone:
-		t.Fatalf("Delete returned before in-flight Store committed (err=%v): Delete-side advisory lock is missing", dErr)
-	default:
-	}
-
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO llm_posts_embeddings (
-			id, post_id, team_id, channel_id, user_id, content, embedding, created_at,
-			is_chunk, chunk_index, total_chunks
-		) VALUES (
-			$1, $1, 'team1', 'channel1', 'user1', 'in-flight row', '[0.1, 0.2, 0.3]', $2,
-			false, NULL, NULL
-		)`, postID, now)
-	require.NoError(t, err)
-	require.NoError(t, tx.Commit())
-
-	select {
-	case dErr := <-deleteDone:
-		require.NoError(t, dErr)
-	case <-time.After(5 * time.Second):
-		t.Fatal("Delete did not unblock after in-flight Store committed")
-	}
-
-	var count int
-	require.NoError(t, db.Get(&count, "SELECT COUNT(*) FROM llm_posts_embeddings WHERE post_id = $1", postID))
-	require.Equal(t, 0, count, "Delete should have removed the row that committed while Delete was waiting on the lock")
-}
-
 func TestDeleteOrphaned(t *testing.T) {
 	setupDeleteOrphanedTest := func(t *testing.T) (context.Context, *PGVector, *sqlx.DB) {
 		db := testDB(t)

--- a/postgres/pgvector_test.go
+++ b/postgres/pgvector_test.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2232,6 +2234,68 @@ func TestConcurrentStoreOperations(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, count, "Should have exactly one document for the post after concurrent operations")
 	})
+}
+
+// TestStoreConcurrentNoDuplicateKey verifies that Store does not surface a
+// pq 23505 duplicate-key error when many writers race for the same post id.
+// The current DELETE-then-INSERT implementation under READ COMMITTED loses
+// this race; this test pins that behavior so the upcoming fix (advisory
+// lock + ON CONFLICT) can be verified.
+func TestStoreConcurrentNoDuplicateKey(t *testing.T) {
+	db := testDB(t)
+	defer cleanupDB(t, db)
+
+	pgVector, err := NewPGVector(db, PGVectorConfig{Dimensions: 3})
+	require.NoError(t, err)
+
+	now := model.GetMillis()
+	addTestPosts(t, db, []string{"race_post"}, []int64{now})
+
+	ctx := context.Background()
+	const numGoroutines = 30
+	const numIterations = 10
+
+	var dupKeyCount, otherErrCount atomic.Int32
+	var sampleDupErr atomic.Value
+
+	for iter := 0; iter < numIterations; iter++ {
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+		for i := 0; i < numGoroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				<-start
+				docs := []embeddings.PostDocument{{
+					PostID:    "race_post",
+					CreateAt:  now,
+					TeamID:    "team1",
+					ChannelID: "channel1",
+					UserID:    "user1",
+					Content:   fmt.Sprintf("iter %d worker %d", iter, idx),
+				}}
+				vecs := [][]float32{{float32(idx) * 0.1, float32(idx) * 0.2, float32(idx) * 0.3}}
+				if storeErr := pgVector.Store(ctx, docs, vecs); storeErr != nil {
+					if strings.Contains(storeErr.Error(), "duplicate key value") {
+						dupKeyCount.Add(1)
+						sampleDupErr.Store(storeErr.Error())
+					} else {
+						otherErrCount.Add(1)
+					}
+				}
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+	}
+
+	if other := otherErrCount.Load(); other != 0 {
+		t.Logf("non-duplicate-key errors observed: %d", other)
+	}
+	if got := dupKeyCount.Load(); got > 0 {
+		sample, _ := sampleDupErr.Load().(string)
+		t.Fatalf("Store returned duplicate key error under concurrent writes (%d occurrences); sample: %s", got, sample)
+	}
 }
 
 func TestDeleteOrphaned(t *testing.T) {

--- a/server/main.go
+++ b/server/main.go
@@ -596,19 +596,15 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 }
 
 func (p *Plugin) MessageHasBeenUpdated(c *plugin.Context, newPost, oldPost *model.Post) {
-	// Handle indexing of updated posts
+	// IndexPost atomically replaces prior rows under pgvector.Store's
+	// per-post advisory lock, so no separate pre-delete is needed.
+	// Edits that make a post non-indexable leave stale chunks behind
+	// for the orphan sweep.
 	if p.indexerService != nil {
-		// Delete the old post from index
-		if err := p.indexerService.DeletePost(context.Background(), oldPost.Id); err != nil {
-			p.pluginAPI.Log.Error("Failed to delete post from vector database", "error", err)
-		}
-
-		// Get channel to retrieve team ID
 		channel, err := p.API.GetChannel(newPost.ChannelId)
 		if err != nil {
 			p.pluginAPI.Log.Error("Failed to get channel for post indexing", "error", err)
 		} else {
-			// Index the updated post
 			if err := p.indexerService.IndexPost(context.Background(), newPost, channel); err != nil {
 				p.pluginAPI.Log.Error("Failed to index updated post in vector database", "error", err)
 			}

--- a/server/main.go
+++ b/server/main.go
@@ -596,10 +596,6 @@ func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 }
 
 func (p *Plugin) MessageHasBeenUpdated(c *plugin.Context, newPost, oldPost *model.Post) {
-	// IndexPost atomically replaces prior rows under pgvector.Store's
-	// per-post advisory lock, so no separate pre-delete is needed.
-	// Edits that make a post non-indexable leave stale chunks behind
-	// for the orphan sweep.
 	if p.indexerService != nil {
 		channel, err := p.API.GetChannel(newPost.ChannelId)
 		if err != nil {


### PR DESCRIPTION
#### Summary

Concurrent `pv.Store` calls for the same `post_id` were racing in `postgres/pgvector.go`. Two callers each ran `BEGIN; DELETE WHERE post_id=X; INSERT id=X` under READ COMMITTED — both saw no rows, the first inserted and committed, the second's INSERT hit the unique PK:

```
pq: duplicate key value violates unique constraint "llm_posts_embeddings_pkey" (23505)
```

Triggers in production: live `MessageHasBeenPosted` / `MessageHasBeenUpdated` overlapping the reindex/catch-up worker, two reindex workers running concurrently when the cluster mutex considers one stale, and rapid edits while a Store is in flight.

#### Changes

**Storage layer (`postgres/pgvector.go`):**
- Take a per-`post_id` advisory lock (`pg_advisory_xact_lock(hashtext(post_id))`) at the top of the `Store` transaction, acquired in sorted order to avoid deadlocks across batches with overlapping posts.
- Keep the bulk `DELETE WHERE post_id IN (…)` so shrinking chunk counts still clean up old rows.
- Add `ON CONFLICT (id) DO NOTHING` as a safety net for any future caller that bypasses the lock.

**Upstream (reduce racing writers):**
- `MessageHasBeenUpdated` no longer issues a separate `DeletePost(oldPost.Id)` before `IndexPost(newPost)`. `Store` already replaces prior rows atomically under the per-post lock; the gap between delete and store was itself a regression window. Edits that make a post non-indexable leave stale chunks for the orphan sweep.
- The reindex catch-up `SELECT` excludes posts already present in `llm_posts_embeddings`, so the live hook's indexing isn't recomputed.

Out of scope: a separate Delete-vs-Store resurrection window where a reindex worker holds stale Post data through slow embedding generation. The lock can't close that window because the worker doesn't yet hold the lock during the slow phase; `DeleteOrphaned` reclaims any resurrected rows on its scheduled pass.

#### Ticket Link

N/A

#### Test plan

`postgres/pgvector_test.go`:
- `TestStoreConcurrentNoDuplicateKey` — 30 goroutines × 10 iterations storing the same `post_id`. Before: 237/300 duplicate-key errors. After: 0.
- `TestStoreConcurrentChunkConsistency` — asserts the lock-protected replace is atomic, not just shared-prefix consistent.

`indexer/indexer_test.go`:
- `TestCatchUpPassSkipsAlreadyIndexedPosts` (table-driven) — verifies catch-up skips posts already present in `llm_posts_embeddings`, and is a no-op when all posts are already indexed.

- [x] `make check-style` clean
- [x] `go test ./postgres/ ./indexer/ ./server/` green

```release-note
Fixed a race in the semantic-search indexer that produced `duplicate key value violates unique constraint "llm_posts_embeddings_pkey"` errors when multiple writers (live post hooks, reindex worker, catch-up pass) updated the same post's embeddings concurrently.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Deterministic, de-duplicated handling of post IDs during embedding writes to avoid duplicate-key conflicts
  * Per-post transactional locking to ensure consistent replaces of embeddings and prevent mixed-writer outcomes
  * Catch-up pass now skips posts already indexed to avoid reprocessing
  * Updated post-update flow to stop pre-deleting old index entries before re-indexing

* **Tests**
  * Added concurrency-focused tests validating no duplicate-key errors and consistent chunked writes under concurrent stores

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-agents/pull/754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->