### PR TITLE
dynamic mcp: add registry and loading tools

### DIFF
--- a/llm/context.go
+++ b/llm/context.go
@@ -78,8 +78,6 @@ type ToolRuntimeContext struct {
 	// predefined flows. They are selected only from the already-authorized MCP
 	// catalog and are request scoped.
 	PreloadedMCPTools []EnabledMCPTool
-
-	restoreMCPDynamicTools func(names []string)
 }
 
 type MCPDynamicToolTelemetry interface {
@@ -189,38 +187,6 @@ func (t *ToolRuntimeContext) MarkMCPDynamicToolLoaded(name string) {
 		t.MCPDynamicLoadedToolNames = make(map[string]bool)
 	}
 	t.MCPDynamicLoadedToolNames[name] = true
-}
-
-// RestoreMCPDynamicTools materializes the named MCP tools into c.Tools.
-func (c *Context) RestoreMCPDynamicTools(names []string) {
-	if c == nil {
-		return
-	}
-	c.ToolRuntime.RestoreMCPDynamicTools(names)
-}
-
-// RestoreMCPDynamicTools materializes the named MCP tools into the active tool store.
-func (t *ToolRuntimeContext) RestoreMCPDynamicTools(names []string) {
-	if t == nil || t.restoreMCPDynamicTools == nil || len(names) == 0 {
-		return
-	}
-	t.restoreMCPDynamicTools(names)
-}
-
-// SetMCPDynamicToolRestorer installs the strict MCP tool restorer.
-func (c *Context) SetMCPDynamicToolRestorer(fn func(names []string)) {
-	if c == nil {
-		return
-	}
-	c.ToolRuntime.SetMCPDynamicToolRestorer(fn)
-}
-
-// SetMCPDynamicToolRestorer installs the strict MCP tool restorer.
-func (t *ToolRuntimeContext) SetMCPDynamicToolRestorer(fn func(names []string)) {
-	if t == nil {
-		return
-	}
-	t.restoreMCPDynamicTools = fn
 }
 
 func (c *Context) ShouldRecordMCPDynamicSearchLoadCallSuccess(name string) bool {

--- a/llm/context_test.go
+++ b/llm/context_test.go
@@ -169,25 +169,3 @@ func TestContextMCPDynamicSearchLoadCallSuccessState(t *testing.T) {
 	assert.True(t, c.ShouldRecordMCPDynamicSearchLoadCallSuccess("jira__get_issue"))
 	assert.False(t, c.ShouldRecordMCPDynamicSearchLoadCallSuccess("jira__get_issue"))
 }
-
-func TestContextRestoreMCPDynamicTools(t *testing.T) {
-	var nilContext *Context
-	nilContext.RestoreMCPDynamicTools([]string{"jira__get_issue"})
-	nilContext.SetMCPDynamicToolRestorer(func([]string) {
-		t.Fatal("nil context should not install a restorer")
-	})
-
-	c := &Context{}
-	c.RestoreMCPDynamicTools([]string{"jira__get_issue"})
-
-	var restored []string
-	c.SetMCPDynamicToolRestorer(func(names []string) {
-		restored = append(restored, names...)
-	})
-
-	c.RestoreMCPDynamicTools(nil)
-	assert.Empty(t, restored)
-
-	c.RestoreMCPDynamicTools([]string{"jira__get_issue"})
-	assert.Equal(t, []string{"jira__get_issue"}, restored)
-}

--- a/llm/tools.go
+++ b/llm/tools.go
@@ -321,7 +321,7 @@ type ToolAuthError struct {
 
 type ToolStore struct {
 	tools            map[string]Tool
-	unloadedMCPTools map[string]ToolInfo
+	unloadedMCPTools map[string]Tool
 	authErrors       []ToolAuthError
 }
 
@@ -429,19 +429,39 @@ func (s *ToolStore) SetUnloadedMCPTools(tools []Tool) {
 		return
 	}
 
-	s.unloadedMCPTools = make(map[string]ToolInfo, len(tools))
+	s.unloadedMCPTools = make(map[string]Tool, len(tools))
 	for _, tool := range tools {
 		if tool.Name == "" || s.GetTool(tool.Name) != nil {
 			continue
 		}
-		s.unloadedMCPTools[tool.Name] = ToolInfo{
-			Name:        tool.Name,
-			Description: tool.Description,
-		}
+		s.unloadedMCPTools[tool.Name] = tool
 	}
 	if len(s.unloadedMCPTools) == 0 {
 		s.unloadedMCPTools = nil
 	}
+}
+
+// LoadMCPTools moves the named tools from the unloaded MCP set into the active
+// tool store, returning the tools that were loaded. Names must be exact
+// (namespaced) registry names; bare names are ignored.
+func (s *ToolStore) LoadMCPTools(names []string) []Tool {
+	if s == nil || len(names) == 0 || len(s.unloadedMCPTools) == 0 {
+		return nil
+	}
+	loaded := make([]Tool, 0, len(names))
+	for _, name := range names {
+		tool, ok := s.unloadedMCPTools[name]
+		if !ok {
+			continue
+		}
+		s.tools[tool.Name] = tool
+		delete(s.unloadedMCPTools, tool.Name)
+		loaded = append(loaded, tool)
+	}
+	if len(s.unloadedMCPTools) == 0 {
+		s.unloadedMCPTools = nil
+	}
+	return loaded
 }
 
 func (s *ToolStore) IsUnloadedMCPTool(name string) bool {
@@ -456,32 +476,36 @@ func (s *ToolStore) GetUnloadedMCPToolInfo(name string) (ToolInfo, bool) {
 	if s == nil || s.GetTool(name) != nil {
 		return ToolInfo{}, false
 	}
-	return s.lookupUnloadedMCPTool(name)
-}
-
-func (s *ToolStore) lookupUnloadedMCPTool(name string) (ToolInfo, bool) {
-	info, ok := s.unloadedMCPTools[name]
-	if ok {
-		return info, true
-	}
-	if !IsBareMCPToolName(name) {
+	tool, ok := s.lookupUnloadedMCPTool(name)
+	if !ok {
 		return ToolInfo{}, false
 	}
+	return ToolInfo{Name: tool.Name, Description: tool.Description}, true
+}
 
-	var matched ToolInfo
+func (s *ToolStore) lookupUnloadedMCPTool(name string) (Tool, bool) {
+	tool, ok := s.unloadedMCPTools[name]
+	if ok {
+		return tool, true
+	}
+	if !IsBareMCPToolName(name) {
+		return Tool{}, false
+	}
+
+	var matched Tool
 	found := false
-	for toolName, info := range s.unloadedMCPTools {
+	for toolName, tool := range s.unloadedMCPTools {
 		if BareMCPToolName(toolName) != name {
 			continue
 		}
 		if found {
-			return ToolInfo{}, false
+			return Tool{}, false
 		}
-		matched = info
+		matched = tool
 		found = true
 	}
 	if !found {
-		return ToolInfo{}, false
+		return Tool{}, false
 	}
 	return matched, true
 }

--- a/llm/tools_test.go
+++ b/llm/tools_test.go
@@ -799,3 +799,67 @@ func TestToolStoreUnloadedMCPTools(t *testing.T) {
 	store.SetUnloadedMCPTools(nil)
 	assert.False(t, store.IsUnloadedMCPTool("github__search"))
 }
+
+func TestToolStoreLoadMCPTools(t *testing.T) {
+	tests := []struct {
+		name        string
+		unloaded    []Tool
+		loadNames   []string
+		wantLoaded  []string
+		wantInStore []string
+	}{
+		{
+			name:        "exact name moves tool from unloaded to loaded",
+			unloaded:    []Tool{{Name: "jira__get_issue", Description: "Get a Jira issue"}},
+			loadNames:   []string{"jira__get_issue"},
+			wantLoaded:  []string{"jira__get_issue"},
+			wantInStore: []string{"jira__get_issue"},
+		},
+		{
+			name:        "bare name does not load",
+			unloaded:    []Tool{{Name: "jira__get_issue", Description: "Get a Jira issue"}},
+			loadNames:   []string{"get_issue"},
+			wantLoaded:  nil,
+			wantInStore: nil,
+		},
+		{
+			name:        "unknown name loads nothing",
+			unloaded:    []Tool{{Name: "jira__get_issue", Description: "Get a Jira issue"}},
+			loadNames:   []string{"github__search"},
+			wantLoaded:  nil,
+			wantInStore: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewNoTools()
+			store.SetUnloadedMCPTools(tt.unloaded)
+
+			loaded := store.LoadMCPTools(tt.loadNames)
+
+			loadedNames := make([]string, 0, len(loaded))
+			for _, tool := range loaded {
+				loadedNames = append(loadedNames, tool.Name)
+			}
+			assert.ElementsMatch(t, tt.wantLoaded, loadedNames)
+
+			for _, name := range tt.wantInStore {
+				assert.NotNil(t, store.GetTool(name))
+				assert.False(t, store.IsUnloadedMCPTool(name))
+			}
+		})
+	}
+}
+
+func TestToolStoreLoadMCPToolsNilsEmptiedMap(t *testing.T) {
+	store := NewNoTools()
+	store.SetUnloadedMCPTools([]Tool{{Name: "jira__get_issue", Description: "Get a Jira issue"}})
+
+	loaded := store.LoadMCPTools([]string{"jira__get_issue"})
+	require.Len(t, loaded, 1)
+
+	// The only unloaded tool was loaded, so the unloaded set is now empty.
+	assert.False(t, store.IsUnloadedMCPTool("jira__get_issue"))
+	assert.Nil(t, store.LoadMCPTools([]string{"jira__get_issue"}))
+}

--- a/mcp/bm25.go
+++ b/mcp/bm25.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+const (
+	bm25K1 = 1.2
+	bm25B  = 0.75
+)
+
+type BM25Document struct {
+	ID   string
+	Text string
+}
+
+type BM25Result struct {
+	ID    string
+	Score float64
+}
+
+type BM25Index struct {
+	documents        []bm25IndexedDocument
+	documentCount    int
+	documentFreqs    map[string]int
+	averageDocLength float64
+}
+
+type bm25IndexedDocument struct {
+	id         string
+	termFreqs  map[string]int
+	tokenCount float64
+}
+
+func NewBM25Index(docs []BM25Document) *BM25Index {
+	idx := &BM25Index{
+		documents:     make([]bm25IndexedDocument, 0, len(docs)),
+		documentCount: len(docs),
+		documentFreqs: make(map[string]int),
+	}
+
+	var totalDocLength float64
+	for _, doc := range docs {
+		tokens := tokenizeBM25Text(doc.Text)
+		termFreqs := make(map[string]int)
+		for _, token := range tokens {
+			termFreqs[token]++
+		}
+
+		for token := range termFreqs {
+			idx.documentFreqs[token]++
+		}
+
+		tokenCount := float64(len(tokens))
+		totalDocLength += tokenCount
+		idx.documents = append(idx.documents, bm25IndexedDocument{
+			id:         doc.ID,
+			termFreqs:  termFreqs,
+			tokenCount: tokenCount,
+		})
+	}
+
+	if idx.documentCount > 0 {
+		idx.averageDocLength = totalDocLength / float64(idx.documentCount)
+	}
+
+	return idx
+}
+
+func (idx *BM25Index) Search(query string, limit int) []BM25Result {
+	if idx == nil || idx.documentCount == 0 || idx.averageDocLength == 0 {
+		return nil
+	}
+
+	queryTokens := uniqueBM25Tokens(tokenizeBM25Text(query))
+	if len(queryTokens) == 0 {
+		return nil
+	}
+
+	results := make([]BM25Result, 0, len(idx.documents))
+	for _, doc := range idx.documents {
+		var score float64
+		for _, token := range queryTokens {
+			tf := float64(doc.termFreqs[token])
+			if tf == 0 {
+				continue
+			}
+
+			df := idx.documentFreqs[token]
+			idf := math.Log(1 + (float64(idx.documentCount-df)+0.5)/(float64(df)+0.5))
+			score += idf * (tf * (bm25K1 + 1)) / (tf + bm25K1*(1-bm25B+bm25B*doc.tokenCount/idx.averageDocLength))
+		}
+
+		if score > 0 {
+			results = append(results, BM25Result{
+				ID:    doc.id,
+				Score: score,
+			})
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score == results[j].Score {
+			return results[i].ID < results[j].ID
+		}
+		return results[i].Score > results[j].Score
+	})
+
+	if len(results) == 0 {
+		return nil
+	}
+
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+
+	return results
+}
+
+func tokenizeBM25Text(text string) []string {
+	var tokens []string
+	var current strings.Builder
+
+	for _, r := range text {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			current.WriteRune(unicode.ToLower(r))
+			continue
+		}
+
+		if current.Len() > 0 {
+			tokens = append(tokens, current.String())
+			current.Reset()
+		}
+	}
+
+	if current.Len() > 0 {
+		tokens = append(tokens, current.String())
+	}
+
+	return tokens
+}
+
+func uniqueBM25Tokens(tokens []string) []string {
+	seen := make(map[string]bool, len(tokens))
+	unique := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		if seen[token] {
+			continue
+		}
+		seen[token] = true
+		unique = append(unique, token)
+	}
+	return unique
+}

--- a/mcp/bm25_test.go
+++ b/mcp/bm25_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBM25SearchRanksRelevantDocuments(t *testing.T) {
+	idx := NewBM25Index([]BM25Document{
+		{ID: "jira__get_issue", Text: "jira__get_issue get issue jira ticket"},
+		{ID: "github__create_pull_request", Text: "github__create_pull_request create pull request"},
+		{ID: "mattermost__search_users", Text: "mattermost__search_users search users"},
+	})
+
+	results := idx.Search("jira issue", 10)
+
+	require.NotEmpty(t, results)
+	require.Equal(t, "jira__get_issue", results[0].ID)
+}
+
+func TestBM25SearchUsesNameAndDescription(t *testing.T) {
+	idx := NewBM25Index([]BM25Document{
+		{ID: "jira__get_issue", Text: "jira__get_issue get_issue"},
+		{ID: "github__create_pull_request", Text: "opens a collaboration review"},
+	})
+
+	nameResults := idx.Search("get issue", 10)
+	require.NotEmpty(t, nameResults)
+	require.Equal(t, "jira__get_issue", nameResults[0].ID)
+
+	descriptionResults := idx.Search("collaboration review", 10)
+	require.NotEmpty(t, descriptionResults)
+	require.Equal(t, "github__create_pull_request", descriptionResults[0].ID)
+}
+
+func TestBM25SearchLimitAndTieBreak(t *testing.T) {
+	idx := NewBM25Index([]BM25Document{
+		{ID: "charlie", Text: "shared"},
+		{ID: "bravo", Text: "shared"},
+		{ID: "alpha", Text: "shared"},
+	})
+
+	results := idx.Search("shared", 2)
+
+	require.Len(t, results, 2)
+	require.Equal(t, "alpha", results[0].ID)
+	require.Equal(t, "bravo", results[1].ID)
+}
+
+func TestBM25EmptyQueryReturnsNil(t *testing.T) {
+	idx := NewBM25Index([]BM25Document{
+		{ID: "jira__get_issue", Text: "jira issue"},
+	})
+
+	require.Nil(t, idx.Search("", 10))
+	require.Nil(t, idx.Search("   ", 10))
+}
+
+func TestBM25NoMatchingTokensReturnsNil(t *testing.T) {
+	idx := NewBM25Index([]BM25Document{
+		{ID: "jira__get_issue", Text: "jira issue"},
+	})
+
+	require.Nil(t, idx.Search("github", 10))
+}
+
+func TestBM25TokenizeNonLatin(t *testing.T) {
+	idx := NewBM25Index([]BM25Document{
+		{ID: "japanese", Text: "検索 ユーザー"},
+		{ID: "chinese_contiguous", Text: "用户搜索"},
+	})
+
+	japaneseResults := idx.Search("検索", 10)
+	require.NotEmpty(t, japaneseResults)
+	require.Equal(t, "japanese", japaneseResults[0].ID)
+
+	contiguousResults := idx.Search("用户搜索", 10)
+	require.NotEmpty(t, contiguousResults)
+	require.Equal(t, "chinese_contiguous", contiguousResults[0].ID)
+
+	// There is no CJK segmentation: a substring query does not match a contiguous token.
+	require.Nil(t, idx.Search("用户", 10))
+}
+
+func TestBM25TokenizeNamespacedSnakeNames(t *testing.T) {
+	idx := NewBM25Index([]BM25Document{
+		{ID: "jira__get_issue", Text: "jira__get_issue"},
+	})
+
+	results := idx.Search("get issue", 10)
+
+	require.NotEmpty(t, results)
+	require.Equal(t, "jira__get_issue", results[0].ID)
+}

--- a/mcp/dynamic_registry.go
+++ b/mcp/dynamic_registry.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-agents/llm"
+)
+
+const DefaultMCPToolSearchLimit = 8
+
+type ToolRegistry struct {
+	tools map[string]ToolRegistryEntry
+	order []string
+	bm25  *BM25Index
+}
+
+type ToolRegistryEntry struct {
+	Tool             llm.Tool
+	Name             string
+	BareName         string
+	ServerOrigin     string
+	RetrievalSummary string
+}
+
+type ToolSearchResult struct {
+	Name    string
+	Summary string
+	Score   float64
+}
+
+type ToolRegistryOption func(*toolRegistryOptions)
+
+type toolRegistryOptions struct {
+	retrievalOverrides map[string]ToolRetrievalOverride
+}
+
+func NewToolRegistry(tools []llm.Tool, opts ...ToolRegistryOption) *ToolRegistry {
+	options := toolRegistryOptions{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+
+	registry := &ToolRegistry{
+		tools: make(map[string]ToolRegistryEntry),
+	}
+
+	for _, tool := range tools {
+		if tool.Name == "" {
+			continue
+		}
+
+		bareName := llm.BareMCPToolName(tool.Name)
+		retrievalSummary := tool.Description
+		if override, ok := options.retrievalOverrides[ToolRetrievalOverrideKey(tool.ServerOrigin, bareName)]; ok {
+			if summary := strings.TrimSpace(override.Summary); summary != "" {
+				retrievalSummary = summary
+			}
+		}
+
+		if _, exists := registry.tools[tool.Name]; !exists {
+			registry.order = append(registry.order, tool.Name)
+		}
+
+		registry.tools[tool.Name] = ToolRegistryEntry{
+			Tool:             tool,
+			Name:             tool.Name,
+			BareName:         bareName,
+			ServerOrigin:     tool.ServerOrigin,
+			RetrievalSummary: retrievalSummary,
+		}
+	}
+
+	sort.Strings(registry.order)
+	registry.rebuildIndex()
+
+	return registry
+}
+
+func WithToolRetrievalOverrides(overrides map[string]ToolRetrievalOverride) ToolRegistryOption {
+	return func(options *toolRegistryOptions) {
+		options.retrievalOverrides = overrides
+	}
+}
+
+func (r *ToolRegistry) Len() int {
+	if r == nil {
+		return 0
+	}
+	return len(r.tools)
+}
+
+func (r *ToolRegistry) List() []ToolRegistryEntry {
+	if r == nil || len(r.order) == 0 {
+		return nil
+	}
+
+	entries := make([]ToolRegistryEntry, 0, len(r.order))
+	for _, name := range r.order {
+		entries = append(entries, r.tools[name])
+	}
+	return entries
+}
+
+func (r *ToolRegistry) Lookup(name string) (ToolRegistryEntry, bool) {
+	if r == nil {
+		return ToolRegistryEntry{}, false
+	}
+
+	entry, ok := r.tools[name]
+	return entry, ok
+}
+
+func (r *ToolRegistry) Search(query string, limit int) []ToolSearchResult {
+	if r == nil || strings.TrimSpace(query) == "" {
+		return nil
+	}
+
+	return r.searchWithIndex(query, normalizedMCPToolSearchLimit(limit))
+}
+
+func (r *ToolRegistry) ClosestMatches(name string, limit int) []ToolSearchResult {
+	if r == nil || strings.TrimSpace(name) == "" {
+		return nil
+	}
+
+	limit = normalizedMCPToolSearchLimit(limit)
+	if results := r.searchWithIndex(name, limit); len(results) > 0 {
+		return results
+	}
+
+	return r.closestMatchesByName(name, limit)
+}
+
+func (r *ToolRegistry) rebuildIndex() {
+	docs := make([]BM25Document, 0, len(r.order))
+	for _, name := range r.order {
+		entry := r.tools[name]
+		docs = append(docs, BM25Document{
+			ID:   entry.Name,
+			Text: entry.Name + " " + entry.BareName + " " + entry.RetrievalSummary,
+		})
+	}
+	r.bm25 = NewBM25Index(docs)
+}
+
+func (r *ToolRegistry) searchWithIndex(query string, limit int) []ToolSearchResult {
+	bm25Results := r.bm25.Search(query, limit)
+	if len(bm25Results) == 0 {
+		return nil
+	}
+
+	results := make([]ToolSearchResult, 0, len(bm25Results))
+	for _, result := range bm25Results {
+		entry, ok := r.tools[result.ID]
+		if !ok {
+			continue
+		}
+		results = append(results, ToolSearchResult{
+			Name:    entry.Name,
+			Summary: entry.RetrievalSummary,
+			Score:   result.Score,
+		})
+	}
+	return results
+}
+
+func (r *ToolRegistry) closestMatchesByName(query string, limit int) []ToolSearchResult {
+	normalizedQuery := normalizedMCPToolName(query)
+	if normalizedQuery == "" {
+		return nil
+	}
+
+	queryTokens := tokenizeBM25Text(query)
+	if len(queryTokens) == 0 {
+		return nil
+	}
+	queryTokenSet := make(map[string]bool, len(queryTokens))
+	for _, token := range queryTokens {
+		queryTokenSet[token] = true
+	}
+
+	results := make([]ToolSearchResult, 0, len(r.order))
+	for _, name := range r.order {
+		entry := r.tools[name]
+		score := fallbackMCPToolNameScore(normalizedQuery, queryTokenSet, entry)
+		if score <= 0 {
+			continue
+		}
+
+		results = append(results, ToolSearchResult{
+			Name:    entry.Name,
+			Summary: entry.RetrievalSummary,
+			Score:   score,
+		})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score == results[j].Score {
+			return results[i].Name < results[j].Name
+		}
+		return results[i].Score > results[j].Score
+	})
+
+	if len(results) == 0 {
+		return nil
+	}
+
+	if len(results) > limit {
+		results = results[:limit]
+	}
+
+	return results
+}
+
+func fallbackMCPToolNameScore(normalizedQuery string, queryTokens map[string]bool, entry ToolRegistryEntry) float64 {
+	normalizedCandidate := normalizedMCPToolName(entry.Name)
+	var score float64
+	if strings.Contains(normalizedCandidate, normalizedQuery) || strings.Contains(normalizedQuery, normalizedCandidate) {
+		score += 2
+	}
+
+	candidateTokens := tokenizeBM25Text(entry.Name + " " + entry.BareName)
+	seenCandidateTokens := make(map[string]bool, len(candidateTokens))
+	for _, token := range candidateTokens {
+		if seenCandidateTokens[token] {
+			continue
+		}
+		seenCandidateTokens[token] = true
+		if queryTokens[token] {
+			score++
+		}
+	}
+
+	return score
+}
+
+func normalizedMCPToolName(name string) string {
+	return strings.Join(tokenizeBM25Text(name), " ")
+}
+
+func normalizedMCPToolSearchLimit(limit int) int {
+	if limit <= 0 {
+		return DefaultMCPToolSearchLimit
+	}
+	return limit
+}

