### PR TITLE
MM-67913: stop toggling app__body on Agents product page

### DIFF
--- a/webapp/src/components/agents/agents_page.tsx
+++ b/webapp/src/components/agents/agents_page.tsx
@@ -15,19 +15,13 @@ export const AGENTS_ROUTE = `/plug/${manifest.id}/agents`;
 // No URL-matching or overlay needed; Mattermost's product routing handles it.
 const AgentsPage = () => {
     useEffect(() => {
-        // ChannelController normally sets these classes, but it's not loaded in
-        // product views. Without them the global header loses its themed colors.
-        // Playbooks and Boards do the same thing in their top-level components.
-        document.body.classList.add('app__body');
-
+        // The host webapp owns `app__body` on document.body (see MM-67913 / Boards #188).
+        // ChannelController normally sets `channel-view` on #root, but it's not loaded in
+        // product views. Without it the global header loses its themed colors.
         const root = document.getElementById('root');
         if (root && !root.classList.contains('channel-view')) {
             root.classList.add('channel-view');
         }
-
-        return () => {
-            document.body.classList.remove('app__body');
-        };
     }, []);
 
     return (


### PR DESCRIPTION
#### Summary

Re-lands #683, which was reverted in #729 while waiting for the Mattermost 11.8 host change ([mattermost/mattermost#36186](https://github.com/mattermost/mattermost/pull/36186)). That dependency is now ready.

Stops adding and removing `app__body` on `document.body` from the Agents product page. The Mattermost web app now owns that class; plugins that toggle it can conflict with the host and cause navigation flicker (e.g. white flash).

Plugin behavior unchanged for `channel-view` on `#root` when `ChannelController` is not loaded.

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-67913

#### Screenshots

N/A (no intentional visual change beyond removing incorrect flicker).

#### Release Note
```release-note
Stopped toggling `app__body` on the Agents product route so the web app remains the sole owner of that class, avoiding navigation flicker when entering or leaving Agents.
```

#### Test Plan

- [ ] Navigate to the Agents product page and verify the global header retains its themed colors
- [ ] Verify no navigation flashes on page transitions when entering or leaving Agents
- [ ] Requires Mattermost 11.8+ (host owns `app__body` on `document.body`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS class management on the agents page to ensure proper styling is applied and displayed correctly without affecting other page elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-agents/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->