### PR TITLE
Add Makefile FIPS targets for FIPS-compliant plugin bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,22 @@ $(info Note: public/ directory contains Go modules, not HTTP assets - skipping b
 
 BUNDLE_NAME ?= $(PLUGIN_ID)-$(PLUGIN_VERSION).tar.gz
 
+# Output dir + source dir for the server binaries. Defaults match the
+# non-FIPS layout; bundle-fips (in build/fips.mk) overrides both to share
+# this target instead of duplicating its LICENSE/NOTICE/assets/webapp/tar
+# logic.
+BUNDLE_DIR ?= dist
+SERVER_DIST_SRC ?= server/dist
+
 # Include custom makefile, if present
 ifneq ($(wildcard build/custom.mk),)
 	include build/custom.mk
+endif
+
+# Include FIPS makefile, if present. Its presence is also the marker the
+# delivery-platform release pipeline uses to detect FIPS opt-in.
+ifneq ($(wildcard build/fips.mk),)
+	include build/fips.mk
 endif
 
 ifneq ($(MM_DEBUG),)
@@ -319,36 +332,36 @@ endif
 ## Generates a tar bundle of the plugin for install.
 .PHONY: bundle
 bundle:
-	rm -rf dist/
-	mkdir -p dist/$(PLUGIN_ID)
-	./build/bin/manifest dist
+	rm -rf $(BUNDLE_DIR)/
+	mkdir -p $(BUNDLE_DIR)/$(PLUGIN_ID)
+	./build/bin/manifest dist $(BUNDLE_DIR)
 ifneq ($(wildcard LICENSE.txt),)
-	cp -r LICENSE.txt dist/$(PLUGIN_ID)/
+	cp -r LICENSE.txt $(BUNDLE_DIR)/$(PLUGIN_ID)/
 endif
 ifneq ($(wildcard NOTICE.txt),)
-	cp -r NOTICE.txt dist/$(PLUGIN_ID)/
+	cp -r NOTICE.txt $(BUNDLE_DIR)/$(PLUGIN_ID)/
 endif
 ifneq ($(wildcard $(ASSETS_DIR)/.),)
-	cp -r $(ASSETS_DIR) dist/$(PLUGIN_ID)/
+	cp -r $(ASSETS_DIR) $(BUNDLE_DIR)/$(PLUGIN_ID)/
 endif
 ifneq ($(HAS_PUBLIC),)
-	cp -r public dist/$(PLUGIN_ID)/
+	cp -r public $(BUNDLE_DIR)/$(PLUGIN_ID)/
 endif
 ifneq ($(HAS_SERVER),)
-	mkdir -p dist/$(PLUGIN_ID)/server
-	cp -r server/dist dist/$(PLUGIN_ID)/server/
+	mkdir -p $(BUNDLE_DIR)/$(PLUGIN_ID)/server/dist
+	cp -r $(SERVER_DIST_SRC)/. $(BUNDLE_DIR)/$(PLUGIN_ID)/server/dist/
 endif
 ifneq ($(HAS_WEBAPP),)
-	mkdir -p dist/$(PLUGIN_ID)/webapp
-	cp -r webapp/dist dist/$(PLUGIN_ID)/webapp/
+	mkdir -p $(BUNDLE_DIR)/$(PLUGIN_ID)/webapp
+	cp -r webapp/dist $(BUNDLE_DIR)/$(PLUGIN_ID)/webapp/
 endif
 ifeq ($(shell uname),Darwin)
-	cd dist && tar --disable-copyfile -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+	cd $(BUNDLE_DIR) && tar --disable-copyfile -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
 else
-	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+	cd $(BUNDLE_DIR) && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
 endif
 
-	@echo plugin built at: dist/$(BUNDLE_NAME)
+	@echo plugin built at: $(BUNDLE_DIR)/$(BUNDLE_NAME)
 
 ## Builds the server for Linux amd64 only (CI optimized).
 .PHONY: server-ci
@@ -551,9 +564,12 @@ mock:
 .PHONY: clean
 clean:
 	rm -fr dist/
+	rm -fr dist-fips/
 ifneq ($(HAS_SERVER),)
 	rm -fr server/coverage.txt
 	rm -fr server/dist
+	rm -fr server/dist-fips
+	rm -fr server/dist-fips-staged
 endif
 ifneq ($(HAS_WEBAPP),)
 	rm -fr webapp/junit.xml

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,6 @@ HAS_PUBLIC :=
 $(info Note: public/ directory contains Go modules, not HTTP assets - skipping bundle)
 
 BUNDLE_NAME ?= $(PLUGIN_ID)-$(PLUGIN_VERSION).tar.gz
-
-# Output dir + source dir for the server binaries. Defaults match the
-# non-FIPS layout; bundle-fips (in build/fips.mk) overrides both to share
-# this target instead of duplicating its LICENSE/NOTICE/assets/webapp/tar
-# logic.
 BUNDLE_DIR ?= dist
 SERVER_DIST_SRC ?= server/dist
 
@@ -46,8 +41,7 @@ ifneq ($(wildcard build/custom.mk),)
 	include build/custom.mk
 endif
 
-# Include FIPS makefile, if present. Its presence is also the marker the
-# delivery-platform release pipeline uses to detect FIPS opt-in.
+# Presence of build/fips.mk is the per-plugin FIPS opt-in marker.
 ifneq ($(wildcard build/fips.mk),)
 	include build/fips.mk
 endif

--- a/build/fips.mk
+++ b/build/fips.mk
@@ -1,0 +1,65 @@
+# FIPS build targets. Opt-in: a plugin includes this file via the same
+# wildcard mechanism the Makefile uses for build/custom.mk. The file's
+# presence is also the marker the delivery-platform release pipeline uses
+# to detect that a plugin has opted into the FIPS build leg.
+#
+# Linux/amd64 only — that's the only platform Mattermost server's FIPS
+# release path supports today.
+
+FIPS_IMAGE ?= cgr.dev/mattermost.com/go-msft-fips:1.26.3-dev@sha256:48ab99fede7fb33e132a0636072971e1ec4a69520865bfa1e4b517ee9cfdef34
+BUNDLE_NAME_FIPS ?= $(PLUGIN_ID)-$(PLUGIN_VERSION)-fips.tar.gz
+FIPS_BIN := server/dist-fips/plugin-linux-amd64-fips
+
+# Builds the server binary inside the FIPS Go toolchain image. The
+# GO_BUILD_* values are Make-side-interpolated into a single-quoted inner
+# shell script so the FIPS binary is built with the same -ldflags,
+# -gcflags, etc. as the non-FIPS one. Env-var passing (`-e VAR=...`) is
+# unsafe here because GO_BUILD_LDFLAGS / GO_BUILD_GCFLAGS contain embedded
+# double quotes (e.g. `-ldflags="-s -w"`) that don't survive a second pass
+# of shell word splitting inside the container.
+.PHONY: server-fips
+server-fips: generate
+	mkdir -p server/dist-fips
+	docker run --rm \
+	  --entrypoint="" \
+	  -v $(PWD):/plugin \
+	  -w /plugin/server \
+	  $(FIPS_IMAGE) \
+	  /bin/sh -c 'CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
+	    go build -trimpath -buildvcs=false \
+	    $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) $(GO_BUILD_LDFLAGS) \
+	    -tags requirefips \
+	    -o dist-fips/plugin-linux-amd64-fips'
+
+# Asserts FIPS markers on the produced binary. Same three checks the server
+# Makefile uses (mattermost/server/build/release.mk). Each check is its OWN
+# Make recipe line so a failure aborts immediately; joining them with `; \`
+# would propagate only the final command's exit status and let a failed
+# check silently pass.
+.PHONY: verify-fips
+verify-fips:
+	@test -f $(FIPS_BIN) || (echo "verify-fips: $(FIPS_BIN) not built" && exit 1)
+	$(GO) version -m $(FIPS_BIN) | grep -q "GOEXPERIMENT=systemcrypto" || (echo "ERROR: missing GOEXPERIMENT=systemcrypto" && exit 1)
+	$(GO) version -m $(FIPS_BIN) | grep "\-tags" | grep -q "requirefips" || (echo "ERROR: missing -tags=requirefips" && exit 1)
+	$(GO) tool nm $(FIPS_BIN) | grep -qE "func_go_openssl_OpenSSL_version|_mkcgo_OpenSSL_version" || (echo "ERROR: missing OpenSSL integration" && exit 1)
+	@echo "verify-fips: OK"
+
+# bundle-fips is a thin wrapper over `bundle`. The only things that differ
+# between FIPS and non-FIPS bundling are the server-binary source dir, the
+# output dir, and the tarball filename — all three parameterized on `bundle`
+# itself via BUNDLE_DIR / BUNDLE_NAME / SERVER_DIST_SRC.
+.PHONY: bundle-fips
+bundle-fips:
+	rm -rf server/dist-fips-staged
+	mkdir -p server/dist-fips-staged
+	@test -f $(FIPS_BIN) \
+	  || (echo "bundle-fips: $(FIPS_BIN) missing — did server-fips run?" && exit 1)
+	cp $(FIPS_BIN) server/dist-fips-staged/plugin-linux-amd64
+	$(MAKE) bundle BUNDLE_DIR=dist-fips BUNDLE_NAME=$(BUNDLE_NAME_FIPS) SERVER_DIST_SRC=server/dist-fips-staged
+
+.PHONY: dist-fips
+dist-fips: apply server-fips verify-fips webapp bundle-fips
+
+# Flat prerequisite list so `apply` and `webapp` run once, not twice.
+.PHONY: dist-all
+dist-all: apply webapp server server-fips verify-fips bundle bundle-fips