--- a/mcp/dynamic_registry.go
+++ b/mcp/dynamic_registry.go
@@ -150,6 +150,10 @@ func (r *ToolRegistry) rebuildIndex() {
 }
 
 func (r *ToolRegistry) searchWithIndex(query string, limit int) []ToolSearchResult {
+	if r == nil || r.bm25 == nil {
+		return nil
+	}
+
 	bm25Results := r.bm25.Search(query, limit)
 	if len(bm25Results) == 0 {
 		return nil

--- a/mcp/dynamic_registry_test.go
+++ b/mcp/dynamic_registry_test.go
@@ -182,6 +182,20 @@ func TestToolRegistryNilReceiverSafe(t *testing.T) {
 	require.Nil(t, registry.ClosestMatches("jira", 10))
 }
 
+func TestToolRegistryZeroValueSafe(t *testing.T) {
+	registry := &ToolRegistry{}
+
+	require.Equal(t, 0, registry.Len())
+	require.Nil(t, registry.List())
+
+	entry, ok := registry.Lookup("jira__search")
+	require.False(t, ok)
+	require.Empty(t, entry)
+
+	require.Nil(t, registry.Search("jira", 10))
+	require.Nil(t, registry.ClosestMatches("jira", 10))
+}
+
 func TestToolRegistrySkipsEmptyNamesAndSearchesEmptyDescriptionsByName(t *testing.T) {
 	registry := NewToolRegistry([]llm.Tool{
 		testRegistryTool("", "No runtime name", "https://jira.example.com"),

--- a/mcp/dynamic_registry_test.go
+++ b/mcp/dynamic_registry_test.go
@@ -4,6 +4,7 @@
 package mcp
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestToolRegistryLookupAndList(t *testing.T) {
 	require.Equal(t, "Get a Jira issue", entry.RetrievalSummary)
 	require.Equal(t, tools[1].Schema, entry.Tool.Schema)
 
-	result, err := entry.Tool.Resolver(&llm.Context{}, func(args any) error { return nil })
+	result, err := entry.Tool.Resolver(context.Background(), &llm.Context{}, func(args any) error { return nil })
 	require.NoError(t, err)
 	require.Equal(t, "jira__get_issue resolved", result)
 }
@@ -227,7 +228,7 @@ func testRegistryTool(name, desc, origin string) llm.Tool {
 		Description:  desc,
 		Schema:       map[string]any{"name": name},
 		ServerOrigin: origin,
-		Resolver: func(context *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
+		Resolver: func(_ context.Context, context *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
 			return name + " resolved", nil
 		},
 	}

--- a/mcp/dynamic_registry_test.go
+++ b/mcp/dynamic_registry_test.go
@@ -1,0 +1,236 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolRegistryLookupAndList(t *testing.T) {
+	tools := []llm.Tool{
+		testRegistryTool("mattermost__search_users", "Search users", "https://mattermost.example.com"),
+		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
+	}
+
+	registry := NewToolRegistry(tools)
+
+	require.Equal(t, 2, registry.Len())
+	require.Equal(t, []string{"jira__get_issue", "mattermost__search_users"}, registryEntryNames(registry.List()))
+
+	entry, ok := registry.Lookup("jira__get_issue")
+	require.True(t, ok)
+	require.Equal(t, "jira__get_issue", entry.Name)
+	require.Equal(t, "get_issue", entry.BareName)
+	require.Equal(t, "https://jira.example.com", entry.ServerOrigin)
+	require.Equal(t, "Get a Jira issue", entry.RetrievalSummary)
+	require.Equal(t, tools[1].Schema, entry.Tool.Schema)
+
+	result, err := entry.Tool.Resolver(&llm.Context{}, func(args any) error { return nil })
+	require.NoError(t, err)
+	require.Equal(t, "jira__get_issue resolved", result)
+}
+
+func TestToolRegistrySearchTop8Deterministic(t *testing.T) {
+	tools := make([]llm.Tool, 0, 10)
+	for i := 9; i >= 0; i-- {
+		tools = append(tools, testRegistryTool(fmt.Sprintf("server__tool_%02d", i), "shared capability", "https://server.example.com"))
+	}
+	registry := NewToolRegistry(tools)
+
+	results := registry.Search("shared", 0)
+
+	require.Len(t, results, DefaultMCPToolSearchLimit)
+	require.Equal(t, []string{
+		"server__tool_00",
+		"server__tool_01",
+		"server__tool_02",
+		"server__tool_03",
+		"server__tool_04",
+		"server__tool_05",
+		"server__tool_06",
+		"server__tool_07",
+	}, registrySearchResultNames(results))
+	for i := 1; i < len(results); i++ {
+		require.LessOrEqual(t, results[i].Score, results[i-1].Score)
+	}
+}
+
+func TestToolRegistrySearchEmptyQuery(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
+	})
+
+	require.Nil(t, registry.Search("", 10))
+	require.Nil(t, registry.Search("   ", 10))
+}
+
+func TestToolRegistrySearchUsesDescriptionOverrideForRetrievalOnly(t *testing.T) {
+	tool := testRegistryTool("jira__get_issue", "Original schema description", "https://jira.example.com")
+	registry := NewToolRegistry(
+		[]llm.Tool{tool},
+		WithToolRetrievalOverrides(map[string]ToolRetrievalOverride{
+			ToolRetrievalOverrideKey("https://jira.example.com", "get_issue"): {
+				Summary: "Find Jira incidents by key",
+			},
+		}),
+	)
+
+	results := registry.Search("incidents", 10)
+	require.Len(t, results, 1)
+	require.Equal(t, "jira__get_issue", results[0].Name)
+	require.Equal(t, "Find Jira incidents by key", results[0].Summary)
+
+	entry, ok := registry.Lookup("jira__get_issue")
+	require.True(t, ok)
+	require.Equal(t, "Original schema description", entry.Tool.Description)
+	require.Equal(t, "Find Jira incidents by key", entry.RetrievalSummary)
+}
+
+func TestToolRegistryOverrideKeyUsesBareName(t *testing.T) {
+	require.Equal(
+		t,
+		ToolRetrievalOverrideKey("https://jira.example.com", "get_issue"),
+		ToolRetrievalOverrideKey("https://jira.example.com", "jira__get_issue"),
+	)
+}
+
+func TestToolRegistryDuplicateNamespacedToolLastWins(t *testing.T) {
+	first := testRegistryTool("jira__search", "First search description", "https://jira.example.com")
+	first.Schema = map[string]any{"version": "first"}
+	second := testRegistryTool("jira__search", "Second search description", "https://jira.example.com")
+	second.Schema = map[string]any{"version": "second"}
+
+	registry := NewToolRegistry([]llm.Tool{first, second})
+
+	require.Equal(t, 1, registry.Len())
+	require.Equal(t, []string{"jira__search"}, registryEntryNames(registry.List()))
+
+	entry, ok := registry.Lookup("jira__search")
+	require.True(t, ok)
+	require.Equal(t, "Second search description", entry.Tool.Description)
+	require.Equal(t, map[string]any{"version": "second"}, entry.Tool.Schema)
+}
+
+func TestToolRegistryDuplicateBareNamesDifferentNamespaces(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__search", "Search Jira", "https://jira.example.com"),
+		testRegistryTool("github__search", "Search GitHub", "https://github.example.com"),
+	})
+
+	require.Equal(t, 2, registry.Len())
+	require.Equal(t, []string{"github__search", "jira__search"}, registryEntryNames(registry.List()))
+
+	jiraEntry, ok := registry.Lookup("jira__search")
+	require.True(t, ok)
+	require.Equal(t, "https://jira.example.com", jiraEntry.ServerOrigin)
+
+	githubEntry, ok := registry.Lookup("github__search")
+	require.True(t, ok)
+	require.Equal(t, "https://github.example.com", githubEntry.ServerOrigin)
+}
+
+func TestToolRegistryClosestMatchesUsesBM25(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
+		testRegistryTool("github__create_pull_request", "Create a pull request", "https://github.example.com"),
+	})
+
+	results := registry.ClosestMatches("issue", 10)
+
+	require.NotEmpty(t, results)
+	require.Equal(t, "jira__get_issue", results[0].Name)
+}
+
+func TestToolRegistryClosestMatchesFallbackForMiss(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("mattermost__search_users", "Find people", "https://mattermost.example.com"),
+		testRegistryTool("github__create_pull_request", "Open collaboration review", "https://github.example.com"),
+	})
+
+	results := registry.ClosestMatches("matter", 10)
+
+	require.Len(t, results, 1)
+	require.Equal(t, "mattermost__search_users", results[0].Name)
+	require.Greater(t, results[0].Score, 0.0)
+}
+
+func TestToolRegistryLookupBareNameDoesNotSucceed(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__search", "Search Jira", "https://jira.example.com"),
+	})
+
+	_, ok := registry.Lookup("search")
+	require.False(t, ok)
+}
+
+func TestToolRegistryNilReceiverSafe(t *testing.T) {
+	var registry *ToolRegistry
+
+	require.Equal(t, 0, registry.Len())
+	require.Nil(t, registry.List())
+
+	entry, ok := registry.Lookup("jira__search")
+	require.False(t, ok)
+	require.Empty(t, entry)
+
+	require.Nil(t, registry.Search("jira", 10))
+	require.Nil(t, registry.ClosestMatches("jira", 10))
+}
+
+func TestToolRegistrySkipsEmptyNamesAndSearchesEmptyDescriptionsByName(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("", "No runtime name", "https://jira.example.com"),
+		testRegistryTool("jira__get_issue", "", "https://jira.example.com"),
+	})
+
+	require.Equal(t, 1, registry.Len())
+	results := registry.Search("get issue", 10)
+	require.Len(t, results, 1)
+	require.Equal(t, "jira__get_issue", results[0].Name)
+}
+
+func TestToolRegistryOnlyContainsProvidedFilteredTools(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get Jira issue", "https://jira.example.com"),
+	})
+
+	require.Equal(t, []string{"jira__get_issue"}, registryEntryNames(registry.List()))
+
+	_, ok := registry.Lookup("github__create_pull_request")
+	require.False(t, ok)
+	require.Nil(t, registry.Search("pull request", 10))
+	require.Nil(t, registry.ClosestMatches("github", 10))
+}
+
+func testRegistryTool(name, desc, origin string) llm.Tool {
+	return llm.Tool{
+		Name:         name,
+		Description:  desc,
+		Schema:       map[string]any{"name": name},
+		ServerOrigin: origin,
+		Resolver: func(context *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
+			return name + " resolved", nil
+		},
+	}
+}
+
+func registryEntryNames(entries []ToolRegistryEntry) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name)
+	}
+	return names
+}
+
+func registrySearchResultNames(results []ToolSearchResult) []string {
+	names := make([]string, 0, len(results))
+	for _, result := range results {
+		names = append(names, result.Name)
+	}
+	return names
+}

