### PR TITLE
Rebuild bots when a DB-agent's service config changes

### DIFF
--- a/bots/bots.go
+++ b/bots/bots.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"slices"
 	"sync"
 
 	"github.com/mattermost/mattermost-plugin-agents/assets"
@@ -87,6 +88,40 @@ func New(mutexPluginAPI cluster.MutexPluginAPI, pluginAPI *pluginapi.Client, lic
 		tokenUsageSinks:        llm.NewTokenUsageSinks(pluginTokenLogger),
 		metrics:                metrics,
 	}
+}
+
+// snapshotBotsAndServices returns the full bot lineup (file-config bots plus
+// DB-backed agents, license cap applied) and the services they reference.
+// EnsureBots calls this for both the optimistic equality check and the
+// rebuild, so the check can't miss a service used only by a DB agent.
+func (b *MMBots) snapshotBotsAndServices() ([]llm.BotConfig, map[string]struct{}, map[string]llm.ServiceConfig, error) {
+	// config.GetBots() returns the config-owned slice; clone before
+	// truncating + appending so we don't overwrite it.
+	botCfgs := slices.Clone(b.config.GetBots())
+	if len(botCfgs) > 1 && !b.licenseChecker.IsMultiLLMLicensed() {
+		b.pluginAPI.Log.Error("Only one bot allowed with current license.")
+		botCfgs = botCfgs[:1]
+	}
+
+	// DB-backed user agents bypass the license multi-LLM cap — gated by
+	// PermissionManageOwnAgent at the API layer instead.
+	activeDBBotUsernames := make(map[string]struct{})
+	if b.agentStore != nil {
+		dbAgents, err := b.agentStore.ListAgents()
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to list user agents: %w", err)
+		}
+		for _, cfg := range dbAgents {
+			if cfg == nil {
+				continue
+			}
+			activeDBBotUsernames[cfg.Name] = struct{}{}
+			botCfgs = append(botCfgs, *cfg)
+		}
+	}
+
+	serviceCfgs := b.resolveServiceCfgs(botCfgs)
+	return botCfgs, activeDBBotUsernames, serviceCfgs, nil
 }
 
 // resolveServiceCfgs builds a map of service configs referenced by the given bot configs.
@@ -207,8 +242,11 @@ func (b *MMBots) EnsureBots() error {
 	// when multiple nodes all try to acquire the mutex simultaneously on config changes.
 	b.reconcileTokenUsageSinks()
 
-	currentBotCfgs := b.config.GetBots()
-	currentServiceCfgs := b.resolveServiceCfgs(currentBotCfgs)
+	var activeDBBotUsernames map[string]struct{}
+	currentBotCfgs, _, currentServiceCfgs, err := b.snapshotBotsAndServices()
+	if err != nil {
+		return err
+	}
 	b.botsLock.RLock()
 	botsAlreadyInitialized := len(b.bots) > 0
 	lastBotCfgs := b.lastEnsuredBotCfgs
@@ -231,8 +269,10 @@ func (b *MMBots) EnsureBots() error {
 	// Re-check after acquiring lock - another node may have already handled this
 	b.reconcileTokenUsageSinks()
 
-	currentBotCfgs = b.config.GetBots()
-	currentServiceCfgs = b.resolveServiceCfgs(currentBotCfgs)
+	currentBotCfgs, activeDBBotUsernames, currentServiceCfgs, err = b.snapshotBotsAndServices()
+	if err != nil {
+		return err
+	}
 	b.botsLock.RLock()
 	botsAlreadyInitialized = len(b.bots) > 0
 	lastBotCfgs = b.lastEnsuredBotCfgs
@@ -249,31 +289,7 @@ func (b *MMBots) EnsureBots() error {
 	if err != nil {
 		return fmt.Errorf("failed to list bots: %w", err)
 	}
-
-	// Only allow one bot if not multi-LLM licensed
-	botCfgs := b.config.GetBots()
-	if len(botCfgs) > 1 && !b.licenseChecker.IsMultiLLMLicensed() {
-		b.pluginAPI.Log.Error("Only one bot allowed with current license.")
-		botCfgs = botCfgs[:1]
-	}
-
-	// Load DB-backed user agents and merge into the bot config list.
-	// These bypass the license multi-LLM check — they are gated by
-	// PermissionManageOwnAgent at the API layer.
-	activeDBBotUsernames := make(map[string]struct{})
-	if b.agentStore != nil {
-		dbAgents, err := b.agentStore.ListAgents()
-		if err != nil {
-			return fmt.Errorf("failed to list user agents: %w", err)
-		}
-		for _, cfg := range dbAgents {
-			if cfg == nil {
-				continue
-			}
-			activeDBBotUsernames[cfg.Name] = struct{}{}
-			botCfgs = append(botCfgs, *cfg)
-		}
-	}
+	botCfgs := currentBotCfgs
 
 	var bots []*Bot
 	aiBotsByUsername := make(map[string]*Bot)

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -640,6 +641,131 @@ func TestEnsureBots(t *testing.T) {
 			}
 		})
 	}