--- a/build/fips.mk
+++ b/build/fips.mk
@@ -10,13 +10,23 @@ FIPS_IMAGE ?= cgr.dev/mattermost.com/go-msft-fips:1.26.3-dev@sha256:48ab99fede7f
 BUNDLE_NAME_FIPS ?= $(PLUGIN_ID)-$(PLUGIN_VERSION)-fips.tar.gz
 FIPS_BIN := server/dist-fips/plugin-linux-amd64-fips
 
+# The FIPS build deliberately does NOT inherit GO_BUILD_LDFLAGS, because the
+# plugin's default release LDFLAGS is `-ldflags="-s -w"` (strip symbol +
+# DWARF tables). With `-s` the binary has no symbol section, and the
+# canonical `go tool nm | grep …OpenSSL_version` check in verify-fips
+# returns zero symbols and fails. `mattermost/server`'s LDFLAGS doesn't
+# include `-s -w` (it only injects build-info -X values), which is why the
+# same nm check works there. Unstripped FIPS binaries are larger but
+# verifiable; that's the right tradeoff for a compliance gate.
+FIPS_GO_BUILD_LDFLAGS ?=
+
 # Builds the server binary inside the FIPS Go toolchain image. The
 # GO_BUILD_* values are Make-side-interpolated into a single-quoted inner