--- a/mcp/meta_tools.go
+++ b/mcp/meta_tools.go
@@ -1,0 +1,229 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-agents/llm"
+)
+
+const (
+	SearchToolsName = "search_tools"
+	LoadToolName    = "load_tool"
+)
+
+// UnloadedMCPToolUserHint returns the canonical message returned to the LLM
+// when it tries to call an MCP tool that is visible in the registry but has
+// not yet been loaded into the active tool store. Callers that surface this
+// to the model should reuse this helper so the wording (and the suggested
+// load_tool invocation) stays consistent across entry points.
+func UnloadedMCPToolUserHint(name string) string {
+	return fmt.Sprintf(`tool %s is available but not loaded. Call %s with {"name":%q} before calling it.`, name, LoadToolName, name)
+}
+
+type SearchToolsArgs struct {
+	Query string `json:"query" jsonschema:"Search query for finding available MCP tools,minLength=1"`
+}
+
+type LoadToolArgs struct {
+	Name string `json:"name" jsonschema:"Exact namespaced MCP tool name to load,minLength=1"`
+}
+
+type SearchToolsResult struct {
+	Tools []SearchToolsResultItem `json:"tools"`
+}
+
+type SearchToolsResultItem struct {
+	Name    string `json:"name"`
+	Summary string `json:"summary"`
+}
+
+type LoadToolResult struct {
+	Loaded  bool                    `json:"loaded"`
+	Name    string                  `json:"name,omitempty"`
+	Schema  any                     `json:"schema,omitempty"`
+	Matches []SearchToolsResultItem `json:"matches,omitempty"`
+	Error   string                  `json:"error,omitempty"`
+}
+
+type LoadedToolRecorder func(llmContext *llm.Context, entry ToolRegistryEntry) error
+
+type MetaToolOption func(*metaToolOptions)
+
+type metaToolOptions struct {
+	loadedToolRecorder LoadedToolRecorder
+}
+
+func WithLoadedToolRecorder(recorder LoadedToolRecorder) MetaToolOption {
+	return func(options *metaToolOptions) {
+		options.loadedToolRecorder = recorder
+	}
+}
+
+func IsMCPMetaTool(name string) bool {
+	return name == SearchToolsName || name == LoadToolName
+}
+
+func NewMetaTools(registry *ToolRegistry, opts ...MetaToolOption) []llm.Tool {
+	options := metaToolOptions{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+
+	return []llm.Tool{
+		{
+			Name:        SearchToolsName,
+			Description: "Use this internal helper to find available MCP tools before loading one. It searches only tools available in the active filtered registry and returns exact names with summaries.",
+			Schema:      llm.NewJSONSchemaFromStruct[SearchToolsArgs](),
+			Resolver:    searchToolsResolver(registry),
+		},
+		{
+			Name:        LoadToolName,
+			Description: "Use this internal helper with exact names returned by search_tools. After loading, the selected MCP tool can be called by that exact name.",
+			Schema:      llm.NewJSONSchemaFromStruct[LoadToolArgs](),
+			Resolver:    loadToolResolver(registry, options.loadedToolRecorder),
+		},
+	}
+}
+
+func searchToolsResolver(registry *ToolRegistry) llm.ToolResolver {
+	return func(llmContext *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
+		observe := func(result string) {
+			if llmContext != nil {
+				llmContext.ObserveMCPDynamicToolEvent("search", result)
+			}
+		}
+
+		var args SearchToolsArgs
+		if err := argsGetter(&args); err != nil {
+			observe("error")
+			return "", err
+		}
+
+		query := strings.TrimSpace(args.Query)
+		items := []SearchToolsResultItem{}
+		if query != "" {
+			if llmContext != nil {
+				llmContext.MarkMCPDynamicToolSearch()
+			}
+			if registry != nil {
+				if found := searchResultsToMetaToolItems(registry.Search(query, DefaultMCPToolSearchLimit)); len(found) > 0 {
+					items = found
+				}
+			}
+		}
+
+		if len(items) == 0 {
+			observe("empty")
+		} else {
+			observe("success")
+		}
+
+		return marshalMetaToolResult(SearchToolsResult{Tools: items})
+	}
+}
+
+func loadToolResolver(registry *ToolRegistry, recorder LoadedToolRecorder) llm.ToolResolver {
+	return func(llmContext *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
+		observe := func(result string) {
+			if llmContext != nil {
+				llmContext.ObserveMCPDynamicToolEvent("load", result)
+			}
+		}
+
+		var args LoadToolArgs
+		if err := argsGetter(&args); err != nil {
+			observe("error")
+			return "", err
+		}
+
+		name := strings.TrimSpace(args.Name)
+		if name == "" {
+			observe("error")
+			return marshalMetaToolResult(LoadToolResult{
+				Loaded: false,
+				Error:  "tool name is required",
+			})
+		}
+
+		if llmContext == nil {
+			return marshalMetaToolResult(LoadToolResult{
+				Loaded: false,
+				Error:  "cannot load tool without an LLM context",
+			})
+		}
+		if registry == nil {
+			observe("error")
+			return marshalMetaToolResult(LoadToolResult{
+				Loaded: false,
+				Error:  "tool registry is unavailable",
+			})
+		}
+
+		entry, ok := registry.Lookup(name)
+		if !ok {
+			observe("miss")
+			return marshalMetaToolResult(LoadToolResult{
+				Loaded: false,
+				Error:  "tool not found",
+				Matches: searchResultsToMetaToolItems(
+					registry.ClosestMatches(name, DefaultMCPToolSearchLimit),
+				),
+			})
+		}
+
+		if llmContext.Tools == nil {
+			observe("error")
+			return marshalMetaToolResult(LoadToolResult{
+				Loaded: false,
+				Error:  "cannot load tool without a visible tool store",
+			})
+		}
+
+		if recorder != nil {
+			if err := recorder(llmContext, entry); err != nil {
+				observe("error")
+				return "", err
+			}
+		}
+
+		llmContext.Tools.AddTools([]llm.Tool{entry.Tool})
+
+		llmContext.MarkMCPDynamicToolLoaded(entry.Name)
+		observe("loaded")
+		return marshalMetaToolResult(LoadToolResult{
+			Loaded: true,
+			Name:   entry.Name,
+			Schema: entry.Tool.Schema,
+		})
+	}
+}
+
+func searchResultsToMetaToolItems(results []ToolSearchResult) []SearchToolsResultItem {
+	if len(results) == 0 {
+		return nil
+	}
+
+	items := make([]SearchToolsResultItem, 0, len(results))
+	for _, result := range results {
+		items = append(items, SearchToolsResultItem{
+			Name:    result.Name,
+			Summary: result.Summary,
+		})
+	}
+	return items
+}
+
+func marshalMetaToolResult(result any) (string, error) {
+	data, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/mcp/meta_tools.go
+++ b/mcp/meta_tools.go
@@ -135,36 +135,43 @@ func loadToolResolver(registry *ToolRegistry) llm.ToolResolver {
 		if llmContext == nil {
 			return "", fmt.Errorf("%s: missing LLM context", LoadToolName)
 		}
+		if llmContext.Tools == nil {
+			observe("error")
+			return "", fmt.Errorf("%s: missing tool store", LoadToolName)
+		}
 		if registry == nil {
 			observe("error")
 			return "", fmt.Errorf("%s: tool registry unavailable", LoadToolName)
 		}
 
-		entry, ok := registry.Lookup(name)
-		if !ok {
-			observe("miss")
+		loaded := llmContext.Tools.LoadMCPTools([]string{name})
+		if len(loaded) == 1 {
+			llmContext.MarkMCPDynamicToolLoaded(loaded[0].Name)
+			observe("loaded")
 			return marshalMetaToolResult(LoadToolResult{
-				Loaded: false,
-				Error:  "tool not found",
-				Matches: searchResultsToMetaToolItems(
-					registry.ClosestMatches(name, DefaultMCPToolSearchLimit),
-				),
+				Loaded: true,
+				Name:   loaded[0].Name,
+				Schema: loaded[0].Schema,
 			})
 		}
 
-		if llmContext.Tools == nil {
-			observe("error")
-			return "", fmt.Errorf("%s: missing tool store", LoadToolName)
+		// Already-loaded tools are idempotent successes.
+		if existing := llmContext.Tools.GetTool(name); existing != nil {
+			observe("loaded")
+			return marshalMetaToolResult(LoadToolResult{
+				Loaded: true,
+				Name:   name,
+				Schema: existing.Schema,
+			})
 		}
 
-		llmContext.Tools.AddTools([]llm.Tool{entry.Tool})
-
-		llmContext.MarkMCPDynamicToolLoaded(entry.Name)
-		observe("loaded")
+		observe("miss")
 		return marshalMetaToolResult(LoadToolResult{
-			Loaded: true,
-			Name:   entry.Name,
-			Schema: entry.Tool.Schema,
+			Loaded: false,
+			Error:  "tool not found",
+			Matches: searchResultsToMetaToolItems(
+				registry.ClosestMatches(name, DefaultMCPToolSearchLimit),
+			),
 		})
 	}
 }

--- a/mcp/meta_tools.go
+++ b/mcp/meta_tools.go
@@ -50,32 +50,11 @@ type LoadToolResult struct {
 	Error   string                  `json:"error,omitempty"`
 }
 
-type LoadedToolRecorder func(llmContext *llm.Context, entry ToolRegistryEntry) error
-
-type MetaToolOption func(*metaToolOptions)
-
-type metaToolOptions struct {
-	loadedToolRecorder LoadedToolRecorder
-}
-
-func WithLoadedToolRecorder(recorder LoadedToolRecorder) MetaToolOption {
-	return func(options *metaToolOptions) {
-		options.loadedToolRecorder = recorder
-	}
-}
-
 func IsMCPMetaTool(name string) bool {
 	return name == SearchToolsName || name == LoadToolName
 }
 
-func NewMetaTools(registry *ToolRegistry, opts ...MetaToolOption) []llm.Tool {
-	options := metaToolOptions{}
-	for _, opt := range opts {
-		if opt != nil {
-			opt(&options)
-		}
-	}
-
+func NewMetaTools(registry *ToolRegistry) []llm.Tool {
 	return []llm.Tool{
 		{
 			Name:        SearchToolsName,
@@ -87,7 +66,7 @@ func NewMetaTools(registry *ToolRegistry, opts ...MetaToolOption) []llm.Tool {
 			Name:        LoadToolName,
 			Description: "Use this internal helper with exact names returned by search_tools. After loading, the selected MCP tool can be called by that exact name.",
 			Schema:      llm.NewJSONSchemaFromStruct[LoadToolArgs](),
-			Resolver:    loadToolResolver(registry, options.loadedToolRecorder),
+			Resolver:    loadToolResolver(registry),
 		},
 	}
 }
@@ -129,7 +108,7 @@ func searchToolsResolver(registry *ToolRegistry) llm.ToolResolver {
 	}
 }
 
-func loadToolResolver(registry *ToolRegistry, recorder LoadedToolRecorder) llm.ToolResolver {
+func loadToolResolver(registry *ToolRegistry) llm.ToolResolver {
 	return func(llmContext *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
 		observe := func(result string) {
 			if llmContext != nil {
@@ -184,13 +163,6 @@ func loadToolResolver(registry *ToolRegistry, recorder LoadedToolRecorder) llm.T
 				Loaded: false,
 				Error:  "cannot load tool without a visible tool store",
 			})
-		}
-
-		if recorder != nil {
-			if err := recorder(llmContext, entry); err != nil {
-				observe("error")
-				return "", err
-			}
 		}
 
 		llmContext.Tools.AddTools([]llm.Tool{entry.Tool})

--- a/mcp/meta_tools.go
+++ b/mcp/meta_tools.go
@@ -59,13 +59,13 @@ func NewMetaTools(registry *ToolRegistry) []llm.Tool {
 	return []llm.Tool{
 		{
 			Name:        SearchToolsName,
-			Description: "Use this internal helper to find available MCP tools before loading one. It searches only tools available in the active filtered registry and returns exact names with summaries.",
+			Description: "Search available MCP tools by keyword.",
 			Schema:      llm.NewJSONSchemaFromStruct[SearchToolsArgs](),
 			Resolver:    searchToolsResolver(registry),
 		},
 		{
 			Name:        LoadToolName,
-			Description: "Use this internal helper with exact names returned by search_tools. After loading, the selected MCP tool can be called by that exact name.",
+			Description: "Load an MCP tool by exact namespaced name.",
 			Schema:      llm.NewJSONSchemaFromStruct[LoadToolArgs](),
 			Resolver:    loadToolResolver(registry),
 		},
@@ -133,17 +133,11 @@ func loadToolResolver(registry *ToolRegistry) llm.ToolResolver {
 		}
 
 		if llmContext == nil {
-			return marshalMetaToolResult(LoadToolResult{
-				Loaded: false,
-				Error:  "cannot load tool without an LLM context",
-			})
+			return "", fmt.Errorf("%s: missing LLM context", LoadToolName)
 		}
 		if registry == nil {
 			observe("error")
-			return marshalMetaToolResult(LoadToolResult{
-				Loaded: false,
-				Error:  "tool registry is unavailable",
-			})
+			return "", fmt.Errorf("%s: tool registry unavailable", LoadToolName)
 		}
 
 		entry, ok := registry.Lookup(name)
@@ -160,10 +154,7 @@ func loadToolResolver(registry *ToolRegistry) llm.ToolResolver {
 
 		if llmContext.Tools == nil {
 			observe("error")
-			return marshalMetaToolResult(LoadToolResult{
-				Loaded: false,
-				Error:  "cannot load tool without a visible tool store",
-			})
+			return "", fmt.Errorf("%s: missing tool store", LoadToolName)
 		}
 
 		llmContext.Tools.AddTools([]llm.Tool{entry.Tool})

--- a/mcp/meta_tools.go
+++ b/mcp/meta_tools.go
@@ -4,6 +4,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -72,7 +73,7 @@ func NewMetaTools(registry *ToolRegistry) []llm.Tool {
 }
 
 func searchToolsResolver(registry *ToolRegistry) llm.ToolResolver {
-	return func(llmContext *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
+	return func(_ context.Context, llmContext *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
 		observe := func(result string) {
 			if llmContext != nil {
 				llmContext.ObserveMCPDynamicToolEvent("search", result)
@@ -109,7 +110,7 @@ func searchToolsResolver(registry *ToolRegistry) llm.ToolResolver {
 }
 
 func loadToolResolver(registry *ToolRegistry) llm.ToolResolver {
-	return func(llmContext *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
+	return func(_ context.Context, llmContext *llm.Context, argsGetter llm.ToolArgumentGetter) (string, error) {
 		observe := func(result string) {
 			if llmContext != nil {
 				llmContext.ObserveMCPDynamicToolEvent("load", result)

--- a/mcp/meta_tools_test.go
+++ b/mcp/meta_tools_test.go
@@ -206,45 +206,6 @@ func TestLoadToolNilContextOrToolStoreReturnsJSONError(t *testing.T) {
 	require.Contains(t, result.Error, "tool store")
 }
 
-func TestLoadToolCallsLoadedToolRecorder(t *testing.T) {
-	registry := NewToolRegistry([]llm.Tool{
-		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
-	})
-	var recorded ToolRegistryEntry
-	loadTool := metaToolByName(t, NewMetaTools(registry, WithLoadedToolRecorder(func(_ *llm.Context, entry ToolRegistryEntry) error {
-		recorded = entry
-		return nil
-	})), LoadToolName)
-	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
-
-	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
-	require.NoError(t, err)
-
-	var result LoadToolResult
-	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
-	require.True(t, result.Loaded)
-	require.Equal(t, "jira__get_issue", recorded.Name)
-	require.Equal(t, "get_issue", recorded.BareName)
-	require.Equal(t, "https://jira.example.com", recorded.ServerOrigin)
-}
-
-func TestLoadToolRecorderErrorReturnsResolverError(t *testing.T) {
-	registry := NewToolRegistry([]llm.Tool{
-		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
-	})
-	recorderErr := errors.New("persist loaded tool")
-	loadTool := metaToolByName(t, NewMetaTools(registry, WithLoadedToolRecorder(func(_ *llm.Context, _ ToolRegistryEntry) error {
-		return recorderErr
-	})), LoadToolName)
-	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
-
-	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
-
-	require.Empty(t, resultJSON)
-	require.ErrorIs(t, err, recorderErr)
-	require.Nil(t, llmContext.Tools.GetTool("jira__get_issue"))
-}
-
 func TestLoadToolDoesNotMutateRegistryToolSchema(t *testing.T) {
 	tool := testRegistryTool("jira__get_issue", "Original schema description", "https://jira.example.com")
 	tool.Schema = map[string]any{"source": "original"}
@@ -274,6 +235,38 @@ func TestLoadToolDoesNotMutateRegistryToolSchema(t *testing.T) {
 	require.True(t, loadResult.Loaded)
 	require.Equal(t, map[string]any{"source": "original"}, loadResult.Schema)
 	require.Equal(t, "Original schema description", llmContext.Tools.GetTool("jira__get_issue").Description)
+}
+
+func TestLoadToolResultWireShape(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
+	})
+	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
+	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+
+	t.Run("success", func(t *testing.T) {
+		resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+		require.NoError(t, err)
+
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resultJSON), &raw))
+		require.Equal(t, true, raw["loaded"])
+		require.Equal(t, "jira__get_issue", raw["name"])
+		require.NotContains(t, raw, "error")
+		require.NotContains(t, raw, "matches")
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		resultJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore(nil, false)}, metaToolArgs(`{"name":"jira__unknown"}`))
+		require.NoError(t, err)
+
+		var raw map[string]any
+		require.NoError(t, json.Unmarshal([]byte(resultJSON), &raw))
+		require.Equal(t, false, raw["loaded"])
+		require.Equal(t, "tool not found", raw["error"])
+		require.NotContains(t, raw, "name")
+		require.NotContains(t, raw, "schema")
+	})
 }
 
 func TestMetaToolsNilRegistryResolvers(t *testing.T) {
@@ -409,19 +402,6 @@ func TestLoadToolTelemetry(t *testing.T) {
 			return errors.New("decode")
 		})
 		require.Error(t, err)
-		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "error"}}, telemetry.events)
-	})
-
-	t.Run("recorder error", func(t *testing.T) {
-		telemetry := &fakeMCPDynamicTelemetry{}
-		recorderErr := errors.New("persist loaded tool")
-		loadTool := metaToolByName(t, NewMetaTools(registry, WithLoadedToolRecorder(func(_ *llm.Context, _ ToolRegistryEntry) error {
-			return recorderErr
-		})), LoadToolName)
-		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(nil, false), MCPDynamicToolTelemetry: telemetry}
-
-		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
-		require.ErrorIs(t, err, recorderErr)
 		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "error"}}, telemetry.events)
 	})
 }

--- a/mcp/meta_tools_test.go
+++ b/mcp/meta_tools_test.go
@@ -126,6 +126,7 @@ func TestLoadToolExactLookupAddsToolToVisibleStore(t *testing.T) {
 	loadTool := metaToolByName(t, metaTools, LoadToolName)
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 	llmContext.Tools.AddTools(metaTools)
+	llmContext.Tools.SetUnloadedMCPTools([]llm.Tool{registryTool})
 
 	resultJSON, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
 	require.NoError(t, err)
@@ -136,14 +137,15 @@ func TestLoadToolExactLookupAddsToolToVisibleStore(t *testing.T) {
 	require.Equal(t, "jira__get_issue", result.Name)
 	require.Equal(t, map[string]any{"name": "jira__get_issue"}, result.Schema)
 	require.NotNil(t, llmContext.Tools.GetTool("jira__get_issue"))
+	require.False(t, llmContext.Tools.IsUnloadedMCPTool("jira__get_issue"))
 }
 
 func TestLoadToolDoesNotLoadBareName(t *testing.T) {
-	registry := NewToolRegistry([]llm.Tool{
-		testRegistryTool("jira__search", "Search Jira", "https://jira.example.com"),
-	})
+	jiraSearch := testRegistryTool("jira__search", "Search Jira", "https://jira.example.com")
+	registry := NewToolRegistry([]llm.Tool{jiraSearch})
 	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
+	llmContext.Tools.SetUnloadedMCPTools([]llm.Tool{jiraSearch})
 
 	resultJSON, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"search"}`))
 	require.NoError(t, err)
@@ -244,6 +246,7 @@ func TestLoadToolDoesNotMutateRegistryToolSchema(t *testing.T) {
 	searchTool := metaToolByName(t, metaTools, SearchToolsName)
 	loadTool := metaToolByName(t, metaTools, LoadToolName)
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
+	llmContext.Tools.SetUnloadedMCPTools([]llm.Tool{tool})
 
 	searchJSON, err := searchTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"query":"override"}`))
 	require.NoError(t, err)
@@ -261,11 +264,11 @@ func TestLoadToolDoesNotMutateRegistryToolSchema(t *testing.T) {
 }
 
 func TestLoadToolResultWireShape(t *testing.T) {
-	registry := NewToolRegistry([]llm.Tool{
-		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
-	})
+	registryTool := testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com")
+	registry := NewToolRegistry([]llm.Tool{registryTool})
 	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
+	llmContext.Tools.SetUnloadedMCPTools([]llm.Tool{registryTool})
 
 	t.Run("success", func(t *testing.T) {
 		resultJSON, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
@@ -376,6 +379,7 @@ func TestLoadToolTelemetry(t *testing.T) {
 			Tools:       llm.NewToolStore(),
 			ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: telemetry},
 		}
+		llmContext.Tools.SetUnloadedMCPTools([]llm.Tool{testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com")})
 
 		_, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
 		require.NoError(t, err)
@@ -426,13 +430,13 @@ func TestLoadToolTelemetry(t *testing.T) {
 }
 
 func TestSearchLoadStateMarkers(t *testing.T) {
-	registry := NewToolRegistry([]llm.Tool{
-		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
-	})
+	registryTool := testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com")
+	registry := NewToolRegistry([]llm.Tool{registryTool})
 	metaTools := NewMetaTools(registry)
 	searchTool := metaToolByName(t, metaTools, SearchToolsName)
 	loadTool := metaToolByName(t, metaTools, LoadToolName)
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
+	llmContext.Tools.SetUnloadedMCPTools([]llm.Tool{registryTool})
 
 	_, err := searchTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"query":"jira issue"}`))
 	require.NoError(t, err)

--- a/mcp/meta_tools_test.go
+++ b/mcp/meta_tools_test.go
@@ -1,0 +1,473 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/stretchr/testify/require"
+)
+
+type mcpTelemetryEvent struct {
+	botName string
+	event   string
+	result  string
+}
+
+type fakeMCPDynamicTelemetry struct {
+	events []mcpTelemetryEvent
+}
+
+func (t *fakeMCPDynamicTelemetry) ObserveMCPDynamicToolEvent(botName, event, result string) {
+	t.events = append(t.events, mcpTelemetryEvent{botName: botName, event: event, result: result})
+}
+
+func TestNewMetaToolsDefinitions(t *testing.T) {
+	tools := NewMetaTools(NewToolRegistry(nil))
+
+	require.Len(t, tools, 2)
+	require.Equal(t, []string{SearchToolsName, LoadToolName}, []string{tools[0].Name, tools[1].Name})
+	for _, tool := range tools {
+		require.NotEmpty(t, tool.Description)
+		require.NotNil(t, tool.Schema)
+		require.NotNil(t, tool.Resolver)
+		require.Empty(t, tool.ServerOrigin)
+	}
+
+	require.True(t, IsMCPMetaTool(SearchToolsName))
+	require.True(t, IsMCPMetaTool(LoadToolName))
+	require.False(t, IsMCPMetaTool("jira__search"))
+	require.False(t, IsMCPMetaTool(""))
+}
+
+func TestSearchToolsReturnsTopEightNameSummary(t *testing.T) {
+	tools := make([]llm.Tool, 0, 10)
+	for i := 9; i >= 0; i-- {
+		tools = append(tools, testRegistryTool(fmt.Sprintf("server__tool_%02d", i), "shared capability", "https://server.example.com"))
+	}
+	searchTool := metaToolByName(t, NewMetaTools(NewToolRegistry(tools)), SearchToolsName)
+
+	resultJSON, err := searchTool.Resolver(&llm.Context{}, metaToolArgs(`{"query":"shared"}`))
+	require.NoError(t, err)
+
+	var result SearchToolsResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.Len(t, result.Tools, DefaultMCPToolSearchLimit)
+	for _, item := range result.Tools {
+		require.NotEmpty(t, item.Name)
+		require.Equal(t, "shared capability", item.Summary)
+	}
+
+	var raw map[string][]map[string]any
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &raw))
+	require.NotContains(t, raw["tools"][0], "score")
+}
+
+func TestSearchToolsEmptyQueryReturnsEmptyList(t *testing.T) {
+	searchTool := metaToolByName(t, NewMetaTools(NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
+	})), SearchToolsName)
+
+	for _, rawArgs := range []string{`{"query":""}`, `{"query":"   "}`} {
+		resultJSON, err := searchTool.Resolver(&llm.Context{}, metaToolArgs(rawArgs))
+		require.NoError(t, err)
+
+		var result SearchToolsResult
+		require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+		require.Empty(t, result.Tools)
+		require.JSONEq(t, `{"tools":[]}`, resultJSON)
+	}
+}
+
+func TestSearchToolsNilContextStillReturnsResults(t *testing.T) {
+	searchTool := metaToolByName(t, NewMetaTools(NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
+	})), SearchToolsName)
+
+	resultJSON, err := searchTool.Resolver(nil, metaToolArgs(`{"query":"issue"}`))
+	require.NoError(t, err)
+
+	var result SearchToolsResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.Len(t, result.Tools, 1)
+	require.Equal(t, "jira__get_issue", result.Tools[0].Name)
+}
+
+func TestSearchToolsUsesFilteredRegistryOnly(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
+	})
+	searchTool := metaToolByName(t, NewMetaTools(registry), SearchToolsName)
+	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+	llmContext.Tools.AddTools([]llm.Tool{
+		testRegistryTool("github__create_pull_request", "Create a pull request", "https://github.example.com"),
+	})
+
+	resultJSON, err := searchTool.Resolver(llmContext, metaToolArgs(`{"query":"pull request"}`))
+	require.NoError(t, err)
+
+	var result SearchToolsResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.Empty(t, result.Tools)
+}
+
+func TestLoadToolExactLookupAddsToolToVisibleStore(t *testing.T) {
+	registryTool := testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com")
+	registry := NewToolRegistry([]llm.Tool{registryTool})
+	metaTools := NewMetaTools(registry)
+	loadTool := metaToolByName(t, metaTools, LoadToolName)
+	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+	llmContext.Tools.AddTools(metaTools)
+
+	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+	require.NoError(t, err)
+
+	var result LoadToolResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.True(t, result.Loaded)
+	require.Equal(t, "jira__get_issue", result.Name)
+	require.Equal(t, map[string]any{"name": "jira__get_issue"}, result.Schema)
+	require.NotNil(t, llmContext.Tools.GetTool("jira__get_issue"))
+}
+
+func TestLoadToolDoesNotLoadBareName(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__search", "Search Jira", "https://jira.example.com"),
+	})
+	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
+	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+
+	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"search"}`))
+	require.NoError(t, err)
+
+	var result LoadToolResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.False(t, result.Loaded)
+	require.Equal(t, "tool not found", result.Error)
+	require.Contains(t, metaToolResultItemNames(result.Matches), "jira__search")
+	require.Nil(t, llmContext.Tools.GetTool("jira__search"))
+}
+
+func TestLoadToolMissReturnsClosestFilteredMatches(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("mattermost__search_users", "Find people", "https://mattermost.example.com"),
+	})
+	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
+	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+
+	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"search user"}`))
+	require.NoError(t, err)
+
+	var result LoadToolResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.False(t, result.Loaded)
+	require.Equal(t, "tool not found", result.Error)
+	require.Equal(t, []string{"mattermost__search_users"}, metaToolResultItemNames(result.Matches))
+	require.Nil(t, llmContext.Tools.GetTool("mattermost__search_users"))
+}
+
+func TestLoadToolEmptyNameReturnsJSONError(t *testing.T) {
+	loadTool := metaToolByName(t, NewMetaTools(NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
+	})), LoadToolName)
+
+	resultJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore(nil, false)}, metaToolArgs(`{"name":"   "}`))
+	require.NoError(t, err)
+
+	var result LoadToolResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.False(t, result.Loaded)
+	require.Equal(t, "tool name is required", result.Error)
+	require.Empty(t, result.Matches)
+}
+
+func TestLoadToolNilContextOrToolStoreReturnsJSONError(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
+	})
+	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
+
+	resultJSON, err := loadTool.Resolver(nil, metaToolArgs(`{"name":"jira__get_issue"}`))
+	require.NoError(t, err)
+	var result LoadToolResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.False(t, result.Loaded)
+	require.Contains(t, result.Error, "LLM context")
+
+	resultJSON, err = loadTool.Resolver(&llm.Context{}, metaToolArgs(`{"name":"jira__get_issue"}`))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.False(t, result.Loaded)
+	require.Contains(t, result.Error, "tool store")
+}
+
+func TestLoadToolCallsLoadedToolRecorder(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
+	})
+	var recorded ToolRegistryEntry
+	loadTool := metaToolByName(t, NewMetaTools(registry, WithLoadedToolRecorder(func(_ *llm.Context, entry ToolRegistryEntry) error {
+		recorded = entry
+		return nil
+	})), LoadToolName)
+	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+
+	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+	require.NoError(t, err)
+
+	var result LoadToolResult
+	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
+	require.True(t, result.Loaded)
+	require.Equal(t, "jira__get_issue", recorded.Name)
+	require.Equal(t, "get_issue", recorded.BareName)
+	require.Equal(t, "https://jira.example.com", recorded.ServerOrigin)
+}
+
+func TestLoadToolRecorderErrorReturnsResolverError(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
+	})
+	recorderErr := errors.New("persist loaded tool")
+	loadTool := metaToolByName(t, NewMetaTools(registry, WithLoadedToolRecorder(func(_ *llm.Context, _ ToolRegistryEntry) error {
+		return recorderErr
+	})), LoadToolName)
+	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+
+	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+
+	require.Empty(t, resultJSON)
+	require.ErrorIs(t, err, recorderErr)
+	require.Nil(t, llmContext.Tools.GetTool("jira__get_issue"))
+}
+
+func TestLoadToolDoesNotMutateRegistryToolSchema(t *testing.T) {
+	tool := testRegistryTool("jira__get_issue", "Original schema description", "https://jira.example.com")
+	tool.Schema = map[string]any{"source": "original"}
+	registry := NewToolRegistry(
+		[]llm.Tool{tool},
+		WithToolRetrievalOverrides(map[string]ToolRetrievalOverride{
+			ToolRetrievalOverrideKey("https://jira.example.com", "get_issue"): {
+				Summary: "Override retrieval summary",
+			},
+		}),
+	)
+	metaTools := NewMetaTools(registry)
+	searchTool := metaToolByName(t, metaTools, SearchToolsName)
+	loadTool := metaToolByName(t, metaTools, LoadToolName)
+	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+
+	searchJSON, err := searchTool.Resolver(llmContext, metaToolArgs(`{"query":"override"}`))
+	require.NoError(t, err)
+	var searchResult SearchToolsResult
+	require.NoError(t, json.Unmarshal([]byte(searchJSON), &searchResult))
+	require.Equal(t, "Override retrieval summary", searchResult.Tools[0].Summary)
+
+	loadJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+	require.NoError(t, err)
+	var loadResult LoadToolResult
+	require.NoError(t, json.Unmarshal([]byte(loadJSON), &loadResult))
+	require.True(t, loadResult.Loaded)
+	require.Equal(t, map[string]any{"source": "original"}, loadResult.Schema)
+	require.Equal(t, "Original schema description", llmContext.Tools.GetTool("jira__get_issue").Description)
+}
+
+func TestMetaToolsNilRegistryResolvers(t *testing.T) {
+	metaTools := NewMetaTools(nil)
+	searchTool := metaToolByName(t, metaTools, SearchToolsName)
+	loadTool := metaToolByName(t, metaTools, LoadToolName)
+
+	searchJSON, err := searchTool.Resolver(&llm.Context{}, metaToolArgs(`{"query":"issue"}`))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"tools":[]}`, searchJSON)
+
+	loadJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore(nil, false)}, metaToolArgs(`{"name":"jira__get_issue"}`))
+	require.NoError(t, err)
+	var loadResult LoadToolResult
+	require.NoError(t, json.Unmarshal([]byte(loadJSON), &loadResult))
+	require.False(t, loadResult.Loaded)
+	require.Equal(t, "tool registry is unavailable", loadResult.Error)
+	require.Empty(t, loadResult.Matches)
+}
+
+func TestSearchToolsTelemetry(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
+	})
+	searchTool := metaToolByName(t, NewMetaTools(registry), SearchToolsName)
+
+	tests := []struct {
+		name       string
+		context    *llm.Context
+		argsGetter llm.ToolArgumentGetter
+		wantResult string
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			context:    &llm.Context{BotUsername: "matty", MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}},
+			argsGetter: metaToolArgs(`{"query":"jira issue"}`),
+			wantResult: "success",
+		},
+		{
+			name:       "empty query",
+			context:    &llm.Context{BotUsername: "matty", MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}},
+			argsGetter: metaToolArgs(`{"query":"   "}`),
+			wantResult: "empty",
+		},
+		{
+			name:       "no results",
+			context:    &llm.Context{BotUsername: "matty", MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}},
+			argsGetter: metaToolArgs(`{"query":"no matching tool"}`),
+			wantResult: "empty",
+		},
+		{
+			name:    "decode error",
+			context: &llm.Context{BotUsername: "matty", MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}},
+			argsGetter: func(any) error {
+				return errors.New("decode")
+			},
+			wantResult: "error",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := searchTool.Resolver(tt.context, tt.argsGetter)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			telemetry := tt.context.MCPDynamicToolTelemetry.(*fakeMCPDynamicTelemetry)
+			require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "search", result: tt.wantResult}}, telemetry.events)
+		})
+	}
+}
+
+func TestLoadToolTelemetry(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
+	})
+
+	t.Run("loaded", func(t *testing.T) {
+		telemetry := &fakeMCPDynamicTelemetry{}
+		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
+		llmContext := &llm.Context{
+			BotUsername:             "matty",
+			Tools:                   llm.NewToolStore(nil, false),
+			MCPDynamicToolTelemetry: telemetry,
+		}
+
+		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+		require.NoError(t, err)
+		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "loaded"}}, telemetry.events)
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		telemetry := &fakeMCPDynamicTelemetry{}
+		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
+		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(nil, false), MCPDynamicToolTelemetry: telemetry}
+
+		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__missing"}`))
+		require.NoError(t, err)
+		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "miss"}}, telemetry.events)
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		telemetry := &fakeMCPDynamicTelemetry{}
+		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
+		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(nil, false), MCPDynamicToolTelemetry: telemetry}
+
+		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"   "}`))
+		require.NoError(t, err)
+		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "error"}}, telemetry.events)
+	})
+
+	t.Run("missing tool store", func(t *testing.T) {
+		telemetry := &fakeMCPDynamicTelemetry{}
+		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
+		llmContext := &llm.Context{BotUsername: "matty", MCPDynamicToolTelemetry: telemetry}
+
+		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+		require.NoError(t, err)
+		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "error"}}, telemetry.events)
+	})
+
+	t.Run("decode error", func(t *testing.T) {
+		telemetry := &fakeMCPDynamicTelemetry{}
+		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
+		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(nil, false), MCPDynamicToolTelemetry: telemetry}
+
+		_, err := loadTool.Resolver(llmContext, func(any) error {
+			return errors.New("decode")
+		})
+		require.Error(t, err)
+		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "error"}}, telemetry.events)
+	})
+
+	t.Run("recorder error", func(t *testing.T) {
+		telemetry := &fakeMCPDynamicTelemetry{}
+		recorderErr := errors.New("persist loaded tool")
+		loadTool := metaToolByName(t, NewMetaTools(registry, WithLoadedToolRecorder(func(_ *llm.Context, _ ToolRegistryEntry) error {
+			return recorderErr
+		})), LoadToolName)
+		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(nil, false), MCPDynamicToolTelemetry: telemetry}
+
+		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+		require.ErrorIs(t, err, recorderErr)
+		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "error"}}, telemetry.events)
+	})
+}
+
+func TestSearchLoadStateMarkers(t *testing.T) {
+	registry := NewToolRegistry([]llm.Tool{
+		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
+	})
+	metaTools := NewMetaTools(registry)
+	searchTool := metaToolByName(t, metaTools, SearchToolsName)
+	loadTool := metaToolByName(t, metaTools, LoadToolName)
+	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+
+	_, err := searchTool.Resolver(llmContext, metaToolArgs(`{"query":"jira issue"}`))
+	require.NoError(t, err)
+	require.True(t, llmContext.MCPDynamicToolSearchUsed)
+
+	_, err = loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+	require.NoError(t, err)
+	require.True(t, llmContext.MCPDynamicLoadedToolNames["jira__get_issue"])
+	require.True(t, llmContext.ShouldRecordMCPDynamicSearchLoadCallSuccess("jira__get_issue"))
+	require.False(t, llmContext.ShouldRecordMCPDynamicSearchLoadCallSuccess("jira__get_issue"))
+}
+
+func metaToolByName(t *testing.T, tools []llm.Tool, name string) llm.Tool {
+	t.Helper()
+
+	for _, tool := range tools {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	require.FailNow(t, "meta tool not found", "name=%s", name)
+	return llm.Tool{}
+}
+
+func metaToolArgs(raw string) llm.ToolArgumentGetter {
+	return func(args any) error {
+		return json.Unmarshal([]byte(raw), args)
+	}
+}
+
+func metaToolResultItemNames(items []SearchToolsResultItem) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	return names
+}

--- a/mcp/meta_tools_test.go
+++ b/mcp/meta_tools_test.go
@@ -33,6 +33,8 @@ func TestNewMetaToolsDefinitions(t *testing.T) {
 
 	require.Len(t, tools, 2)
 	require.Equal(t, []string{SearchToolsName, LoadToolName}, []string{tools[0].Name, tools[1].Name})
+	require.Equal(t, "Search available MCP tools by keyword.", tools[0].Description)
+	require.Equal(t, "Load an MCP tool by exact namespaced name.", tools[1].Description)
 	for _, tool := range tools {
 		require.NotEmpty(t, tool.Description)
 		require.NotNil(t, tool.Schema)
@@ -187,24 +189,44 @@ func TestLoadToolEmptyNameReturnsJSONError(t *testing.T) {
 	require.Empty(t, result.Matches)
 }
 
-func TestLoadToolNilContextOrToolStoreReturnsJSONError(t *testing.T) {
+func TestLoadToolInvariantFailuresReturnErrors(t *testing.T) {
 	registry := NewToolRegistry([]llm.Tool{
 		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
 	})
-	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
+	tests := []struct {
+		name       string
+		tool       llm.Tool
+		context    *llm.Context
+		wantErrMsg string
+	}{
+		{
+			name:       "missing LLM context",
+			tool:       metaToolByName(t, NewMetaTools(registry), LoadToolName),
+			context:    nil,
+			wantErrMsg: "missing LLM context",
+		},
+		{
+			name:       "missing registry",
+			tool:       metaToolByName(t, NewMetaTools(nil), LoadToolName),
+			context:    &llm.Context{Tools: llm.NewToolStore()},
+			wantErrMsg: "tool registry unavailable",
+		},
+		{
+			name:       "missing tool store",
+			tool:       metaToolByName(t, NewMetaTools(registry), LoadToolName),
+			context:    &llm.Context{},
+			wantErrMsg: "missing tool store",
+		},
+	}
 
-	resultJSON, err := loadTool.Resolver(context.Background(), nil, metaToolArgs(`{"name":"jira__get_issue"}`))
-	require.NoError(t, err)
-	var result LoadToolResult
-	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
-	require.False(t, result.Loaded)
-	require.Contains(t, result.Error, "LLM context")
-
-	resultJSON, err = loadTool.Resolver(context.Background(), &llm.Context{}, metaToolArgs(`{"name":"jira__get_issue"}`))
-	require.NoError(t, err)
-	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
-	require.False(t, result.Loaded)
-	require.Contains(t, result.Error, "tool store")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.tool.Resolver(context.Background(), tt.context, metaToolArgs(`{"name":"jira__get_issue"}`))
+			require.Error(t, err)
+			require.Empty(t, result)
+			require.Contains(t, err.Error(), tt.wantErrMsg)
+		})
+	}
 }
 
 func TestLoadToolDoesNotMutateRegistryToolSchema(t *testing.T) {
@@ -279,13 +301,9 @@ func TestMetaToolsNilRegistryResolvers(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, `{"tools":[]}`, searchJSON)
 
-	loadJSON, err := loadTool.Resolver(context.Background(), &llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"jira__get_issue"}`))
-	require.NoError(t, err)
-	var loadResult LoadToolResult
-	require.NoError(t, json.Unmarshal([]byte(loadJSON), &loadResult))
-	require.False(t, loadResult.Loaded)
-	require.Equal(t, "tool registry is unavailable", loadResult.Error)
-	require.Empty(t, loadResult.Matches)
+	_, err = loadTool.Resolver(context.Background(), &llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"jira__get_issue"}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tool registry unavailable")
 }
 
 func TestSearchToolsTelemetry(t *testing.T) {
@@ -390,7 +408,7 @@ func TestLoadToolTelemetry(t *testing.T) {
 		llmContext := &llm.Context{BotUsername: "matty", ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: telemetry}}
 
 		_, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
-		require.NoError(t, err)
+		require.Error(t, err)
 		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "error"}}, telemetry.events)
 	})
 