+}
+
+// stubAgentStore returns a fixed slice. Tests can swap the slice between
+// EnsureBots calls to mimic a config save changing the DB-backed agent.
+type stubAgentStore struct {
+	agents []llm.BotConfig
+}
+
+func (s *stubAgentStore) ListAgents() ([]*llm.BotConfig, error) {
+	out := make([]*llm.BotConfig, len(s.agents))
+	for i := range s.agents {
+		cfg := s.agents[i]
+		out[i] = &cfg
+	}
+	return out, nil
+}
+
+// TestSnapshotBotsAndServicesDoesNotMutateConfigBots pins that
+// snapshotBotsAndServices treats config.GetBots() as read-only. Without the
+// clone, an unlicensed-server truncate-then-append overwrites the config's
+// backing array at index 1.
+func TestSnapshotBotsAndServicesDoesNotMutateConfigBots(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	client := pluginapi.NewClient(mockAPI, nil)
+	mockAPI.On("GetConfig").Return(&model.Config{}).Maybe()
+	mockAPI.On("GetLicense").Return((*model.License)(nil)).Maybe()
+	mockAPI.On("LogError", mock.Anything).Return(nil).Maybe()
+	mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	originalBots := []llm.BotConfig{
+		{ID: "file-bot-1", Name: "filebot1", DisplayName: "File Bot 1", ServiceID: "svc1"},
+		{ID: "file-bot-2", Name: "filebot2", DisplayName: "File Bot 2", ServiceID: "svc1"},
+	}
+	cfg := &mockConfig{
+		bots: originalBots,
+		services: []llm.ServiceConfig{
+			{ID: "svc1", Type: llm.ServiceTypeOpenAI, APIKey: "k", DefaultModel: "gpt-5.4"},
+		},
+	}
+	agentStore := &stubAgentStore{
+		agents: []llm.BotConfig{
+			{ID: "db-agent-1", Name: "dbagent1", DisplayName: "DB Agent 1", ServiceID: "svc1"},
+		},
+	}
+	mmBots := New(mockAPI, client, enterprise.NewLicenseChecker(client), cfg, agentStore, &http.Client{}, nil)
+
+	_, _, _, err := mmBots.snapshotBotsAndServices()
+	require.NoError(t, err)
+
+	require.Equal(t, originalBots[1].ID, cfg.GetBots()[1].ID,
+		"snapshotBotsAndServices must not write into the config-owned slice")
+	assert.Equal(t, "file-bot-2", cfg.GetBots()[1].ID)
+}
+
+// TestEnsureBotsRebuildsBotWhenServiceInputTokenLimitChanges pins that
+// EnsureBots rebuilds when a service referenced only by a DB-backed agent
+// changes. Without the snapshot-based equality check, the optimistic
+// fast-path misses the change and the bot's LLM keeps the stale limit.
+func TestEnsureBotsRebuildsBotWhenServiceInputTokenLimitChanges(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	client := pluginapi.NewClient(mockAPI, nil)
+
+	mockAPI.On("GetConfig").Return(&model.Config{}).Maybe()
+	mockAPI.On("GetLicense").Return((*model.License)(nil)).Maybe()
+	mockAPI.On("GetBots", mock.AnythingOfType("*model.BotGetOptions")).Return([]*model.Bot{}, nil).Maybe()
+	mockAPI.On("CreateBot", mock.AnythingOfType("*model.Bot")).Return(func(bot *model.Bot) *model.Bot { return bot }, nil).Maybe()
+	mockAPI.On("GetUser", mock.AnythingOfType("string")).Return(&model.User{LastPictureUpdate: 0}, nil).Maybe()
+	mockAPI.On("SetProfileImage", mock.AnythingOfType("string"), mock.AnythingOfType("[]uint8")).Return(nil).Maybe()
+	mockAPI.On("UpdateBotActive", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return(&model.Bot{}, nil).Maybe()
+	mockAPI.On("PatchBot", mock.AnythingOfType("string"), mock.AnythingOfType("*model.BotPatch")).Return(&model.Bot{}, nil).Maybe()
+	mockAPI.On("KVSetWithOptions", mock.AnythingOfType("string"), mock.AnythingOfType("[]uint8"), mock.AnythingOfType("model.PluginKVSetOptions")).Return(true, nil).Maybe()
+	mockAPI.On("KVDelete", mock.AnythingOfType("string")).Return(nil).Maybe()
+	mockAPI.On("LogError", mock.Anything).Return(nil).Maybe()
+	mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockAPI.On("LogDebug", mock.Anything).Return(nil).Maybe()
+	mockAPI.On("LogDebug", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	licenseChecker := enterprise.NewLicenseChecker(client)
+	// DB-backed agent only — no file-config bot — exercises the path
+	// where the service is referenced only by an agent in the store.
+	cfg := &mockConfig{
+		bots: []llm.BotConfig{},
+		services: []llm.ServiceConfig{
+			{
+				ID:              "svc1",
+				Type:            llm.ServiceTypeOpenAI,
+				APIKey:          "k",
+				DefaultModel:    "gpt-5.4",
+				InputTokenLimit: 0,
+			},
+		},
+	}
+	agentStore := &stubAgentStore{
+		agents: []llm.BotConfig{
+			{ID: "bot1", Name: "openai", DisplayName: "OpenAI", ServiceID: "svc1"},
+		},
+	}
+	mmBots := New(mockAPI, client, licenseChecker, cfg, agentStore, &http.Client{}, nil)
+
+	require.NoError(t, mmBots.EnsureBots())
+	bots := mmBots.GetAllBots()
+	require.Len(t, bots, 1)
+	require.NotNil(t, bots[0].LLM(), "bot must have an LLM after initial EnsureBots")
+	// Capture instead of hardcoding 0: providers may return a hardcoded
+	// fallback for InputTokenLimit=0 (e.g. OpenAI → 128000).
+	initialLimit := bots[0].LLM().InputTokenLimit()
+
+	// 250000 is chosen to not coincide with any provider hardcoded default.
+	cfg.services = []llm.ServiceConfig{
+		{
+			ID:              "svc1",
+			Type:            llm.ServiceTypeOpenAI,
+			APIKey:          "k",
+			DefaultModel:    "gpt-5.4",
+			InputTokenLimit: 250000,
+		},
+	}
+
+	require.NoError(t, mmBots.EnsureBots())
+	bots = mmBots.GetAllBots()
+	require.Len(t, bots, 1)
+	require.NotNil(t, bots[0].LLM())
+	require.NotEqual(t, initialLimit, bots[0].LLM().InputTokenLimit(),
+		"EnsureBots must rebuild after a service-config change for a DB-backed agent")
+	assert.Equal(t, 250000, bots[0].LLM().InputTokenLimit())
 }
 
 func TestEnsureBotsFailsWhenListAgentsFails(t *testing.T) {


### PR DESCRIPTION
#### Summary

`EnsureBots`' optimistic equality check (the fast path that decides whether to grab the cluster mutex and rebuild) was looking only at file-config bots (`b.config.GetBots()`) and the services those bots reference. **DB-backed agents** (created through the `/agents` UI) get loaded *later* in the same function. So a service config change for a service used only by a DB-backed agent was invisible to the check — both `botConfigsEqual` and `serviceConfigsEqual` returned true (file config unchanged), and the function bailed out before reaching the rebuild loop. The user-visible symptom was that any change made to a service's config (token limits, API keys, etc.) didn't take effect until the plugin was reactivated.

**Fix:** Extracted `snapshotBotsAndServices()`. It returns the full bot lineup (file bots capped by license + DB agents) and the services referenced by **all** of them. Both equality checks in `EnsureBots` now use this snapshot, so a service change for a DB-agent's service triggers a rebuild on the next `EnsureBots` call.

**Regression guard:** `TestEnsureBotsRebuildsBotWhenServiceInputTokenLimitChanges` configures an empty file-config Bots slice + a DB-backed agent referencing `svc1`, calls EnsureBots, captures the initial limit. Mutates the service to a known unusual value (250000), calls EnsureBots again, asserts the limit changed and now matches 250000. Without the fix this test fails — EnsureBots takes the fast-path skip and the bot keeps reporting the previous limit.

#### Ticket Link

N/A — found while debugging the context-usage indicator (separate PR stack).

#### Release Note
\`\`\`release-note
Fixed a bug where edits to an AI service config (token limits, API keys, model, etc.) did not take effect for DB-backed agents until the plugin was restarted.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bot lineup now uses a non-destructive snapshot of file and DB-backed configurations, ensuring service setting updates (e.g., input token limits) are applied and active bots are correctly activated/deactivated.

* **Tests**
  * Added tests verifying snapshotting does not mutate file-config bots and that rebuilds apply service changes for DB-backed bots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-agents/pull/787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->