-# shell script so the FIPS binary is built with the same -ldflags,
-# -gcflags, etc. as the non-FIPS one. Env-var passing (`-e VAR=...`) is
-# unsafe here because GO_BUILD_LDFLAGS / GO_BUILD_GCFLAGS contain embedded
-# double quotes (e.g. `-ldflags="-s -w"`) that don't survive a second pass
-# of shell word splitting inside the container.
+# shell script so the FIPS binary is built with the same -gcflags etc. as
+# the non-FIPS one (LDFLAGS excepted — see above). Env-var passing
+# (`-e VAR=...`) is unsafe because GO_BUILD_GCFLAGS can contain embedded
+# double quotes (e.g. `-gcflags "all=-N -l"`) that don't survive a second
+# pass of shell word splitting inside the container.
 .PHONY: server-fips
 server-fips: generate
 	mkdir -p server/dist-fips
@@ -27,7 +37,7 @@ server-fips: generate
 	  $(FIPS_IMAGE) \
 	  /bin/sh -c 'CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
 	    go build -trimpath -buildvcs=false \
-	    $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) $(GO_BUILD_LDFLAGS) \
+	    $(GO_BUILD_FLAGS) $(GO_BUILD_GCFLAGS) $(FIPS_GO_BUILD_LDFLAGS) \
 	    -tags requirefips \
 	    -o dist-fips/plugin-linux-amd64-fips'
 
@@ -48,12 +58,15 @@ verify-fips:
 # between FIPS and non-FIPS bundling are the server-binary source dir, the
 # output dir, and the tarball filename — all three parameterized on `bundle`
 # itself via BUNDLE_DIR / BUNDLE_NAME / SERVER_DIST_SRC.
+#
+# Depends on verify-fips so a direct `make bundle-fips` invocation can't
+# package a binary that hasn't passed the FIPS marker checks. Make
+# deduplicates phony targets within a single invocation, so dist-fips /
+# dist-all still run verify-fips exactly once.
 .PHONY: bundle-fips
-bundle-fips:
+bundle-fips: verify-fips
 	rm -rf server/dist-fips-staged
 	mkdir -p server/dist-fips-staged