--- a/mcp/meta_tools_test.go
+++ b/mcp/meta_tools_test.go
@@ -103,7 +103,7 @@ func TestSearchToolsUsesFilteredRegistryOnly(t *testing.T) {
 		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
 	})
 	searchTool := metaToolByName(t, NewMetaTools(registry), SearchToolsName)
-	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 	llmContext.Tools.AddTools([]llm.Tool{
 		testRegistryTool("github__create_pull_request", "Create a pull request", "https://github.example.com"),
 	})
@@ -121,7 +121,7 @@ func TestLoadToolExactLookupAddsToolToVisibleStore(t *testing.T) {
 	registry := NewToolRegistry([]llm.Tool{registryTool})
 	metaTools := NewMetaTools(registry)
 	loadTool := metaToolByName(t, metaTools, LoadToolName)
-	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 	llmContext.Tools.AddTools(metaTools)
 
 	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
@@ -140,7 +140,7 @@ func TestLoadToolDoesNotLoadBareName(t *testing.T) {
 		testRegistryTool("jira__search", "Search Jira", "https://jira.example.com"),
 	})
 	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
-	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 
 	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"search"}`))
 	require.NoError(t, err)
@@ -158,7 +158,7 @@ func TestLoadToolMissReturnsClosestFilteredMatches(t *testing.T) {
 		testRegistryTool("mattermost__search_users", "Find people", "https://mattermost.example.com"),
 	})
 	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
-	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 
 	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"search user"}`))
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestLoadToolEmptyNameReturnsJSONError(t *testing.T) {
 		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
 	})), LoadToolName)
 
