### PR TITLE
fix: 409 on first Full Reindex click for fresh installs

### DIFF
--- a/api/api_admin.go
+++ b/api/api_admin.go
@@ -100,12 +100,13 @@ func (a *API) handleCancelJob(c *gin.Context) {
 
 	jobStatus, err := a.indexerService.CancelJob()
 	if err != nil {
-		switch err.Error() {
-		case "not found":
+		if mmapi.IsKVNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{
 				"status": "no_job",
 			})
 			return
+		}
+		switch err.Error() {
 		case "not running":
 			c.JSON(http.StatusBadRequest, gin.H{
 				"status": "not_running",

--- a/api/api_admin_test.go
+++ b/api/api_admin_test.go
@@ -143,6 +143,35 @@ func TestHandleGetJobStatusIncludesStale(t *testing.T) {
 	}
 }
 
+// Fresh install: clicking Cancel when no job has ever run must surface as
+// 404 {"status":"no_job"}, not a 500. Pre-fix, the wrapper masked the
+// missing key as a present-but-zero JobStatus and CancelJob returned
+// "not running" — which the handler matched. The wrapper fix promotes the
+// missing key to ErrKVNotFound, so the handler must branch on
+// IsKVNotFound or fall through to a 500.
+func TestHandleCancelJob_FreshInstallReturns404NoJob(t *testing.T) {
+	api, mockAPI, _ := setupAdminTestEnvironment(t)
+	defer mockAPI.AssertExpectations(t)
+
+	mockAPI.On("HasPermissionTo", "admin-user", model.PermissionManageSystem).Return(true).Maybe()
+	mockAPI.On("LogError", mock.Anything).Return().Maybe()
+
+	api.indexerService = createMockIndexer(t, &mockIndexerService{jobStatus: nil})
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/reindex/cancel", nil)
+	req.Header.Set("Mattermost-User-Id", "admin-user")
+
+	recorder := httptest.NewRecorder()
+	api.ServeHTTP(&plugin.Context{}, recorder, req)
+
+	resp := recorder.Result()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	require.Equal(t, "no_job", body["status"])
+}
+
 func TestHandleIndexHealthCheck(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/api/api_admin_test.go
+++ b/api/api_admin_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/mcp"
 	"github.com/mattermost/mattermost-plugin-agents/metrics"
+	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 	"github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
@@ -58,16 +59,27 @@ func setupAdminTestEnvironment(t *testing.T) (*API, *plugintest.API, *adminTestS
 
 func TestHandleGetJobStatusIncludesStale(t *testing.T) {
 	tests := []struct {
-		name           string
-		indexerNil     bool
-		jobStatus      *indexer.JobStatus
-		expectedStatus int
-		expectedStale  bool
+		name              string
+		indexerNil        bool
+		jobStatus         *indexer.JobStatus
+		expectedStatus    int
+		expectedStale     bool
+		expectedBodyField string // optional: when set, asserts JSON contains {"status": <field>}
 	}{
 		{
-			name:           "returns 404 when indexer is nil",
-			indexerNil:     true,
-			expectedStatus: http.StatusNotFound,
+			name:              "returns 404 when indexer is nil",
+			indexerNil:        true,
+			expectedStatus:    http.StatusNotFound,
+			expectedBodyField: "no_job",
+		},
+		{
+			// Fresh install: missing KV key must surface as 404 with
+			// {"status":"no_job"} (the contract use_job_status.tsx relies on).
+			name:              "returns 404 with no_job when no job has ever run",
+			indexerNil:        false,
+			jobStatus:         nil,
+			expectedStatus:    http.StatusNotFound,
+			expectedBodyField: "no_job",
 		},
 		{
 			name:       "running job with recent heartbeat is not stale",
@@ -120,6 +132,12 @@ func TestHandleGetJobStatusIncludesStale(t *testing.T) {
 				err := json.NewDecoder(resp.Body).Decode(&response)
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedStale, response.IsStale)
+			}
+			if tt.expectedBodyField != "" {
+				var body map[string]string
+				err := json.NewDecoder(resp.Body).Decode(&body)
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedBodyField, body["status"])
 			}
 		})
 	}
@@ -250,13 +268,6 @@ func TestHandleFetchModelsVertexAndGeminiValidation(t *testing.T) {
 	}
 }
 
-// notFoundError simulates the "not found" error that the indexer checks for
-type notFoundError struct{}
-
-func (e notFoundError) Error() string {
-	return "not found"
-}
-
 // mockIndexerService holds the mock configuration for creating test indexers
 type mockIndexerService struct {
 	jobStatus *indexer.JobStatus
@@ -269,13 +280,10 @@ func createMockIndexer(t *testing.T, mockService *mockIndexerService) *indexer.I
 	mockMutexAPI := &plugintest.API{}
 	mockClient := mocks.NewMockClient(t)
 
-	// Setup mock for GetJobStatus - always handle the ReindexJobKey
 	if mockService.jobStatus == nil {
-		// No job exists - return "not found" error
 		mockClient.On("KVGet", indexer.ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(notFoundError{}).Maybe()
+			Return(mmapi.ErrKVNotFound).Maybe()
 	} else {
-		// Job exists - populate the status
 		mockClient.On("KVGet", indexer.ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
 			Run(func(args mock.Arguments) {
 				status := args.Get(1).(*indexer.JobStatus)

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/embeddings"
 	embeddingsmocks "github.com/mattermost/mattermost-plugin-agents/embeddings/mocks"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 	"github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -345,7 +347,7 @@ func TestCheckModelCompatibility(t *testing.T) {
 		{
 			name:                "fresh install with no stored info returns compatible",
 			storedInfo:          ModelInfo{},
-			storedInfoErr:       errors.New("not found"),
+			storedInfoErr:       mmapi.ErrKVNotFound,
 			currentProviderType: "openai",
 			currentDimensions:   1536,
 			currentModelName:    "text-embedding-3-small",
@@ -470,7 +472,7 @@ func TestCursorOperations(t *testing.T) {
 		mockClient := mocks.NewMockClient(t)
 
 		mockClient.On("KVGet", IndexerCursorKey, mock.AnythingOfType("*indexer.Cursor")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 
 		indexer := New(nil, nil, mockClient, nil, nil, nil)
 		loaded := indexer.loadCursor()
@@ -517,7 +519,7 @@ func TestLastIndexedTimestamp(t *testing.T) {
 		mockClient := mocks.NewMockClient(t)
 
 		mockClient.On("KVGet", IndexerLastIndexedKey, mock.AnythingOfType("*int64")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 
 		indexer := New(nil, nil, mockClient, nil, nil, nil)
 		loaded := indexer.getLastIndexedTimestamp()
@@ -703,7 +705,7 @@ func TestStartCatchUpJob(t *testing.T) {
 
 		// No previous timestamp stored
 		mockClient.On("KVGet", IndexerLastIndexedKey, mock.AnythingOfType("*int64")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 
 		indexer := New(func() embeddings.EmbeddingSearch { return mockSearch }, nil, mockClient, nil, nil, nil)
 		_, err := indexer.StartCatchUpJob()
@@ -1112,7 +1114,7 @@ func TestGetJobStatusIncludesStale(t *testing.T) {
 		mockClient := mocks.NewMockClient(t)
 
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 
 		indexer := New(nil, nil, mockClient, nil, nil, nil)
 		_, err := indexer.GetJobStatus()
@@ -1507,11 +1509,11 @@ func TestStartReindexJob(t *testing.T) {
 
 		// First KVGet (optimistic check) - no job running
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found")).Once()
+			Return(mmapi.ErrKVNotFound).Once()
 
 		// Second KVGet (after mutex acquired) - still no job running
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found")).Once()
+			Return(mmapi.ErrKVNotFound).Once()
 
 		var savedStatus *JobStatus
 		mockClient.On("KVCompareAndSet", ReindexJobKey, nil, mock.MatchedBy(func(v interface{}) bool {
@@ -1532,7 +1534,7 @@ func TestStartReindexJob(t *testing.T) {
 
 		// For the background job - we need to handle various operations
 		// The job will fail because we don't have full DB setup, but the start should succeed
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVCompareAndSet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
@@ -1566,11 +1568,11 @@ func TestStartReindexJob(t *testing.T) {
 
 		// First KVGet (optimistic check)
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found")).Once()
+			Return(mmapi.ErrKVNotFound).Once()
 
 		// Second KVGet (after mutex)
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found")).Once()
+			Return(mmapi.ErrKVNotFound).Once()
 
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
 
@@ -1707,7 +1709,7 @@ func TestStartCatchUpJob_AdditionalCases(t *testing.T) {
 
 		// Check if job is running
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 
 		mockClient.On("KVCompareAndSet", ReindexJobKey, nil, mock.MatchedBy(func(v interface{}) bool {
 			status, ok := v.(JobStatus)
@@ -1724,7 +1726,7 @@ func TestStartCatchUpJob_AdditionalCases(t *testing.T) {
 		})).Return(nil).Once()
 
 		// Background job operations
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVCompareAndSet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
@@ -1800,7 +1802,7 @@ func TestStartCatchUpJob_AdditionalCases(t *testing.T) {
 
 		// Check if job is running
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 
 		// Capture the saved job status to verify CutoffAt
 		var savedStatus JobStatus
@@ -1817,7 +1819,7 @@ func TestStartCatchUpJob_AdditionalCases(t *testing.T) {
 		mockClient.On("KVSet", IndexerCursorKey, mock.Anything).Return(nil).Once()
 
 		// Background job operations
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVCompareAndSet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
@@ -1892,7 +1894,7 @@ func TestStartCatchUpJob_AdditionalCases(t *testing.T) {
 
 		// Check if job is running - return not found
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 
 		// Cursor operations - the catch-up job sets cursor to start from lastIndexedTime
 		// When the background job loads it, return the cursor that was set
@@ -1905,7 +1907,7 @@ func TestStartCatchUpJob_AdditionalCases(t *testing.T) {
 			Return(nil).Maybe()
 
 		// Other KVGet calls (like model info)
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 
 		// Track which documents are stored
 		var storedPostIDs []string
@@ -1978,7 +1980,7 @@ func TestRunReindexJob(t *testing.T) {
 		mockSearch.On("Store", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 		// KV operations - use Maybe() for flexible matching
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
@@ -2070,7 +2072,7 @@ func TestRunReindexJob(t *testing.T) {
 			}).
 			Return(nil)
 		mockClient.On("KVGet", IndexerCursorKey, mock.AnythingOfType("*indexer.Cursor")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 		mockClient.On("KVCompareAndSet", ReindexJobKey, mock.Anything, mock.Anything).Return(true, nil)
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return()
 
@@ -2135,7 +2137,7 @@ func TestJobProgressAndHeartbeat(t *testing.T) {
 		mockSearch.On("Store", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 		// Use Maybe() for all mocks to make them flexible
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 
 		// Track job status saves
 		saveCount := 0
@@ -2201,7 +2203,7 @@ func TestBatchProcessing(t *testing.T) {
 			}).
 			Return(nil).Maybe()
 
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
@@ -2261,7 +2263,7 @@ func TestCutoffTimestampHandling(t *testing.T) {
 		mockSearch.On("Clear", mock.Anything).Return(nil)
 		mockSearch.On("Store", mock.Anything, mock.Anything).Return(nil).Maybe()
 
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
@@ -2568,14 +2570,14 @@ func TestResumeFromCheckpoint(t *testing.T) {
 
 		// KV operations
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found")).Maybe()
+			Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVGet", IndexerCursorKey, mock.AnythingOfType("*indexer.Cursor")).
 			Run(func(args mock.Arguments) {
 				cursor := args.Get(1).(*Cursor)
 				*cursor = savedCursor
 			}).
 			Return(nil).Once()
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
@@ -2643,8 +2645,8 @@ func TestResumeFromCheckpoint(t *testing.T) {
 
 		// No cursor exists
 		mockClient.On("KVGet", IndexerCursorKey, mock.AnythingOfType("*indexer.Cursor")).
-			Return(errors.New("not found"))
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+			Return(mmapi.ErrKVNotFound)
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
@@ -2703,7 +2705,7 @@ func TestResumeFromCheckpoint(t *testing.T) {
 
 		// Track cursor saves
 		var savedCursor *Cursor
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", IndexerCursorKey, mock.AnythingOfType("indexer.Cursor")).
 			Run(func(args mock.Arguments) {
 				c := args.Get(1).(Cursor)
@@ -2850,7 +2852,7 @@ func TestMarkOrphanedJobAsFailed(t *testing.T) {
 		mockClient := mocks.NewMockClient(t)
 
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 
 		indexer := New(nil, nil, mockClient, nil, nil, nil)
 		err := indexer.MarkOrphanedJobAsFailed()
@@ -2959,7 +2961,7 @@ func TestCatchUpPassHeartbeat(t *testing.T) {
 		mockSearch.On("Clear", mock.Anything).Return(nil)
 		mockSearch.On("Store", mock.Anything, mock.Anything).Return(nil).Maybe()
 
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
@@ -3008,7 +3010,7 @@ func TestCatchUpPassHeartbeat(t *testing.T) {
 		mockSearch.On("Clear", mock.Anything).Return(nil)
 		mockSearch.On("Store", mock.Anything, mock.Anything).Return(nil).Maybe()
 
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 
 		// Track job status saves during catch-up
 		catchUpSaveCount := 0
@@ -3070,7 +3072,7 @@ func TestCatchUpFailureHandling(t *testing.T) {
 		// Track whether we're in catch-up phase (no posts before cutoff means first Store is catch-up)
 		mockSearch.On("Store", mock.Anything, mock.Anything).Return(errors.New("simulated catch-up failure"))
 
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
@@ -3133,7 +3135,7 @@ func TestResumePreservation(t *testing.T) {
 			Return(true, nil)
 		mockClient.On("KVCompareAndSet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
 		mockClient.On("LogError", mock.Anything, mock.Anything).Return().Maybe()
@@ -3178,7 +3180,7 @@ func TestResumePreservation(t *testing.T) {
 		mockSearch.On("Clear", mock.Anything).Return(nil).Maybe()
 		mockSearch.On("Store", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 
 		// Capture the new job status
 		var savedJobStatus *JobStatus
@@ -3190,7 +3192,7 @@ func TestResumePreservation(t *testing.T) {
 			Return(true, nil)
 		mockClient.On("KVCompareAndSet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
 		mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 		mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
 		mockClient.On("LogWarn", mock.Anything, mock.Anything).Return().Maybe()
 		mockClient.On("LogError", mock.Anything, mock.Anything).Return().Maybe()
@@ -3395,8 +3397,8 @@ func TestReindexJobCancelReplicaLagRace(t *testing.T) {
 			Return(nil)
 
 		mockClient.On("KVGet", IndexerCursorKey, mock.AnythingOfType("*indexer.Cursor")).
-			Return(errors.New("not found"))
-		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+			Return(mmapi.ErrKVNotFound)
+		mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 
 		var storedPostIDs []string
 		var storedMu sync.Mutex
@@ -3466,7 +3468,7 @@ func TestReindexJobCancelReplicaLagRace(t *testing.T) {
 			}).
 			Return(nil)
 		mockClient.On("KVGet", IndexerCursorKey, mock.AnythingOfType("*indexer.Cursor")).
-			Return(errors.New("not found"))
+			Return(mmapi.ErrKVNotFound)
 		mockSearch.On("Clear", mock.Anything).Return(nil).Maybe()
 
 		var sawCancelCAS bool
@@ -3523,8 +3525,8 @@ func TestStartReindexJobAssignsFreshJobID(t *testing.T) {
 	mockMutexAPI.On("KVDelete", mock.AnythingOfType("string")).Return(nil).Maybe()
 
 	mockClient.On("KVGet", ReindexJobKey, mock.AnythingOfType("*indexer.JobStatus")).
-		Return(errors.New("not found")).Maybe()
-	mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+		Return(mmapi.ErrKVNotFound).Maybe()
+	mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 
 	var captured string
 	mockClient.On("KVCompareAndSet", ReindexJobKey, mock.Anything, mock.AnythingOfType("indexer.JobStatus")).
@@ -3784,7 +3786,7 @@ func TestCatchUpPassSkipsAlreadyIndexedPosts(t *testing.T) {
 			// No Store expectation when expectedStoredIDs is empty — an
 			// unexpected Store call will then fail the test.
 
-			mockClient.On("KVGet", mock.Anything, mock.Anything).Return(errors.New("not found")).Maybe()
+			mockClient.On("KVGet", mock.Anything, mock.Anything).Return(mmapi.ErrKVNotFound).Maybe()
 			mockClient.On("KVSet", mock.Anything, mock.Anything).Return(nil).Maybe()
 			mockClient.On("KVCompareAndSet", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
 			mockClient.On("KVDelete", mock.Anything).Return(nil).Maybe()
@@ -3805,4 +3807,77 @@ func TestCatchUpPassSkipsAlreadyIndexedPosts(t *testing.T) {
 			assert.ElementsMatch(t, tc.expectedStoredIDs, storedPostIDs)
 		})
 	}
+}
+
+// Exercises the real mmapi.Client wrapper against upstream's authentic
+// "(nil, nil) on missing" reply, the contract previous test sites mocked
+// over. Reproduces the fresh-install 409.
+func TestStartReindexJob_FreshInstall_AuthenticUpstreamContract(t *testing.T) {
+	db := testDB(t)
+	defer cleanupDB(t, db)
+
+	pluginTestAPI := &plugintest.API{}
+	pluginTestAPI.On("KVGet", mock.AnythingOfType("string")).Return(nil, nil)
+
+	// Capture every CAS attempt against ReindexJobKey so we can assert
+	// the production invariant directly: a fresh-install Start must CAS
+	// with an empty OldValue. The matchers simulate real KV CAS
+	// semantics so the test fails fast against the broken wrapper; the
+	// capture is what pins the invariant in case those semantics drift.
+	var reindexCASOldValues [][]byte
+	pluginTestAPI.On("KVSetWithOptions",
+		ReindexJobKey,
+		mock.AnythingOfType("[]uint8"),
+		mock.AnythingOfType("model.PluginKVSetOptions"),
+	).Run(func(args mock.Arguments) {
+		opts := args.Get(2).(model.PluginKVSetOptions)
+		if opts.Atomic {
+			reindexCASOldValues = append(reindexCASOldValues, opts.OldValue)
+		}
+	}).Return(func(_ string, _ []byte, opts model.PluginKVSetOptions) (bool, *model.AppError) {
+		if opts.Atomic && len(opts.OldValue) > 0 {
+			return false, nil
+		}
+		return true, nil
+	}).Maybe()
+	// Cluster mutex and any non-ReindexJobKey writes follow the same
+	// CAS shape but aren't what we care about here.
+	pluginTestAPI.On("KVSetWithOptions",
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("[]uint8"),
+		mock.AnythingOfType("model.PluginKVSetOptions"),
+	).Return(true, (*model.AppError)(nil)).Maybe()
+	pluginTestAPI.On("KVDelete", mock.AnythingOfType("string")).Return((*model.AppError)(nil)).Maybe()
+	pluginTestAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+	pluginTestAPI.On("LogWarn", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+	pluginTestAPI.On("LogDebug", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+
+	pluginAPIClient := pluginapi.NewClient(pluginTestAPI, nil)
+	realClient := mmapi.NewClient(pluginAPIClient)
+
+	mockSearch := embeddingsmocks.NewMockEmbeddingSearch(t)
+	mockSearch.On("Clear", mock.Anything).Return(nil).Maybe()
+	mockSearch.On("Store", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	indexer := New(
+		func() embeddings.EmbeddingSearch { return mockSearch },
+		nil,
+		realClient,
+		&bots.MMBots{},
+		db,
+		pluginTestAPI,
+	)
+
+	status, err := indexer.StartReindexJob(true)
+	require.NoError(t, err, "fresh-install Start must succeed; a 409 here is the user-visible regression")
+	assert.NotEmpty(t, status.JobID)
+	assert.Equal(t, JobStatusRunning, status.Status)
+	assert.False(t, status.StartedAt.IsZero())
+
+	require.NotEmpty(t, reindexCASOldValues, "expected at least one atomic CAS against ReindexJobKey")
+	require.Empty(t, reindexCASOldValues[0],
+		"fresh-install CAS must use empty OldValue; non-empty means the wrapper "+
+			"masked a missing key as present-but-zero")
+
+	time.Sleep(50 * time.Millisecond) // let background goroutine settle
 }

--- a/mcp/oauth_manager_test.go
+++ b/mcp/oauth_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 	"github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/mock"
@@ -483,15 +484,18 @@ func TestProcessCallback_InvalidSession(t *testing.T) {
 	state := "test-state"
 	code := "auth-code"
 
-	// Mock session not found - KVGet should return an error
-	appErr := model.NewAppError("test", "not_found", nil, "session not found", 404)
-	mockClient.On("KVGet", mock.AnythingOfType("string"), mock.AnythingOfType("*mcp.OAuthSession")).Return(appErr)
+	// Missing session must surface as an error rather than nil-panic on
+	// session.State below. Asserting ErrorIs against the sentinel pins
+	// that the wrap chain survives ProcessCallback's fmt.Errorf and is
+	// not hostage to the user-facing wording.
+	mockClient.On("KVGet", mock.AnythingOfType("string"), mock.AnythingOfType("*mcp.OAuthSession")).Return(mmapi.ErrKVNotFound)
 
 	ctx := context.Background()
 	session, err := manager.ProcessCallback(ctx, userID, state, code)
 
 	require.Error(t, err)
 	require.Nil(t, session)
+	require.ErrorIs(t, err, mmapi.ErrKVNotFound)
 	require.Contains(t, err.Error(), "invalid or expired session")
 }
 

--- a/mcp/oauth_store.go
+++ b/mcp/oauth_store.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 	"golang.org/x/oauth2"
 )
 
@@ -50,6 +51,9 @@ func (m *OAuthManager) loadToken(userID, serverID string) (*oauth2.Token, error)
 	var oauth2Token oauth2.Token
 	err := m.pluginAPI.KVGet(tokenKey, &oauth2Token)
 	if err != nil {
+		if mmapi.IsKVNotFound(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to retrieve token from KV store: %w", err)
 	}
 
@@ -84,6 +88,9 @@ func (m *OAuthManager) LoadAuthNeededState(userID, serverID string) (*OAuthNeede
 	var state OAuthNeededState
 	err := m.pluginAPI.KVGet(authNeededKey, &state)
 	if err != nil {
+		if mmapi.IsKVNotFound(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to retrieve OAuth-needed state from KV store: %w", err)
 	}
 
@@ -155,6 +162,9 @@ func (m *OAuthManager) loadClientCredentials(serverURL string) (*ClientCredentia
 	var creds ClientCredentials
 	err := m.pluginAPI.KVGet(credKey, &creds)
 	if err != nil {
+		if mmapi.IsKVNotFound(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to retrieve client credentials from KV store: %w", err)
 	}
 
@@ -197,6 +207,8 @@ type OAuthSession struct {
 	CreatedAt         time.Time `json:"createdAt"`
 }
 
+// Unlike the other loaders, a missing key surfaces as an error here:
+// ProcessCallback nil-derefs the returned session unguarded.
 func (m *OAuthManager) loadSession(userID, state string) (*OAuthSession, error) {
 	sessionKey := buildSessionKey(userID, state)
 

--- a/mcp/user_preferences.go
+++ b/mcp/user_preferences.go
@@ -38,6 +38,9 @@ func userPreferencesKVKey(userID string) string {
 func LoadUserPreferences(pluginAPI mmapi.Client, userID string) (*UserToolProviderPreferences, error) {
 	var prefs UserToolProviderPreferences
 	if err := pluginAPI.KVGet(userPreferencesKVKey(userID), &prefs); err != nil {
+		if mmapi.IsKVNotFound(err) {
+			return &UserToolProviderPreferences{DisabledServers: []string{}}, nil
+		}
 		return nil, fmt.Errorf("failed to load user preferences: %w", err)
 	}
 	if prefs.DisabledServers == nil {

--- a/mmapi/client.go
+++ b/mmapi/client.go
@@ -4,6 +4,9 @@
 package mmapi
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -11,6 +14,10 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 )
+
+// ErrKVNotFound disambiguates a missing key from a present-but-zero value:
+// upstream pluginapi.KV.Get returns (nil err, empty bytes) for missing keys.
+var ErrKVNotFound = errors.New("kv key not found")
 
 type Client interface {
 	GetUser(userID string) (*model.User, error)
@@ -89,18 +96,28 @@ func (m *client) LogWarn(msg string, keyValuePairs ...interface{}) {
 	m.pluginAPI.Log.Warn(msg, keyValuePairs...)
 }
 
+// KVGet reads raw bytes from pluginapi so it can translate the upstream
+// "(nil err, empty bytes)" reply for a missing key into ErrKVNotFound.
 func (m *client) KVGet(key string, value interface{}) error {
-	return m.pluginAPI.KV.Get(key, value)
+	var raw []byte
+	if err := m.pluginAPI.KV.Get(key, &raw); err != nil {
+		return err
+	}
+	if len(raw) == 0 {
+		return ErrKVNotFound
+	}
+	if bytesOut, ok := value.(*[]byte); ok {
+		*bytesOut = raw
+		return nil
+	}
+	if err := json.Unmarshal(raw, value); err != nil {
+		return fmt.Errorf("failed to unmarshal value for key %s: %w", key, err)
+	}
+	return nil
 }
 
-// IsKVNotFound returns true if the error represents a KV key not found condition.
-// The pluginapi returns ErrNotFound (with message "not found") for 404 status codes,
-// and test mocks use the same error message convention.
 func IsKVNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	return err.Error() == "not found"
+	return errors.Is(err, ErrKVNotFound)
 }
 
 func (m *client) KVSet(key string, value interface{}) error {

--- a/mmapi/client_test.go
+++ b/mmapi/client_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mmapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/stretchr/testify/require"
+)
+
+type sampleKVValue struct {
+	A string `json:"a"`
+	B int    `json:"b"`
+}
+
+func newTestClient(api *plugintest.API) *client {
+	pluginAPI := pluginapi.NewClient(api, nil)
+	return &client{
+		PostService:          pluginAPI.Post,
+		UserService:          pluginAPI.User,
+		FrontendService:      pluginAPI.Frontend,
+		ConfigurationService: pluginAPI.Configuration,
+		pluginAPI:            pluginAPI,
+	}
+}
+
+func TestKVGet_MissingKeyReturnsErrKVNotFound(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	mockAPI.On("KVGet", "missing-key").Return(nil, nil).Once()
+
+	c := newTestClient(mockAPI)
+
+	var dest sampleKVValue
+	err := c.KVGet("missing-key", &dest)
+
+	require.ErrorIs(t, err, ErrKVNotFound)
+	require.Equal(t, sampleKVValue{}, dest)
+	mockAPI.AssertExpectations(t)
+}
+
+func TestKVGet_PresentKeyUnmarshals(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	mockAPI.On("KVGet", "present").Return([]byte(`{"a":"hello","b":42}`), nil).Once()
+
+	c := newTestClient(mockAPI)
+
+	var dest sampleKVValue
+	err := c.KVGet("present", &dest)
+
+	require.NoError(t, err)
+	require.Equal(t, sampleKVValue{A: "hello", B: 42}, dest)
+	mockAPI.AssertExpectations(t)
+}
+
+func TestKVGet_BytesPassthrough(t *testing.T) {
+	raw := []byte(`raw-payload`)
+
+	mockAPI := &plugintest.API{}
+	mockAPI.On("KVGet", "bytes").Return(raw, nil).Once()
+
+	c := newTestClient(mockAPI)
+
+	var dest []byte
+	err := c.KVGet("bytes", &dest)
+
+	require.NoError(t, err)
+	require.Equal(t, raw, dest)
+	mockAPI.AssertExpectations(t)
+}
+
+func TestKVGet_BytesPassthroughMissingKey(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	mockAPI.On("KVGet", "bytes-missing").Return(nil, nil).Once()
+
+	c := newTestClient(mockAPI)
+
+	var dest []byte
+	err := c.KVGet("bytes-missing", &dest)
+
+	require.ErrorIs(t, err, ErrKVNotFound)
+	require.Nil(t, dest)
+	mockAPI.AssertExpectations(t)
+}
+
+func TestKVGet_UnmarshalErrorWrapsKey(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	mockAPI.On("KVGet", "bad-json").Return([]byte(`{not json`), nil).Once()
+
+	c := newTestClient(mockAPI)
+
+	var dest sampleKVValue
+	err := c.KVGet("bad-json", &dest)
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrKVNotFound)
+	require.Contains(t, err.Error(), "bad-json", "key should appear in the error to aid debugging")
+	var syntaxErr *json.SyntaxError
+	require.ErrorAs(t, err, &syntaxErr, "underlying json decode error must survive the %w wrap")
+	mockAPI.AssertExpectations(t)
+}
+
+func TestKVGet_UnderlyingErrorPropagates(t *testing.T) {
+	appErr := model.NewAppError("KVGet", "boom", nil, "db down", 500)
+
+	mockAPI := &plugintest.API{}
+	mockAPI.On("KVGet", "db-error").Return(nil, appErr).Once()
+
+	c := newTestClient(mockAPI)
+
+	var dest sampleKVValue
+	err := c.KVGet("db-error", &dest)
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrKVNotFound)
+	var got *model.AppError
+	require.ErrorAs(t, err, &got, "underlying *model.AppError must survive the wrapper")
+	require.Equal(t, http.StatusInternalServerError, got.StatusCode)
+	require.Contains(t, err.Error(), "db down")
+	mockAPI.AssertExpectations(t)
+}
+
+func TestIsKVNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil is not a not-found",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "sentinel itself",
+			err:  ErrKVNotFound,
+			want: true,
+		},
+		{
+			name: "wrapped sentinel",
+			err:  fmt.Errorf("oauth load: %w", ErrKVNotFound),
+			want: true,
+		},
+		{
+			name: "string-equal but not the sentinel",
+			err:  errors.New("kv key not found"),
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsKVNotFound(tt.err))
+		})
+	}
+}
+
+// Pins upstream pluginapi.KV.Get's missing-key contract directly (skipping
+// the mmapi wrapper). If upstream ever stops returning (nil, nil) for a
+// missing key, this test breaks immediately — independent of our wrapper.
+func TestUpstreamPluginAPIMissingKeyContract(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	mockAPI.On("KVGet", "never-set").Return(nil, nil).Once()
+
+	pluginAPI := pluginapi.NewClient(mockAPI, nil)
+
+	var raw []byte
+	err := pluginAPI.KV.Get("never-set", &raw)
+
+	require.NoError(t, err, "upstream signals missing via nil err, not an error")
+	require.Empty(t, raw, "upstream signals missing via empty bytes")
+}


### PR DESCRIPTION
#### Summary

On a fresh install, the first click of "Full Reindex" in the system console returned 409 and could not recover. Regression from #689 (commit fb01e43f), present in v2.0.0–v2.0.3.

Root cause: `mmapi.KVGet` passed upstream `pluginapi.KV.Get`'s `(nil err, empty bytes)` reply through unchanged, so callers could not distinguish "missing" from "present-but-zero." `mmapi.IsKVNotFound` then matched the literal string `"not found"`, which the real pluginapi never returns for missing keys. The indexer's CAS ran with a marshaled zero `JobStatus` as `oldValue` against an empty KV store and lost — surfacing as "job already running" → 409.

Fix:
- `mmapi.KVGet` reads raw bytes and translates the empty-bytes reply into a new `ErrKVNotFound` sentinel. `IsKVNotFound` uses `errors.Is`.
- Updated 4 sites in `mcp/oauth_store.go` and 1 in `mcp/user_preferences.go` that silently depended on the old "(nil, empty struct)" behavior to preserve their documented "default on missing" semantics. `loadSession` deliberately propagates the error — its caller (`ProcessCallback`) dereferences the returned session unguarded, so a missing session must surface as `"invalid or expired session"`, not nil-panic.
- Swept indexer/api tests that mocked the wrapper with `errors.New("not found")` to use the sentinel directly.

Tests:
- New `mmapi/client_test.go` pins the wrapper contract (missing key, present-key unmarshal, bytes passthrough, unmarshal error preserves `%w` chain, underlying `*model.AppError` survives the wrapper).
- New `TestStartReindexJob_FreshInstall_AuthenticUpstreamContract` exercises the real `mmapi.Client` wrapping `plugintest.API` returning `(nil, nil)` (the authentic upstream signal previous test sites mocked over). Captures the CAS call and asserts the production invariant: fresh-install CAS must use an empty `OldValue`.
- `TestHandleGetJobStatusIncludesStale` extended to cover `404 {"status":"no_job"}` for fresh installs.
- `TestProcessCallback_InvalidSession` updated to use `mmapi.ErrKVNotFound` and assert wrap-chain preservation.

#### Ticket Link

Regression from #689 (commit fb01e43f). Affects v2.0.0–v2.0.3.

#### Test plan

- [x] `go test ./mmapi/ ./api/ ./indexer/ ./mcp/` — all green
- [ ] Deploy to a fresh local Mattermost (no prior reindex), click "Full Reindex" in the system console, confirm 200 + progress UI

#### Release Note
```release-note
Fixed a regression where the first click of "Full Reindex" in the system console returned an error on a fresh install and could not recover. Affects v2.0.0–v2.0.3.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for key-value storage and fresh-install semantics, including new checks for missing-job and missing-key behaviours.

* **Bug Fixes**
  * Standardised handling of missing key data: returns sensible defaults (e.g. user preferences, token state) or a clear 404 {"status":"no_job"} for cancel/status endpoints on fresh installs, reducing spurious errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-agents/pull/764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->