-	@test -f $(FIPS_BIN) \
-	  || (echo "bundle-fips: $(FIPS_BIN) missing — did server-fips run?" && exit 1)
 	cp $(FIPS_BIN) server/dist-fips-staged/plugin-linux-amd64
 	$(MAKE) bundle BUNDLE_DIR=dist-fips BUNDLE_NAME=$(BUNDLE_NAME_FIPS) SERVER_DIST_SRC=server/dist-fips-staged
 

--- a/build/fips.mk
+++ b/build/fips.mk
@@ -1,32 +1,18 @@
-# FIPS build targets. Opt-in: a plugin includes this file via the same
-# wildcard mechanism the Makefile uses for build/custom.mk. The file's
-# presence is also the marker the delivery-platform release pipeline uses
-# to detect that a plugin has opted into the FIPS build leg.
-#
-# Linux/amd64 only — that's the only platform Mattermost server's FIPS
-# release path supports today.
+# FIPS-compliant Linux/amd64 build. Linux/amd64 is the only platform
+# mattermost-server's FIPS release path supports.
 
 FIPS_IMAGE ?= cgr.dev/mattermost.com/go-msft-fips:1.26.3-dev@sha256:48ab99fede7fb33e132a0636072971e1ec4a69520865bfa1e4b517ee9cfdef34
 BUNDLE_NAME_FIPS ?= $(PLUGIN_ID)-$(PLUGIN_VERSION)-fips.tar.gz
 FIPS_BIN := server/dist-fips/plugin-linux-amd64-fips
 
-# The FIPS build deliberately does NOT inherit GO_BUILD_LDFLAGS, because the
-# plugin's default release LDFLAGS is `-ldflags="-s -w"` (strip symbol +
-# DWARF tables). With `-s` the binary has no symbol section, and the
-# canonical `go tool nm | grep …OpenSSL_version` check in verify-fips
-# returns zero symbols and fails. `mattermost/server`'s LDFLAGS doesn't
-# include `-s -w` (it only injects build-info -X values), which is why the
-# same nm check works there. Unstripped FIPS binaries are larger but
-# verifiable; that's the right tradeoff for a compliance gate.
+# Empty by default. Inheriting the plugin's release LDFLAGS (`-ldflags="-s -w"`)
+# would strip the symbol table, and verify-fips below needs symbols intact
+# for `go tool nm` to find the OpenSSL integration.
 FIPS_GO_BUILD_LDFLAGS ?=
 
-# Builds the server binary inside the FIPS Go toolchain image. The
-# GO_BUILD_* values are Make-side-interpolated into a single-quoted inner
-# shell script so the FIPS binary is built with the same -gcflags etc. as
-# the non-FIPS one (LDFLAGS excepted — see above). Env-var passing
-# (`-e VAR=...`) is unsafe because GO_BUILD_GCFLAGS can contain embedded
-# double quotes (e.g. `-gcflags "all=-N -l"`) that don't survive a second
-# pass of shell word splitting inside the container.
+# GO_BUILD_* are Make-substituted into the single-quoted inner script.
+# Env-var passing (`-e VAR=...`) doesn't survive a second pass of word
+# splitting on values with embedded quotes like `-gcflags "all=-N -l"`.
 .PHONY: server-fips
 server-fips: generate
 	mkdir -p server/dist-fips
@@ -41,11 +27,9 @@ server-fips: generate
 	    -tags requirefips \
 	    -o dist-fips/plugin-linux-amd64-fips'
 
-# Asserts FIPS markers on the produced binary. Same three checks the server
-# Makefile uses (mattermost/server/build/release.mk). Each check is its OWN
-# Make recipe line so a failure aborts immediately; joining them with `; \`
-# would propagate only the final command's exit status and let a failed
-# check silently pass.
+# Mirrors mattermost-server/build/release.mk. Each check is its own recipe
+# line so a failure exits with the right status; joined with `; \`, only
+# the last command's exit propagates and a failed check would be masked.
 .PHONY: verify-fips
 verify-fips:
 	@test -f $(FIPS_BIN) || (echo "verify-fips: $(FIPS_BIN) not built" && exit 1)
@@ -54,15 +38,9 @@ verify-fips:
 	$(GO) tool nm $(FIPS_BIN) | grep -qE "func_go_openssl_OpenSSL_version|_mkcgo_OpenSSL_version" || (echo "ERROR: missing OpenSSL integration" && exit 1)
 	@echo "verify-fips: OK"
 