-	resultJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore(nil, false)}, metaToolArgs(`{"name":"   "}`))
+	resultJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"   "}`))
 	require.NoError(t, err)
 
 	var result LoadToolResult
@@ -220,7 +220,7 @@ func TestLoadToolDoesNotMutateRegistryToolSchema(t *testing.T) {
 	metaTools := NewMetaTools(registry)
 	searchTool := metaToolByName(t, metaTools, SearchToolsName)
 	loadTool := metaToolByName(t, metaTools, LoadToolName)
-	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 
 	searchJSON, err := searchTool.Resolver(llmContext, metaToolArgs(`{"query":"override"}`))
 	require.NoError(t, err)
@@ -242,7 +242,7 @@ func TestLoadToolResultWireShape(t *testing.T) {
 		testRegistryTool("jira__get_issue", "Get a Jira issue", "https://jira.example.com"),
 	})
 	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
-	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 
 	t.Run("success", func(t *testing.T) {
 		resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
@@ -257,7 +257,7 @@ func TestLoadToolResultWireShape(t *testing.T) {
 	})
 
 	t.Run("miss", func(t *testing.T) {
-		resultJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore(nil, false)}, metaToolArgs(`{"name":"jira__unknown"}`))
+		resultJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"jira__unknown"}`))
 		require.NoError(t, err)
 
 		var raw map[string]any
@@ -278,7 +278,7 @@ func TestMetaToolsNilRegistryResolvers(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, `{"tools":[]}`, searchJSON)
 
-	loadJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore(nil, false)}, metaToolArgs(`{"name":"jira__get_issue"}`))
+	loadJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"jira__get_issue"}`))
 	require.NoError(t, err)
 	var loadResult LoadToolResult
 	require.NoError(t, json.Unmarshal([]byte(loadJSON), &loadResult))
@@ -354,7 +354,7 @@ func TestLoadToolTelemetry(t *testing.T) {
 		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
 		llmContext := &llm.Context{
 			BotUsername:             "matty",
-			Tools:                   llm.NewToolStore(nil, false),
+			Tools:                   llm.NewToolStore(),
 			MCPDynamicToolTelemetry: telemetry,
 		}
 
@@ -366,7 +366,7 @@ func TestLoadToolTelemetry(t *testing.T) {
 	t.Run("miss", func(t *testing.T) {
 		telemetry := &fakeMCPDynamicTelemetry{}
 		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
-		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(nil, false), MCPDynamicToolTelemetry: telemetry}
+		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(), MCPDynamicToolTelemetry: telemetry}
 
 		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__missing"}`))
 		require.NoError(t, err)
@@ -376,7 +376,7 @@ func TestLoadToolTelemetry(t *testing.T) {
 	t.Run("empty name", func(t *testing.T) {
 		telemetry := &fakeMCPDynamicTelemetry{}
 		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
-		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(nil, false), MCPDynamicToolTelemetry: telemetry}
+		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(), MCPDynamicToolTelemetry: telemetry}
 
 		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"   "}`))
 		require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestLoadToolTelemetry(t *testing.T) {
 	t.Run("decode error", func(t *testing.T) {
 		telemetry := &fakeMCPDynamicTelemetry{}
 		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
-		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(nil, false), MCPDynamicToolTelemetry: telemetry}
+		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(), MCPDynamicToolTelemetry: telemetry}
 
 		_, err := loadTool.Resolver(llmContext, func(any) error {
 			return errors.New("decode")
@@ -413,7 +413,7 @@ func TestSearchLoadStateMarkers(t *testing.T) {
 	metaTools := NewMetaTools(registry)
 	searchTool := metaToolByName(t, metaTools, SearchToolsName)
 	loadTool := metaToolByName(t, metaTools, LoadToolName)
-	llmContext := &llm.Context{Tools: llm.NewToolStore(nil, false)}
+	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 
 	_, err := searchTool.Resolver(llmContext, metaToolArgs(`{"query":"jira issue"}`))
 	require.NoError(t, err)

--- a/mcp/meta_tools_test.go
+++ b/mcp/meta_tools_test.go
@@ -4,6 +4,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -52,7 +53,7 @@ func TestSearchToolsReturnsTopEightNameSummary(t *testing.T) {
 	}
 	searchTool := metaToolByName(t, NewMetaTools(NewToolRegistry(tools)), SearchToolsName)
 
-	resultJSON, err := searchTool.Resolver(&llm.Context{}, metaToolArgs(`{"query":"shared"}`))
+	resultJSON, err := searchTool.Resolver(context.Background(), &llm.Context{}, metaToolArgs(`{"query":"shared"}`))
 	require.NoError(t, err)
 
 	var result SearchToolsResult
@@ -74,7 +75,7 @@ func TestSearchToolsEmptyQueryReturnsEmptyList(t *testing.T) {
 	})), SearchToolsName)
 
 	for _, rawArgs := range []string{`{"query":""}`, `{"query":"   "}`} {
-		resultJSON, err := searchTool.Resolver(&llm.Context{}, metaToolArgs(rawArgs))
+		resultJSON, err := searchTool.Resolver(context.Background(), &llm.Context{}, metaToolArgs(rawArgs))
 		require.NoError(t, err)
 
 		var result SearchToolsResult
@@ -89,7 +90,7 @@ func TestSearchToolsNilContextStillReturnsResults(t *testing.T) {
 		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
 	})), SearchToolsName)
 
-	resultJSON, err := searchTool.Resolver(nil, metaToolArgs(`{"query":"issue"}`))
+	resultJSON, err := searchTool.Resolver(context.Background(), nil, metaToolArgs(`{"query":"issue"}`))
 	require.NoError(t, err)
 
 	var result SearchToolsResult
@@ -108,7 +109,7 @@ func TestSearchToolsUsesFilteredRegistryOnly(t *testing.T) {
 		testRegistryTool("github__create_pull_request", "Create a pull request", "https://github.example.com"),
 	})
 
-	resultJSON, err := searchTool.Resolver(llmContext, metaToolArgs(`{"query":"pull request"}`))
+	resultJSON, err := searchTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"query":"pull request"}`))
 	require.NoError(t, err)
 
 	var result SearchToolsResult