-# bundle-fips is a thin wrapper over `bundle`. The only things that differ
-# between FIPS and non-FIPS bundling are the server-binary source dir, the
-# output dir, and the tarball filename — all three parameterized on `bundle`
-# itself via BUNDLE_DIR / BUNDLE_NAME / SERVER_DIST_SRC.
-#
-# Depends on verify-fips so a direct `make bundle-fips` invocation can't
-# package a binary that hasn't passed the FIPS marker checks. Make
-# deduplicates phony targets within a single invocation, so dist-fips /
-# dist-all still run verify-fips exactly once.
+# Depends on verify-fips so a direct `make bundle-fips` can't package an
+# unverified binary. Phony-target dedup means dist-fips / dist-all still
+# run verify-fips exactly once.
 .PHONY: bundle-fips
 bundle-fips: verify-fips
 	rm -rf server/dist-fips-staged

--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -85,7 +85,11 @@ func main() {
 		}
 
 	case "dist":
-		if err := distManifest(manifest); err != nil {
+		outDir := "dist"
+		if len(os.Args) > 2 {
+			outDir = os.Args[2]
+		}
+		if err := distManifest(manifest, outDir); err != nil {
 			panic("failed to write manifest to dist directory: " + err.Error())
 		}
 
@@ -205,13 +209,13 @@ func applyManifest(manifest *model.Manifest) error {
 }
 
 // distManifest writes the manifest file to the dist directory
-func distManifest(manifest *model.Manifest) error {
+func distManifest(manifest *model.Manifest, outDir string) error {
 	manifestBytes, err := json.MarshalIndent(manifest, "", "    ")
 	if err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(fmt.Sprintf("dist/%s/plugin.json", manifest.Id), manifestBytes, 0600); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/%s/plugin.json", outDir, manifest.Id), manifestBytes, 0600); err != nil {
 		return errors.Wrap(err, "failed to write plugin.json")
 	}
 


### PR DESCRIPTION
#### Summary

Adds the Makefile plumbing for building FIPS-compliant plugin bundles. No
CI changes, no secrets, no behavior change to existing builds.

A developer can run `make dist-fips` (or `make dist-all`) to produce a
verified FIPS Linux/amd64 bundle alongside the normal one, assuming they
are authenticated to `cgr.dev` to pull the Chainguard FIPS Go toolchain
image.

- `Makefile` — parameterizes the existing `bundle` target with
  `BUNDLE_DIR` / `SERVER_DIST_SRC` so `bundle-fips` can reuse it instead
  of duplicating the LICENSE/NOTICE/assets/public/webapp/tar logic.
  Wildcard-includes `build/fips.mk`. Extends `clean` to remove
  `dist-fips/`, `server/dist-fips/`, and `server/dist-fips-staged/`.
- `build/fips.mk` (new) — defines `server-fips` (docker run against the
  SHA-pinned FIPS image), `verify-fips` (the three FIPS marker checks
  from `mattermost-server`'s `release.mk`), `bundle-fips` (thin wrapper
  over `bundle`), and the aggregates `dist-fips` / `dist-all`.
- `build/manifest/main.go` — the `dist` command now accepts an optional
  output-dir argument so `manifest dist dist-fips` writes into the FIPS
  bundle dir.

QA:

- `tar -tzf dist/*.tar.gz | sort` is unchanged before and after the
  `bundle` parameterization.
- `make verify-fips` and `make bundle-fips` fail loudly with a clear
  message when the FIPS binary is missing.
- With a stub binary in `server/dist-fips/`, `make bundle-fips` produces
  `dist-fips/mattermost-ai-<ver>-fips.tar.gz` containing
  `server/dist/plugin-linux-amd64` (renamed from the FIPS source name),
  which is what the plugin loader expects.
- `make clean` removes `dist/`, `dist-fips/`, and the corresponding
  `server/dist*` directories.

The live `docker run cgr.dev/.../go-msft-fips` build was not exercised
locally (no chainctl auth in this environment) and this PR does not
touch CI, so end-to-end validation against the FIPS image will land
with the follow-up CI wire-up.

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configurable bundle and server distribution staging directories for more flexible packaging.
  * Opt-in FIPS build, verification and distribution flow for a FIPS-compliant server binary (Linux/amd64).
  * Manifest generation now supports specifying a custom output directory for release artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-agents/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->