@@ -124,7 +125,7 @@ func TestLoadToolExactLookupAddsToolToVisibleStore(t *testing.T) {
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 	llmContext.Tools.AddTools(metaTools)
 
-	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+	resultJSON, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
 	require.NoError(t, err)
 
 	var result LoadToolResult
@@ -142,7 +143,7 @@ func TestLoadToolDoesNotLoadBareName(t *testing.T) {
 	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 
-	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"search"}`))
+	resultJSON, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"search"}`))
 	require.NoError(t, err)
 
 	var result LoadToolResult
@@ -160,7 +161,7 @@ func TestLoadToolMissReturnsClosestFilteredMatches(t *testing.T) {
 	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 
-	resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"search user"}`))
+	resultJSON, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"search user"}`))
 	require.NoError(t, err)
 
 	var result LoadToolResult
@@ -176,7 +177,7 @@ func TestLoadToolEmptyNameReturnsJSONError(t *testing.T) {
 		testRegistryTool("jira__get_issue", "Get issue", "https://jira.example.com"),
 	})), LoadToolName)
 
-	resultJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"   "}`))
+	resultJSON, err := loadTool.Resolver(context.Background(), &llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"   "}`))
 	require.NoError(t, err)
 
 	var result LoadToolResult
@@ -192,14 +193,14 @@ func TestLoadToolNilContextOrToolStoreReturnsJSONError(t *testing.T) {
 	})
 	loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
 
-	resultJSON, err := loadTool.Resolver(nil, metaToolArgs(`{"name":"jira__get_issue"}`))
+	resultJSON, err := loadTool.Resolver(context.Background(), nil, metaToolArgs(`{"name":"jira__get_issue"}`))
 	require.NoError(t, err)
 	var result LoadToolResult
 	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
 	require.False(t, result.Loaded)
 	require.Contains(t, result.Error, "LLM context")
 
-	resultJSON, err = loadTool.Resolver(&llm.Context{}, metaToolArgs(`{"name":"jira__get_issue"}`))
+	resultJSON, err = loadTool.Resolver(context.Background(), &llm.Context{}, metaToolArgs(`{"name":"jira__get_issue"}`))
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal([]byte(resultJSON), &result))
 	require.False(t, result.Loaded)
@@ -222,13 +223,13 @@ func TestLoadToolDoesNotMutateRegistryToolSchema(t *testing.T) {
 	loadTool := metaToolByName(t, metaTools, LoadToolName)
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 
-	searchJSON, err := searchTool.Resolver(llmContext, metaToolArgs(`{"query":"override"}`))
+	searchJSON, err := searchTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"query":"override"}`))
 	require.NoError(t, err)
 	var searchResult SearchToolsResult
 	require.NoError(t, json.Unmarshal([]byte(searchJSON), &searchResult))
 	require.Equal(t, "Override retrieval summary", searchResult.Tools[0].Summary)
 
-	loadJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+	loadJSON, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
 	require.NoError(t, err)
 	var loadResult LoadToolResult
 	require.NoError(t, json.Unmarshal([]byte(loadJSON), &loadResult))
@@ -245,7 +246,7 @@ func TestLoadToolResultWireShape(t *testing.T) {
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 
 	t.Run("success", func(t *testing.T) {
-		resultJSON, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+		resultJSON, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
 		require.NoError(t, err)
 
 		var raw map[string]any
@@ -257,7 +258,7 @@ func TestLoadToolResultWireShape(t *testing.T) {
 	})
 
 	t.Run("miss", func(t *testing.T) {
-		resultJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"jira__unknown"}`))
+		resultJSON, err := loadTool.Resolver(context.Background(), &llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"jira__unknown"}`))
 		require.NoError(t, err)
 
 		var raw map[string]any
@@ -274,11 +275,11 @@ func TestMetaToolsNilRegistryResolvers(t *testing.T) {
 	searchTool := metaToolByName(t, metaTools, SearchToolsName)
 	loadTool := metaToolByName(t, metaTools, LoadToolName)
 
-	searchJSON, err := searchTool.Resolver(&llm.Context{}, metaToolArgs(`{"query":"issue"}`))
+	searchJSON, err := searchTool.Resolver(context.Background(), &llm.Context{}, metaToolArgs(`{"query":"issue"}`))
 	require.NoError(t, err)
 	require.JSONEq(t, `{"tools":[]}`, searchJSON)
 
-	loadJSON, err := loadTool.Resolver(&llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"jira__get_issue"}`))
+	loadJSON, err := loadTool.Resolver(context.Background(), &llm.Context{Tools: llm.NewToolStore()}, metaToolArgs(`{"name":"jira__get_issue"}`))
 	require.NoError(t, err)
 	var loadResult LoadToolResult
 	require.NoError(t, json.Unmarshal([]byte(loadJSON), &loadResult))
@@ -302,25 +303,25 @@ func TestSearchToolsTelemetry(t *testing.T) {
 	}{
 		{
 			name:       "success",
-			context:    &llm.Context{BotUsername: "matty", MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}},
+			context:    &llm.Context{BotUsername: "matty", ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}}},
 			argsGetter: metaToolArgs(`{"query":"jira issue"}`),
 			wantResult: "success",
 		},
 		{
 			name:       "empty query",
-			context:    &llm.Context{BotUsername: "matty", MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}},
+			context:    &llm.Context{BotUsername: "matty", ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}}},
 			argsGetter: metaToolArgs(`{"query":"   "}`),
 			wantResult: "empty",
 		},
 		{
 			name:       "no results",
-			context:    &llm.Context{BotUsername: "matty", MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}},
+			context:    &llm.Context{BotUsername: "matty", ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}}},
 			argsGetter: metaToolArgs(`{"query":"no matching tool"}`),
 			wantResult: "empty",
 		},
 		{
 			name:    "decode error",
-			context: &llm.Context{BotUsername: "matty", MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}},
+			context: &llm.Context{BotUsername: "matty", ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: &fakeMCPDynamicTelemetry{}}},
 			argsGetter: func(any) error {
 				return errors.New("decode")
 			},
@@ -331,14 +332,14 @@ func TestSearchToolsTelemetry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := searchTool.Resolver(tt.context, tt.argsGetter)
+			_, err := searchTool.Resolver(context.Background(), tt.context, tt.argsGetter)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}
 
-			telemetry := tt.context.MCPDynamicToolTelemetry.(*fakeMCPDynamicTelemetry)
+			telemetry := tt.context.ToolRuntime.MCPDynamicToolTelemetry.(*fakeMCPDynamicTelemetry)
 			require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "search", result: tt.wantResult}}, telemetry.events)
 		})
 	}
@@ -353,12 +354,12 @@ func TestLoadToolTelemetry(t *testing.T) {
 		telemetry := &fakeMCPDynamicTelemetry{}
 		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
 		llmContext := &llm.Context{
-			BotUsername:             "matty",
-			Tools:                   llm.NewToolStore(),
-			MCPDynamicToolTelemetry: telemetry,
+			BotUsername: "matty",
+			Tools:       llm.NewToolStore(),
+			ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: telemetry},
 		}
 
-		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+		_, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
 		require.NoError(t, err)
 		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "loaded"}}, telemetry.events)
 	})
@@ -366,9 +367,9 @@ func TestLoadToolTelemetry(t *testing.T) {
 	t.Run("miss", func(t *testing.T) {
 		telemetry := &fakeMCPDynamicTelemetry{}
 		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
-		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(), MCPDynamicToolTelemetry: telemetry}
+		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(), ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: telemetry}}
 
-		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__missing"}`))
+		_, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__missing"}`))
 		require.NoError(t, err)
 		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "miss"}}, telemetry.events)
 	})
@@ -376,9 +377,9 @@ func TestLoadToolTelemetry(t *testing.T) {
 	t.Run("empty name", func(t *testing.T) {
 		telemetry := &fakeMCPDynamicTelemetry{}
 		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
-		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(), MCPDynamicToolTelemetry: telemetry}
+		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(), ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: telemetry}}
 
-		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"   "}`))
+		_, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"   "}`))
 		require.NoError(t, err)
 		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "error"}}, telemetry.events)
 	})
@@ -386,9 +387,9 @@ func TestLoadToolTelemetry(t *testing.T) {
 	t.Run("missing tool store", func(t *testing.T) {
 		telemetry := &fakeMCPDynamicTelemetry{}
 		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
-		llmContext := &llm.Context{BotUsername: "matty", MCPDynamicToolTelemetry: telemetry}
+		llmContext := &llm.Context{BotUsername: "matty", ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: telemetry}}
 
-		_, err := loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+		_, err := loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
 		require.NoError(t, err)
 		require.Equal(t, []mcpTelemetryEvent{{botName: "matty", event: "load", result: "error"}}, telemetry.events)
 	})
@@ -396,9 +397,9 @@ func TestLoadToolTelemetry(t *testing.T) {
 	t.Run("decode error", func(t *testing.T) {
 		telemetry := &fakeMCPDynamicTelemetry{}
 		loadTool := metaToolByName(t, NewMetaTools(registry), LoadToolName)
-		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(), MCPDynamicToolTelemetry: telemetry}
+		llmContext := &llm.Context{BotUsername: "matty", Tools: llm.NewToolStore(), ToolRuntime: llm.ToolRuntimeContext{MCPDynamicToolTelemetry: telemetry}}
 
-		_, err := loadTool.Resolver(llmContext, func(any) error {
+		_, err := loadTool.Resolver(context.Background(), llmContext, func(any) error {
 			return errors.New("decode")
 		})
 		require.Error(t, err)
@@ -415,13 +416,13 @@ func TestSearchLoadStateMarkers(t *testing.T) {
 	loadTool := metaToolByName(t, metaTools, LoadToolName)
 	llmContext := &llm.Context{Tools: llm.NewToolStore()}
 
-	_, err := searchTool.Resolver(llmContext, metaToolArgs(`{"query":"jira issue"}`))
+	_, err := searchTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"query":"jira issue"}`))
 	require.NoError(t, err)
-	require.True(t, llmContext.MCPDynamicToolSearchUsed)
+	require.True(t, llmContext.ToolRuntime.MCPDynamicToolSearchUsed)
 
-	_, err = loadTool.Resolver(llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
+	_, err = loadTool.Resolver(context.Background(), llmContext, metaToolArgs(`{"name":"jira__get_issue"}`))
 	require.NoError(t, err)
-	require.True(t, llmContext.MCPDynamicLoadedToolNames["jira__get_issue"])
+	require.True(t, llmContext.ToolRuntime.MCPDynamicLoadedToolNames["jira__get_issue"])
 	require.True(t, llmContext.ShouldRecordMCPDynamicSearchLoadCallSuccess("jira__get_issue"))
 	require.False(t, llmContext.ShouldRecordMCPDynamicSearchLoadCallSuccess("jira__get_issue"))
 }


### PR DESCRIPTION
#### Summary
Adds the dynamic MCP tool registry, BM25 search, and the `search_tools` / `load_tool` meta-tools used to discover and materialize MCP tools on demand. Centralizes tool loading on a single `ToolStore.LoadMCPTools` path (used by `load_tool` and, in later floors, cross-turn restoration), refactors `load_tool` to emit a canonical turn-derivable JSON envelope (replacing in-process loaded-tool recording), and guards zero-value registry searches.

**Stack:** 3/6
- ↓ [772 — dynamic-mcp-02-client-catalog](https://github.com/mattermost/mattermost-plugin-agents/pull/772)
- ↑ [774 — dynamic-mcp-04-context-toolrunner](https://github.com/mattermost/mattermost-plugin-agents/pull/774)

#### Ticket Link

N/A

#### Screenshots

N/A

#### Release Note

```release-note
Added dynamic MCP search and load tools for on-demand MCP tool discovery.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relevance-ranked search across registered tools (BM25) with deterministic tie-breaking and result limits.
  * In-memory tool registry with name/summary search and a "closest matches" fallback for partial hits.
  * Two meta-operations exposed: search available tools by keyword and load a specific tool at runtime.

* **Chores**
  * Removed legacy per-request MCP tool restorer API; dynamic load tracking simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
