### PR TITLE
Lazy-load file attachments via an on-demand read_file tool

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/customprompts"
 	"github.com/mattermost/mattermost-plugin-agents/embeddings"
 	"github.com/mattermost/mattermost-plugin-agents/enterprise"
+	"github.com/mattermost/mattermost-plugin-agents/files"
 	"github.com/mattermost/mattermost-plugin-agents/i18n"
 	"github.com/mattermost/mattermost-plugin-agents/indexer"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
@@ -128,6 +129,7 @@ type API struct {
 	meetingsService       *meetings.Service
 	indexerService        *indexer.Indexer
 	searchService         *search.Search
+	fileService           *files.Service
 	pluginAPI             *pluginapi.Client
 	metricsService        metrics.Metrics
 	metricsHandler        http.Handler
@@ -200,6 +202,7 @@ func New(
 		meetingsService:       meetingsService,
 		indexerService:        indexerService,
 		searchService:         searchService,
+		fileService:           files.New(mmClient),
 		pluginAPI:             pluginAPI,
 		metricsService:        metricsService,
 		metricsHandler:        metrics.NewMetricsHandler(metricsService),
@@ -312,6 +315,11 @@ func (a *API) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Reques
 	// Raw search endpoint returns enriched semantic search results without LLM processing.
 	// Used by the MCP server for external search callbacks.
 	router.POST("/search/raw", a.handleRawSearch)
+
+	// Raw file content endpoint returns a ranged slice of a file's text after
+	// checking the requesting user's channel permission. Used by the MCP server
+	// for external read_file callbacks.
+	router.POST("/files/content", a.handleRawFileContent)
 
 	// Custom prompts routes — available to all authenticated users
 	promptsRouter := router.Group("/custom-prompts")

--- a/api/api_files.go
+++ b/api/api_files.go
@@ -46,7 +46,7 @@ func (a *API) handleRawFileContent(c *gin.Context) {
 	}
 
 	var req RawFileContentRequest
-	if err := c.BindJSON(&req); err != nil {
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 		return
 	}

--- a/api/api_files.go
+++ b/api/api_files.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mattermost/mattermost-plugin-agents/files"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// RawFileContentRequest is the request body for the raw file content endpoint.
+type RawFileContentRequest struct {
+	FileID string `json:"file_id"`
+	Offset int    `json:"offset,omitempty"`
+	Limit  int    `json:"limit,omitempty"`
+}
+
+// RawFileContentResponse is the response body for the raw file content endpoint.
+type RawFileContentResponse struct {
+	Name       string `json:"name"`
+	MimeType   string `json:"mime_type"`
+	TotalRunes int    `json:"total_runes"`
+	Offset     int    `json:"offset"`
+	Returned   int    `json:"returned"`
+	HasMore    bool   `json:"has_more"`
+	HasText    bool   `json:"has_text"`
+	Text       string `json:"text"`
+}
+
+// handleRawFileContent handles the POST /files/content endpoint.
+// It returns a ranged slice of a file's text after verifying the requesting
+// user's channel permission. Used by the MCP server for external read_file
+// callbacks; the requesting user is taken from the authenticated header, never
+// from the request body.
+func (a *API) handleRawFileContent(c *gin.Context) {
+	userID := c.GetHeader("Mattermost-User-Id")
+
+	if a.fileService == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "file content service is not available"})
+		return
+	}
+
+	var req RawFileContentRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	if !model.IsValidId(req.FileID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "a valid file_id is required"})
+		return
+	}
+
+	content, err := a.fileService.GetContent(c.Request.Context(), userID, req.FileID, req.Offset, req.Limit)
+	if err != nil {
+		if errors.Is(err, files.ErrForbidden) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "you do not have permission to access this file"})
+			return
+		}
+		a.pluginAPI.Log.Error("Raw file content read failed", "error", err, "user_id", userID, "file_id", req.FileID)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read file"})
+		return
+	}
+
+	c.JSON(http.StatusOK, RawFileContentResponse{
+		Name:       content.Name,
+		MimeType:   content.MimeType,
+		TotalRunes: content.TotalRunes,
+		Offset:     content.Offset,
+		Returned:   content.Returned,
+		HasMore:    content.HasMore,
+		HasText:    content.HasText,
+		Text:       content.Text,
+	})
+}

--- a/api/api_files_test.go
+++ b/api/api_files_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-agents/files"
+	"github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+func TestHandleRawFileContent(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	userID := model.NewId()
+	channelID := model.NewId()
+	fileID := model.NewId()
+
+	doPost := func(t *testing.T, a *API, body any) *httptest.ResponseRecorder {
+		t.Helper()
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		req := httptest.NewRequest(http.MethodPost, "/files/content", bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Mattermost-User-Id", userID)
+		c.Request = req
+		a.handleRawFileContent(c)
+		return rec
+	}
+
+	t.Run("service unavailable returns 503", func(t *testing.T) {
+		a := &API{fileService: nil}
+		rec := doPost(t, a, RawFileContentRequest{FileID: fileID})
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	})
+
+	t.Run("invalid file id returns 400", func(t *testing.T) {
+		m := mocks.NewMockClient(t)
+		a := &API{fileService: files.New(m)}
+		rec := doPost(t, a, RawFileContentRequest{FileID: "too-short"})
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("no channel permission returns 403", func(t *testing.T) {
+		m := mocks.NewMockClient(t)
+		m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{Id: fileID, ChannelId: channelID}, nil)
+		m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(false)
+		a := &API{fileService: files.New(m)}
+
+		rec := doPost(t, a, RawFileContentRequest{FileID: fileID})
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("success returns content json", func(t *testing.T) {
+		m := mocks.NewMockClient(t)
+		m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+			Id: fileID, ChannelId: channelID, Name: "notes.txt", MimeType: "text/plain", Content: "hello world",
+		}, nil)
+		m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+		a := &API{fileService: files.New(m)}
+
+		rec := doPost(t, a, RawFileContentRequest{FileID: fileID})
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var resp RawFileContentResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		assert.True(t, resp.HasText)
+		assert.Equal(t, "hello world", resp.Text)
+		assert.Equal(t, "notes.txt", resp.Name)
+		assert.Equal(t, 11, resp.TotalRunes)
+		assert.False(t, resp.HasMore)
+	})
+
+	t.Run("missing user header is forbidden", func(t *testing.T) {
+		// The requesting user comes from the authenticated header, never the
+		// body. With no header the permission check runs against an empty user
+		// and must fail closed rather than leak the file.
+		m := mocks.NewMockClient(t)
+		m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{Id: fileID, ChannelId: channelID}, nil)
+		m.EXPECT().HasPermissionToChannel("", channelID, model.PermissionReadChannel).Return(false)
+		a := &API{fileService: files.New(m)}
+
+		b, err := json.Marshal(RawFileContentRequest{FileID: fileID})
+		require.NoError(t, err)
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		req := httptest.NewRequest(http.MethodPost, "/files/content", bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		// Intentionally no Mattermost-User-Id header.
+		c.Request = req
+		a.handleRawFileContent(c)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+}

--- a/api/api_files_test.go
+++ b/api/api_files_test.go
@@ -28,82 +28,99 @@ func TestHandleRawFileContent(t *testing.T) {
 	channelID := model.NewId()
 	fileID := model.NewId()
 
-	doPost := func(t *testing.T, a *API, body any) *httptest.ResponseRecorder {
-		t.Helper()
-		b, err := json.Marshal(body)
-		require.NoError(t, err)
-		rec := httptest.NewRecorder()
-		c, _ := gin.CreateTestContext(rec)
-		req := httptest.NewRequest(http.MethodPost, "/files/content", bytes.NewReader(b))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Mattermost-User-Id", userID)
-		c.Request = req
-		a.handleRawFileContent(c)
-		return rec
+	tests := []struct {
+		name           string
+		nilService     bool
+		setup          func(m *mocks.MockClient)
+		request        RawFileContentRequest
+		omitUserHeader bool
+		wantStatus     int
+		assertResp     func(t *testing.T, resp RawFileContentResponse)
+	}{
+		{
+			name:       "service unavailable returns 503",
+			nilService: true,
+			request:    RawFileContentRequest{FileID: fileID},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "invalid file id returns 400",
+			request:    RawFileContentRequest{FileID: "too-short"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "no channel permission returns 403",
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{Id: fileID, ChannelId: channelID}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(false)
+			},
+			request:    RawFileContentRequest{FileID: fileID},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "success returns content json",
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, Name: "notes.txt", MimeType: "text/plain", Content: "hello world",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+			},
+			request:    RawFileContentRequest{FileID: fileID},
+			wantStatus: http.StatusOK,
+			assertResp: func(t *testing.T, resp RawFileContentResponse) {
+				assert.True(t, resp.HasText)
+				assert.Equal(t, "hello world", resp.Text)
+				assert.Equal(t, "notes.txt", resp.Name)
+				assert.Equal(t, 11, resp.TotalRunes)
+				assert.False(t, resp.HasMore)
+			},
+		},
+		{
+			// The requesting user comes from the authenticated header, never the
+			// body. With no header the permission check runs against an empty user
+			// and must fail closed rather than leak the file.
+			name: "missing user header is forbidden",
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{Id: fileID, ChannelId: channelID}, nil)
+				m.EXPECT().HasPermissionToChannel("", channelID, model.PermissionReadChannel).Return(false)
+			},
+			request:        RawFileContentRequest{FileID: fileID},
+			omitUserHeader: true,
+			wantStatus:     http.StatusForbidden,
+		},
 	}
 
-	t.Run("service unavailable returns 503", func(t *testing.T) {
-		a := &API{fileService: nil}
-		rec := doPost(t, a, RawFileContentRequest{FileID: fileID})
-		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &API{}
+			if !tt.nilService {
+				m := mocks.NewMockClient(t)
+				if tt.setup != nil {
+					tt.setup(m)
+				}
+				a.fileService = files.New(m)
+			}
 
-	t.Run("invalid file id returns 400", func(t *testing.T) {
-		m := mocks.NewMockClient(t)
-		a := &API{fileService: files.New(m)}
-		rec := doPost(t, a, RawFileContentRequest{FileID: "too-short"})
-		assert.Equal(t, http.StatusBadRequest, rec.Code)
-	})
+			body, err := json.Marshal(tt.request)
+			require.NoError(t, err)
 
-	t.Run("no channel permission returns 403", func(t *testing.T) {
-		m := mocks.NewMockClient(t)
-		m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{Id: fileID, ChannelId: channelID}, nil)
-		m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(false)
-		a := &API{fileService: files.New(m)}
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			req := httptest.NewRequest(http.MethodPost, "/files/content", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			if !tt.omitUserHeader {
+				req.Header.Set("Mattermost-User-Id", userID)
+			}
+			c.Request = req
 
-		rec := doPost(t, a, RawFileContentRequest{FileID: fileID})
-		assert.Equal(t, http.StatusForbidden, rec.Code)
-	})
+			a.handleRawFileContent(c)
 
-	t.Run("success returns content json", func(t *testing.T) {
-		m := mocks.NewMockClient(t)
-		m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
-			Id: fileID, ChannelId: channelID, Name: "notes.txt", MimeType: "text/plain", Content: "hello world",
-		}, nil)
-		m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
-		a := &API{fileService: files.New(m)}
-
-		rec := doPost(t, a, RawFileContentRequest{FileID: fileID})
-		require.Equal(t, http.StatusOK, rec.Code)
-
-		var resp RawFileContentResponse
-		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-		assert.True(t, resp.HasText)
-		assert.Equal(t, "hello world", resp.Text)
-		assert.Equal(t, "notes.txt", resp.Name)
-		assert.Equal(t, 11, resp.TotalRunes)
-		assert.False(t, resp.HasMore)
-	})
-
-	t.Run("missing user header is forbidden", func(t *testing.T) {
-		// The requesting user comes from the authenticated header, never the
-		// body. With no header the permission check runs against an empty user
-		// and must fail closed rather than leak the file.
-		m := mocks.NewMockClient(t)
-		m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{Id: fileID, ChannelId: channelID}, nil)
-		m.EXPECT().HasPermissionToChannel("", channelID, model.PermissionReadChannel).Return(false)
-		a := &API{fileService: files.New(m)}
-
-		b, err := json.Marshal(RawFileContentRequest{FileID: fileID})
-		require.NoError(t, err)
-		rec := httptest.NewRecorder()
-		c, _ := gin.CreateTestContext(rec)
-		req := httptest.NewRequest(http.MethodPost, "/files/content", bytes.NewReader(b))
-		req.Header.Set("Content-Type", "application/json")
-		// Intentionally no Mattermost-User-Id header.
-		c.Request = req
-		a.handleRawFileContent(c)
-
-		assert.Equal(t, http.StatusForbidden, rec.Code)
-	})
+			require.Equal(t, tt.wantStatus, rec.Code)
+			if tt.assertResp != nil {
+				var resp RawFileContentResponse
+				require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+				tt.assertResp(t, resp)
+			}
+		})
+	}
 }

--- a/conversation/convert.go
+++ b/conversation/convert.go
@@ -6,14 +6,22 @@ package conversation
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 
+	"github.com/mattermost/mattermost-plugin-agents/format"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/mmapi"
 )
 
 const DefaultMaxFileSize = int64(5 * 1024 * 1024)
+
+// InlineFileMaxBytes is the upper bound on readable text that gets inlined
+// directly into a turn. Files at or below this size are cheap enough to inline
+// (and save the LLM a tool round trip); larger files are surfaced as metadata
+// only and fetched on demand via the read_file tool. ~8 KiB ≈ 2000 tokens.
+const InlineFileMaxBytes = int64(8 * 1024)
 
 // UnsharedToolResultRedaction replaces tool_result content the requester has
 // not shared, preserving the tool_use/tool_result pairing required by LLM
@@ -49,6 +57,7 @@ func BlocksToPost(
 
 	var textParts []string
 	var fileContents []string
+	var descriptors []string
 
 	for _, block := range blocks {
 		switch block.Type {
@@ -143,29 +152,46 @@ func BlocksToPost(
 				continue
 			}
 
-			var content string
-			if trimmed := strings.TrimSpace(fileInfo.Content); trimmed != "" {
-				if int64(len(trimmed)) >= effectiveMax {
-					trimmed = trimmed[:effectiveMax] + "\n... (content truncated due to size limit)"
-				}
-				content = trimmed
-			} else if strings.HasPrefix(fileInfo.MimeType, "text/") {
+			// Decide inline vs descriptor from metadata alone (no download):
+			// readable text within InlineFileMaxBytes is inlined; larger files
+			// and binaries with no extractable text become a read-on-demand
+			// descriptor.
+			extracted := strings.TrimSpace(fileInfo.Content)
+			isText := strings.HasPrefix(fileInfo.MimeType, "text/")
+			inlineSize := int64(-1) // -1 means no readable text → descriptor only
+			switch {
+			case extracted != "":
+				inlineSize = int64(len(extracted))
+			case isText:
+				inlineSize = fileInfo.Size
+			}
+
+			if inlineSize < 0 || inlineSize > InlineFileMaxBytes {
+				var b strings.Builder
+				format.WriteFileDescriptor(&b, format.FileDescriptorEntry{
+					HeaderLabel: fmt.Sprintf("Attached File %d", len(descriptors)+1),
+					FileInfo:    fileInfo,
+				})
+				descriptors = append(descriptors, strings.TrimRight(b.String(), "\n"))
+				continue
+			}
+
+			content := extracted
+			if content == "" {
 				reader, err := mmClient.GetFile(block.FileID)
 				if err != nil {
 					mmClient.LogError("failed to get file for file attachment", "error", err)
 					continue
 				}
 				body, err := io.ReadAll(io.LimitReader(reader, effectiveMax))
+				if closeErr := reader.Close(); closeErr != nil {
+					mmClient.LogError("failed to close file attachment reader", "error", closeErr)
+				}
 				if err != nil {
 					mmClient.LogError("failed to read file content", "error", err)
 					continue
 				}
 				content = string(body)
-				if int64(len(body)) >= effectiveMax {
-					content += "\n... (content truncated due to size limit)"
-				}
-			} else {
-				continue
 			}
 
 			fileContents = append(fileContents, "File Name: "+fileInfo.Name+"\nContent: "+content)
@@ -180,6 +206,9 @@ func BlocksToPost(
 	}
 	if len(fileContents) > 0 {
 		post.Message += "\nAttached File Contents:\n" + strings.Join(fileContents, "\n\n")
+	}
+	if len(descriptors) > 0 {
+		post.Message += "\nAttached files (call the read_file tool with the File ID to read their contents):\n" + strings.Join(descriptors, "\n\n")
 	}
 
 	return post

--- a/conversation/convert.go
+++ b/conversation/convert.go
@@ -6,7 +6,6 @@ package conversation
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"strings"
 
@@ -169,8 +168,8 @@ func BlocksToPost(
 			if inlineSize < 0 || inlineSize > InlineFileMaxBytes {
 				var b strings.Builder
 				format.WriteFileDescriptor(&b, format.FileDescriptorEntry{
-					HeaderLabel: fmt.Sprintf("Attached File %d", len(descriptors)+1),
-					FileInfo:    fileInfo,
+					Number:   len(descriptors) + 1,
+					FileInfo: fileInfo,
 				})
 				descriptors = append(descriptors, strings.TrimRight(b.String(), "\n"))
 				continue

--- a/conversation/convert_test.go
+++ b/conversation/convert_test.go
@@ -6,6 +6,7 @@ package conversation
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -588,47 +589,79 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 		assert.Contains(t, post.Message, "Content: pre-extracted content")
 	})
 
-	t.Run("text/plain file at exactly maxFileSize gets truncation marker", func(t *testing.T) {
-		const maxBytes = int64(8)
-		body := "ABCDEFGH" // exactly 8 bytes
-
+	t.Run("large text file is surfaced as a descriptor without reading it", func(t *testing.T) {
 		mmClient := mmapimocks.NewMockClient(t)
 		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
 			Id:       "doc1",
-			Name:     "big.txt",
+			Name:     "bigdoc.txt",
 			MimeType: "text/plain",
-			Size:     int64(len(body)),
+			Size:     InlineFileMaxBytes + 1,
 		}, nil)
-		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser(body), nil)
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "big.txt", MimeType: "text/plain"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, maxBytes)
-
-		assert.Contains(t, post.Message, "... (content truncated due to size limit)",
-			"reading exactly maxFileSize bytes must append the truncation marker so the LLM knows the content was cut")
-	})
-
-	t.Run("non-text non-image MIME with empty Content is skipped without GetFile", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id:       "doc1",
-			Name:     "binary.pdf",
-			MimeType: "application/pdf",
-		}, nil)
-		// No GetFile expectation — mockery fails if it is called.
+		// No GetFile expectation — the inline-vs-descriptor decision is made
+		// from metadata alone, so a large file is never downloaded here.
 
 		blocks := []ContentBlock{
 			{Type: BlockTypeText, Text: "see attached"},
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "binary.pdf", MimeType: "application/pdf"},
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "bigdoc.txt", MimeType: "text/plain"},
 		}
 
 		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
 
-		assert.Equal(t, "see attached", post.Message,
-			"non-text non-image attachments without pre-extracted Content must be silently skipped")
+		// Pin the full assembled suffix: the header sentence the read_file tool
+		// relies on, the per-entry header, and every descriptor field.
+		expected := "see attached\n" +
+			"Attached files (call the read_file tool with the File ID to read their contents):\n" +
+			fmt.Sprintf("**Attached File 1**:\nName: bigdoc.txt\nFile ID: doc1\nType: text/plain\nSize: %d bytes", InlineFileMaxBytes+1)
+		assert.Equal(t, expected, post.Message)
+		mmClient.AssertNotCalled(t, "GetFile", "doc1")
+	})
+
+	t.Run("large pre-extracted content is surfaced as a descriptor", func(t *testing.T) {
+		bigContent := strings.Repeat("x", int(InlineFileMaxBytes)+1)
+
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id:       "doc1",
+			Name:     "huge.pdf",
+			MimeType: "application/pdf",
+			Content:  bigContent,
+		}, nil)
+		// No GetFile expectation — pre-extracted content is measured directly.
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "huge.pdf", MimeType: "application/pdf"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		assert.Contains(t, post.Message, "File ID: doc1")
+		assert.NotContains(t, post.Message, bigContent,
+			"the descriptor must not inline the extracted content")
+		assert.NotContains(t, post.Message, "Attached File Contents:",
+			"a partial inline of the extracted content would still be a regression")
+	})
+
+	t.Run("binary file with no extractable text is surfaced as a descriptor without GetFile", func(t *testing.T) {
+		mmClient := mmapimocks.NewMockClient(t)
+		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+			Id:       "doc1",
+			Name:     "archive.zip",
+			MimeType: "application/zip",
+		}, nil)
+		// No GetFile expectation — a binary with no extractable text still gets
+		// a metadata descriptor so the LLM is aware of it.
+
+		blocks := []ContentBlock{
+			{Type: BlockTypeText, Text: "see attached"},
+			{Type: BlockTypeFile, FileID: "doc1", Filename: "archive.zip", MimeType: "application/zip"},
+		}
+
+		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+
+		assert.Contains(t, post.Message, "see attached")
+		assert.Contains(t, post.Message, "Name: archive.zip")
+		assert.Contains(t, post.Message, "File ID: doc1")
+		mmClient.AssertNotCalled(t, "GetFile", "doc1")
 	})
 
 	t.Run("multiple mixed blocks: text + image + text/plain file", func(t *testing.T) {
@@ -731,31 +764,11 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 			"text content must still appear when an image attachment fails to load")
 	})
 
-	// The maxFileSize=0 → DefaultMaxFileSize boundary trio. We pin the
-	// constant by name so this test has to be updated alongside any change
-	// to DefaultMaxFileSize.
-	t.Run("maxFileSize=0 default: payload of DefaultMaxFileSize-1 bytes has no truncation marker", func(t *testing.T) {
-		body := strings.Repeat("A", int(DefaultMaxFileSize-1))
-
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id: "doc1", Name: "under.txt", MimeType: "text/plain", Size: int64(len(body)),
-		}, nil)
-		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser(body), nil)
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "under.txt", MimeType: "text/plain"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		assert.Contains(t, post.Message, "File Name: under.txt")
-		assert.NotContains(t, post.Message, "content truncated",
-			"a payload of DefaultMaxFileSize-1 bytes must NOT be marked truncated")
-	})
-
-	t.Run("maxFileSize=0 default: payload of exactly DefaultMaxFileSize bytes gets truncation marker", func(t *testing.T) {
-		body := strings.Repeat("A", int(DefaultMaxFileSize))
+	// Pin the inline-vs-descriptor boundary by name: a file whose readable size
+	// is at or below InlineFileMaxBytes is inlined; one byte over becomes a
+	// descriptor (covered by "large text file is surfaced as a descriptor").
+	t.Run("text file at exactly InlineFileMaxBytes is inlined", func(t *testing.T) {
+		body := strings.Repeat("A", int(InlineFileMaxBytes))
 
 		mmClient := mmapimocks.NewMockClient(t)
 		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
@@ -769,27 +782,10 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 
 		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
 
-		assert.Contains(t, post.Message, "... (content truncated due to size limit)",
-			"reading exactly DefaultMaxFileSize bytes must append the truncation marker (LimitReader saw the cap)")
-	})
-
-	t.Run("maxFileSize=0 default: payload of DefaultMaxFileSize+1 bytes gets truncation marker", func(t *testing.T) {
-		body := strings.Repeat("A", int(DefaultMaxFileSize+1))
-
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id: "doc1", Name: "over.txt", MimeType: "text/plain", Size: int64(len(body)),
-		}, nil)
-		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser(body), nil)
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "over.txt", MimeType: "text/plain"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		assert.Contains(t, post.Message, "... (content truncated due to size limit)",
-			"a payload above DefaultMaxFileSize must be truncated with the marker")
+		assert.Contains(t, post.Message, "Attached File Contents:")
+		assert.Contains(t, post.Message, "File Name: boundary.txt")
+		assert.NotContains(t, post.Message, "read_file",
+			"a file at the inline threshold must be inlined, not described")
 	})
 
 	t.Run("nil mmClient is safe when no file or image blocks are present", func(t *testing.T) {
@@ -813,9 +809,9 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 	t.Run("BlockTypeFile with image/* MIME goes through file path, not image path", func(t *testing.T) {
 		// Dispatch must be by block.Type, not by MimeType — a malformed
 		// block (Type=file but MimeType=image/png) must not be sent to
-		// the LLM as an image. With empty FileInfo.Content and a
-		// non-text MIME, the file-text path skips the block, so GetFile
-		// must NOT be called.
+		// the LLM as an image. With empty FileInfo.Content and a non-text
+		// MIME there is no extractable text, so the block is surfaced as a
+		// metadata descriptor and GetFile must NOT be called.
 		mmClient := mmapimocks.NewMockClient(t)
 		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
 			Id: "doc1", Name: "weird.png", MimeType: "image/png",
@@ -834,8 +830,9 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 		mmClient.AssertNotCalled(t, "GetFile", "doc1")
 		assert.Empty(t, post.Files,
 			"a BlockTypeFile must never populate Post.Files even when its MimeType says image/*")
-		assert.Equal(t, "see attached", post.Message,
-			"a non-text non-image file block with empty Content must be silently skipped")
+		assert.Contains(t, post.Message, "see attached")
+		assert.Contains(t, post.Message, "File ID: doc1",
+			"a file block with no extractable text is surfaced as a metadata descriptor")
 	})
 
 	t.Run("FileInfo.Content non-empty wins over GetFile (explicit AssertNotCalled)", func(t *testing.T) {
@@ -856,33 +853,5 @@ func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
 		mmClient.AssertNotCalled(t, "GetFile", "doc1",
 			"pre-extracted FileInfo.Content must short-circuit GetFile to avoid a redundant blob read")
 		assert.Contains(t, post.Message, "Content: server-extracted text")
-	})
-
-	t.Run("pre-extracted FileInfo.Content larger than maxFileSize gets truncation marker", func(t *testing.T) {
-		// Mattermost's server-side text extraction is itself bounded, but
-		// a per-bot MaxFileSize lower than the server's cap could be
-		// silently violated by the pre-extracted-content shortcut. Cap it
-		// the same way the GetFile branch does.
-		const maxBytes = int64(8)
-		oversized := strings.Repeat("X", int(maxBytes)+1) // 9 bytes vs maxBytes=8
-
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id: "doc1", Name: "huge.pdf", MimeType: "application/pdf",
-			Content: oversized,
-		}, nil)
-		// GetFile must NOT be called — pre-extracted content path still
-		// short-circuits the byte fetch even when the cap clips it.
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "huge.pdf", MimeType: "application/pdf"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, maxBytes)
-
-		mmClient.AssertNotCalled(t, "GetFile", "doc1",
-			"the pre-extracted-content cap must not trigger a GetFile fetch")
-		assert.Contains(t, post.Message, "... (content truncated due to size limit)",
-			"FileInfo.Content longer than effectiveMax must be truncated with the marker")
 	})
 }

--- a/conversation/convert_test.go
+++ b/conversation/convert_test.go
@@ -480,378 +480,381 @@ func newFakeReadCloser(s string) io.ReadCloser {
 // moment we build the LLM request, instead of being inlined when the user
 // turn was first written.
 func TestBlocksToPost_LazyResolvesAttachments(t *testing.T) {
-	t.Run("image block with EnableVision=true populates Files", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
-			Id:       "img1",
-			Name:     "shot.png",
-			MimeType: "image/png",
-			Size:     1234,
-		}, nil)
-		mmClient.On("GetFile", "img1").Return(newFakeReadCloser("PNGDATA"), nil)
+	bigContent := strings.Repeat("x", int(InlineFileMaxBytes)+1)
+	boundaryBody := strings.Repeat("A", int(InlineFileMaxBytes))
 
-		blocks := []ContentBlock{
-			{Type: BlockTypeImage, FileID: "img1", Filename: "shot.png", MimeType: "image/png"},
-		}
+	tests := []struct {
+		name         string
+		role         string // defaults to "user"
+		enableVision bool
+		nilClient    bool
+		setup        func(m *mmapimocks.MockClient)
+		blocks       []ContentBlock
+		assert       func(t *testing.T, m *mmapimocks.MockClient, post llm.Post)
+	}{
+		{
+			name:         "image block with EnableVision=true populates Files",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "img1").Return(&model.FileInfo{
+					Id: "img1", Name: "shot.png", MimeType: "image/png", Size: 1234,
+				}, nil)
+				m.On("GetFile", "img1").Return(newFakeReadCloser("PNGDATA"), nil)
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeImage, FileID: "img1", Filename: "shot.png", MimeType: "image/png"},
+			},
+			assert: func(t *testing.T, _ *mmapimocks.MockClient, post llm.Post) {
+				require.Len(t, post.Files, 1, "an image block with vision enabled must produce exactly one entry in Post.Files")
+				assert.Equal(t, "image/png", post.Files[0].MimeType)
+				assert.Equal(t, int64(1234), post.Files[0].Size)
+				assert.Equal(t, []byte("PNGDATA"), post.Files[0].Data)
+				require.NotNil(t, post.Files[0].Reader)
 
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
+				// Read the bytes back and pin them to what the mock returned.
+				// Catches a wrong-FileID-resolution bug (e.g. iterating wrong
+				// FileID, returning a stale reader, etc.).
+				bytesBack, readErr := io.ReadAll(post.Files[0].Reader)
+				require.NoError(t, readErr)
+				assert.Equal(t, "PNGDATA", string(bytesBack),
+					"the Reader bound to Post.Files must yield the bytes that mmClient.GetFile returned for that exact FileID")
+			},
+		},
+		{
+			name:         "image block with EnableVision=false is skipped",
+			enableVision: false,
+			// No expectations: GetFile/GetFileInfo must NOT be called when
+			// vision is off. mockery will fail the test if either runs.
+			blocks: []ContentBlock{
+				{Type: BlockTypeImage, FileID: "img1", Filename: "shot.png", MimeType: "image/png"},
+			},
+			assert: func(t *testing.T, _ *mmapimocks.MockClient, post llm.Post) {
+				assert.Empty(t, post.Files, "image block must be silently dropped when vision is disabled")
+			},
+		},
+		{
+			name:         "unsupported image MIME is passed through without reading blob",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "img1").Return(&model.FileInfo{
+					Id: "img1", Name: "vector.svg", MimeType: "image/svg+xml", Size: 1234,
+				}, nil)
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeImage, FileID: "img1", Filename: "vector.svg", MimeType: "image/svg+xml"},
+			},
+			assert: func(t *testing.T, m *mmapimocks.MockClient, post llm.Post) {
+				require.Len(t, post.Files, 1)
+				m.AssertNotCalled(t, "GetFile", "img1")
+				assert.Equal(t, "image/svg+xml", post.Files[0].MimeType)
+				assert.Empty(t, post.Files[0].Data)
+				assert.Nil(t, post.Files[0].Reader)
+			},
+		},
+		{
+			name:         "text/plain file block reads content via GetFile and appends Attached File Contents",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+					Id: "doc1", Name: "foo.txt", MimeType: "text/plain", Size: 11,
+				}, nil)
+				m.On("GetFile", "doc1").Return(newFakeReadCloser("hello world"), nil)
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeText, Text: "look at this"},
+				{Type: BlockTypeFile, FileID: "doc1", Filename: "foo.txt", MimeType: "text/plain"},
+			},
+			assert: func(t *testing.T, _ *mmapimocks.MockClient, post llm.Post) {
+				assert.Empty(t, post.Files, "non-image text file must NOT go through Post.Files")
+				assert.Contains(t, post.Message, "look at this")
+				assert.Contains(t, post.Message, "\nAttached File Contents:\nFile Name: foo.txt\nContent: hello world")
+			},
+		},
+		{
+			name:         "file block uses pre-extracted FileInfo.Content without GetFile",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+					Id: "doc1", Name: "doc.pdf", MimeType: "application/pdf", Content: "pre-extracted content",
+				}, nil)
+				// No GetFile expectation — mockery fails if it is called.
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeFile, FileID: "doc1", Filename: "doc.pdf", MimeType: "application/pdf"},
+			},
+			assert: func(t *testing.T, _ *mmapimocks.MockClient, post llm.Post) {
+				assert.Contains(t, post.Message, "File Name: doc.pdf")
+				assert.Contains(t, post.Message, "Content: pre-extracted content")
+			},
+		},
+		{
+			name:         "large text file is surfaced as a descriptor without reading it",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+					Id: "doc1", Name: "bigdoc.txt", MimeType: "text/plain", Size: InlineFileMaxBytes + 1,
+				}, nil)
+				// No GetFile expectation — the inline-vs-descriptor decision is
+				// made from metadata alone, so a large file is never downloaded.
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeText, Text: "see attached"},
+				{Type: BlockTypeFile, FileID: "doc1", Filename: "bigdoc.txt", MimeType: "text/plain"},
+			},
+			assert: func(t *testing.T, m *mmapimocks.MockClient, post llm.Post) {
+				// Pin the full assembled suffix: the header sentence the read_file
+				// tool relies on, the per-entry header, and every descriptor field.
+				expected := "see attached\n" +
+					"Attached files (call the read_file tool with the File ID to read their contents):\n" +
+					fmt.Sprintf("**Attached File 1**:\nName: bigdoc.txt\nFile ID: doc1\nType: text/plain\nSize: %d bytes", InlineFileMaxBytes+1)
+				assert.Equal(t, expected, post.Message)
+				m.AssertNotCalled(t, "GetFile", "doc1")
+			},
+		},
+		{
+			name:         "large pre-extracted content is surfaced as a descriptor",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+					Id: "doc1", Name: "huge.pdf", MimeType: "application/pdf", Content: bigContent,
+				}, nil)
+				// No GetFile expectation — pre-extracted content is measured directly.
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeFile, FileID: "doc1", Filename: "huge.pdf", MimeType: "application/pdf"},
+			},
+			assert: func(t *testing.T, _ *mmapimocks.MockClient, post llm.Post) {
+				assert.Contains(t, post.Message, "File ID: doc1")
+				assert.NotContains(t, post.Message, bigContent,
+					"the descriptor must not inline the extracted content")
+				assert.NotContains(t, post.Message, "Attached File Contents:",
+					"a partial inline of the extracted content would still be a regression")
+			},
+		},
+		{
+			name:         "binary file with no extractable text is surfaced as a descriptor without GetFile",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+					Id: "doc1", Name: "archive.zip", MimeType: "application/zip",
+				}, nil)
+				// No GetFile expectation — a binary with no extractable text still
+				// gets a metadata descriptor so the LLM is aware of it.
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeText, Text: "see attached"},
+				{Type: BlockTypeFile, FileID: "doc1", Filename: "archive.zip", MimeType: "application/zip"},
+			},
+			assert: func(t *testing.T, m *mmapimocks.MockClient, post llm.Post) {
+				assert.Contains(t, post.Message, "see attached")
+				assert.Contains(t, post.Message, "Name: archive.zip")
+				assert.Contains(t, post.Message, "File ID: doc1")
+				m.AssertNotCalled(t, "GetFile", "doc1")
+			},
+		},
+		{
+			name:         "multiple mixed blocks: text + image + text/plain file",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "img1").Return(&model.FileInfo{
+					Id: "img1", Name: "shot.png", MimeType: "image/png", Size: 500,
+				}, nil)
+				m.On("GetFile", "img1").Return(newFakeReadCloser("PNGDATA"), nil)
+				m.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+					Id: "doc1", Name: "foo.txt", MimeType: "text/plain", Size: 5,
+				}, nil)
+				m.On("GetFile", "doc1").Return(newFakeReadCloser("hello"), nil)
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeText, Text: "the text"},
+				{Type: BlockTypeImage, FileID: "img1", Filename: "shot.png", MimeType: "image/png"},
+				{Type: BlockTypeFile, FileID: "doc1", Filename: "foo.txt", MimeType: "text/plain"},
+			},
+			assert: func(t *testing.T, _ *mmapimocks.MockClient, post llm.Post) {
+				require.Len(t, post.Files, 1, "exactly the image attachment should populate Post.Files")
+				assert.Equal(t, "image/png", post.Files[0].MimeType)
+				assert.Contains(t, post.Message, "the text")
+				assert.Contains(t, post.Message, "Attached File Contents:")
+				assert.Contains(t, post.Message, "File Name: foo.txt")
+				assert.Contains(t, post.Message, "Content: hello")
 
-		require.Len(t, post.Files, 1, "an image block with vision enabled must produce exactly one entry in Post.Files")
-		assert.Equal(t, "image/png", post.Files[0].MimeType)
-		assert.Equal(t, int64(1234), post.Files[0].Size)
-		assert.Equal(t, []byte("PNGDATA"), post.Files[0].Data)
-		require.NotNil(t, post.Files[0].Reader)
+				// Ordering contract: original user text precedes the
+				// "Attached File Contents:" suffix. Without this ordering,
+				// the LLM would see file content inserted before the user's
+				// own message.
+				idxText := strings.Index(post.Message, "the text")
+				idxAttach := strings.Index(post.Message, "Attached File Contents:")
+				require.NotEqual(t, -1, idxText)
+				require.NotEqual(t, -1, idxAttach)
+				assert.Less(t, idxText, idxAttach,
+					"user text must appear in the message before the Attached File Contents suffix")
+			},
+		},
+		{
+			name:         "multiple text/plain files appear in input order in the message",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "doc-a").Return(&model.FileInfo{
+					Id: "doc-a", Name: "a.txt", MimeType: "text/plain", Size: 5,
+				}, nil)
+				m.On("GetFile", "doc-a").Return(newFakeReadCloser("AAAAA"), nil)
+				m.On("GetFileInfo", "doc-b").Return(&model.FileInfo{
+					Id: "doc-b", Name: "b.txt", MimeType: "text/plain", Size: 5,
+				}, nil)
+				m.On("GetFile", "doc-b").Return(newFakeReadCloser("BBBBB"), nil)
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeText, Text: "two attachments"},
+				{Type: BlockTypeFile, FileID: "doc-a", Filename: "a.txt", MimeType: "text/plain"},
+				{Type: BlockTypeFile, FileID: "doc-b", Filename: "b.txt", MimeType: "text/plain"},
+			},
+			assert: func(t *testing.T, _ *mmapimocks.MockClient, post llm.Post) {
+				idxA := strings.Index(post.Message, "File Name: a.txt")
+				idxB := strings.Index(post.Message, "File Name: b.txt")
+				require.NotEqual(t, -1, idxA, "a.txt must appear in the message")
+				require.NotEqual(t, -1, idxB, "b.txt must appear in the message")
+				assert.Less(t, idxA, idxB,
+					"file blocks must appear in input order in the Attached File Contents suffix")
+			},
+		},
+		{
+			name:         "GetFile error on image is logged and skipped, conversation continues",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "img1").Return(&model.FileInfo{
+					Id: "img1", Name: "broken.png", MimeType: "image/png",
+				}, nil)
+				m.On("GetFile", "img1").Return(nil, errors.New("file store offline"))
+				// LogError must actually be invoked — without .Maybe() this fails
+				// if production silently swallows the error (the broken behavior).
+				m.On("LogError", mock.Anything, mock.Anything).Return()
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeText, Text: "still here"},
+				{Type: BlockTypeImage, FileID: "img1", Filename: "broken.png", MimeType: "image/png"},
+			},
+			assert: func(t *testing.T, m *mmapimocks.MockClient, post llm.Post) {
+				// Pin that GetFile was actually attempted — production simply
+				// dropping the image without trying to fetch it would still leave
+				// post.Files empty, so the previous broken behavior would pass
+				// without this AssertCalled.
+				m.AssertCalled(t, "GetFile", "img1")
+				assert.Empty(t, post.Files, "GetFile errors must drop the entry, not abort the request")
+				assert.Equal(t, "still here", post.Message,
+					"text content must still appear when an image attachment fails to load")
+			},
+		},
+		{
+			// Pin the inline-vs-descriptor boundary by name: a file whose readable
+			// size is at or below InlineFileMaxBytes is inlined; one byte over
+			// becomes a descriptor (covered by the large-text-file case above).
+			name:         "text file at exactly InlineFileMaxBytes is inlined",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+					Id: "doc1", Name: "boundary.txt", MimeType: "text/plain", Size: int64(len(boundaryBody)),
+				}, nil)
+				m.On("GetFile", "doc1").Return(newFakeReadCloser(boundaryBody), nil)
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeFile, FileID: "doc1", Filename: "boundary.txt", MimeType: "text/plain"},
+			},
+			assert: func(t *testing.T, _ *mmapimocks.MockClient, post llm.Post) {
+				assert.Contains(t, post.Message, "Attached File Contents:")
+				assert.Contains(t, post.Message, "File Name: boundary.txt")
+				assert.NotContains(t, post.Message, "read_file",
+					"a file at the inline threshold must be inlined, not described")
+			},
+		},
+		{
+			// Documents the zero-config safety guarantee: a turn with only
+			// text/thinking/tool blocks must not panic when mmClient is nil.
+			name:      "nil mmClient is safe when no file or image blocks are present",
+			role:      "assistant",
+			nilClient: true,
+			blocks: []ContentBlock{
+				{Type: BlockTypeText, Text: "hello"},
+				{Type: BlockTypeThinking, Text: "reason", Signature: "sig"},
+				{Type: BlockTypeToolUse, ID: "tc1", Name: "search", Input: json.RawMessage(`{}`), Status: StatusSuccess, Shared: BoolPtr(true)},
+			},
+			assert: func(t *testing.T, _ *mmapimocks.MockClient, post llm.Post) {
+				assert.Equal(t, "hello", post.Message)
+				assert.Equal(t, "reason", post.Reasoning)
+				require.Len(t, post.ToolUse, 1)
+				assert.Equal(t, "tc1", post.ToolUse[0].ID)
+			},
+		},
+		{
+			// Dispatch must be by block.Type, not by MimeType — a malformed
+			// block (Type=file but MimeType=image/png) must not be sent to the
+			// LLM as an image. With empty FileInfo.Content and a non-text MIME
+			// there is no extractable text, so the block is surfaced as a
+			// metadata descriptor and GetFile must NOT be called.
+			name:         "BlockTypeFile with image/* MIME goes through file path, not image path",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+					Id: "doc1", Name: "weird.png", MimeType: "image/png",
+				}, nil)
+				// No GetFile expectation — mockery fails the test if production
+				// fetches bytes anyway (which would happen if dispatch went by
+				// MimeType into the image branch).
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeText, Text: "see attached"},
+				{Type: BlockTypeFile, FileID: "doc1", Filename: "weird.png", MimeType: "image/png"},
+			},
+			assert: func(t *testing.T, m *mmapimocks.MockClient, post llm.Post) {
+				m.AssertNotCalled(t, "GetFile", "doc1")
+				assert.Empty(t, post.Files,
+					"a BlockTypeFile must never populate Post.Files even when its MimeType says image/*")
+				assert.Contains(t, post.Message, "see attached")
+				assert.Contains(t, post.Message, "File ID: doc1",
+					"a file block with no extractable text is surfaced as a metadata descriptor")
+			},
+		},
+		{
+			name:         "FileInfo.Content non-empty wins over GetFile (explicit AssertNotCalled)",
+			enableVision: true,
+			setup: func(m *mmapimocks.MockClient) {
+				m.On("GetFileInfo", "doc1").Return(&model.FileInfo{
+					Id: "doc1", Name: "extracted.pdf", MimeType: "application/pdf",
+					Content: "server-extracted text",
+				}, nil)
+				// No GetFile expectation: when fileInfo.Content is non-empty,
+				// the byte fetch must be skipped entirely.
+			},
+			blocks: []ContentBlock{
+				{Type: BlockTypeFile, FileID: "doc1", Filename: "extracted.pdf", MimeType: "application/pdf"},
+			},
+			assert: func(t *testing.T, m *mmapimocks.MockClient, post llm.Post) {
+				m.AssertNotCalled(t, "GetFile", "doc1",
+					"pre-extracted FileInfo.Content must short-circuit GetFile to avoid a redundant blob read")
+				assert.Contains(t, post.Message, "Content: server-extracted text")
+			},
+		},
+	}
 
-		// Read the bytes back and pin them to what the mock returned.
-		// Catches a wrong-FileID-resolution bug (e.g. iterating wrong
-		// FileID, returning a stale reader, etc.).
-		bytesBack, readErr := io.ReadAll(post.Files[0].Reader)
-		require.NoError(t, readErr)
-		assert.Equal(t, "PNGDATA", string(bytesBack),
-			"the Reader bound to Post.Files must yield the bytes that mmClient.GetFile returned for that exact FileID")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			role := tt.role
+			if role == "" {
+				role = "user"
+			}
 
-	t.Run("image block with EnableVision=false is skipped", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		// No expectations: GetFile/GetFileInfo must NOT be called when
-		// vision is off. mockery will fail the test if either runs.
+			if tt.nilClient {
+				post := BlocksToPost(tt.blocks, role, false, nil, tt.enableVision, 0)
+				tt.assert(t, nil, post)
+				return
+			}
 
-		blocks := []ContentBlock{
-			{Type: BlockTypeImage, FileID: "img1", Filename: "shot.png", MimeType: "image/png"},
-		}
+			mmClient := mmapimocks.NewMockClient(t)
+			if tt.setup != nil {
+				tt.setup(mmClient)
+			}
 
-		post := BlocksToPost(blocks, "user", false, mmClient, false, 0)
-
-		assert.Empty(t, post.Files, "image block must be silently dropped when vision is disabled")
-	})
-
-	t.Run("unsupported image MIME is passed through without reading blob", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
-			Id:       "img1",
-			Name:     "vector.svg",
-			MimeType: "image/svg+xml",
-			Size:     1234,
-		}, nil)
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeImage, FileID: "img1", Filename: "vector.svg", MimeType: "image/svg+xml"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		require.Len(t, post.Files, 1)
-		mmClient.AssertNotCalled(t, "GetFile", "img1")
-		assert.Equal(t, "image/svg+xml", post.Files[0].MimeType)
-		assert.Empty(t, post.Files[0].Data)
-		assert.Nil(t, post.Files[0].Reader)
-	})
-
-	t.Run("text/plain file block reads content via GetFile and appends Attached File Contents", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id:       "doc1",
-			Name:     "foo.txt",
-			MimeType: "text/plain",
-			Size:     11,
-		}, nil)
-		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser("hello world"), nil)
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeText, Text: "look at this"},
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "foo.txt", MimeType: "text/plain"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		assert.Empty(t, post.Files, "non-image text file must NOT go through Post.Files")
-		assert.Contains(t, post.Message, "look at this")
-		assert.Contains(t, post.Message, "\nAttached File Contents:\nFile Name: foo.txt\nContent: hello world")
-	})
-
-	t.Run("file block uses pre-extracted FileInfo.Content without GetFile", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id:       "doc1",
-			Name:     "doc.pdf",
-			MimeType: "application/pdf",
-			Content:  "pre-extracted content",
-		}, nil)
-		// No GetFile expectation — mockery fails if it is called.
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "doc.pdf", MimeType: "application/pdf"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		assert.Contains(t, post.Message, "File Name: doc.pdf")
-		assert.Contains(t, post.Message, "Content: pre-extracted content")
-	})
-
-	t.Run("large text file is surfaced as a descriptor without reading it", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id:       "doc1",
-			Name:     "bigdoc.txt",
-			MimeType: "text/plain",
-			Size:     InlineFileMaxBytes + 1,
-		}, nil)
-		// No GetFile expectation — the inline-vs-descriptor decision is made
-		// from metadata alone, so a large file is never downloaded here.
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeText, Text: "see attached"},
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "bigdoc.txt", MimeType: "text/plain"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		// Pin the full assembled suffix: the header sentence the read_file tool
-		// relies on, the per-entry header, and every descriptor field.
-		expected := "see attached\n" +
-			"Attached files (call the read_file tool with the File ID to read their contents):\n" +
-			fmt.Sprintf("**Attached File 1**:\nName: bigdoc.txt\nFile ID: doc1\nType: text/plain\nSize: %d bytes", InlineFileMaxBytes+1)
-		assert.Equal(t, expected, post.Message)
-		mmClient.AssertNotCalled(t, "GetFile", "doc1")
-	})
-
-	t.Run("large pre-extracted content is surfaced as a descriptor", func(t *testing.T) {
-		bigContent := strings.Repeat("x", int(InlineFileMaxBytes)+1)
-
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id:       "doc1",
-			Name:     "huge.pdf",
-			MimeType: "application/pdf",
-			Content:  bigContent,
-		}, nil)
-		// No GetFile expectation — pre-extracted content is measured directly.
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "huge.pdf", MimeType: "application/pdf"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		assert.Contains(t, post.Message, "File ID: doc1")
-		assert.NotContains(t, post.Message, bigContent,
-			"the descriptor must not inline the extracted content")
-		assert.NotContains(t, post.Message, "Attached File Contents:",
-			"a partial inline of the extracted content would still be a regression")
-	})
-
-	t.Run("binary file with no extractable text is surfaced as a descriptor without GetFile", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id:       "doc1",
-			Name:     "archive.zip",
-			MimeType: "application/zip",
-		}, nil)
-		// No GetFile expectation — a binary with no extractable text still gets
-		// a metadata descriptor so the LLM is aware of it.
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeText, Text: "see attached"},
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "archive.zip", MimeType: "application/zip"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		assert.Contains(t, post.Message, "see attached")
-		assert.Contains(t, post.Message, "Name: archive.zip")
-		assert.Contains(t, post.Message, "File ID: doc1")
-		mmClient.AssertNotCalled(t, "GetFile", "doc1")
-	})
-
-	t.Run("multiple mixed blocks: text + image + text/plain file", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
-			Id:       "img1",
-			Name:     "shot.png",
-			MimeType: "image/png",
-			Size:     500,
-		}, nil)
-		mmClient.On("GetFile", "img1").Return(newFakeReadCloser("PNGDATA"), nil)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id:       "doc1",
-			Name:     "foo.txt",
-			MimeType: "text/plain",
-			Size:     5,
-		}, nil)
-		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser("hello"), nil)
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeText, Text: "the text"},
-			{Type: BlockTypeImage, FileID: "img1", Filename: "shot.png", MimeType: "image/png"},
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "foo.txt", MimeType: "text/plain"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		require.Len(t, post.Files, 1, "exactly the image attachment should populate Post.Files")
-		assert.Equal(t, "image/png", post.Files[0].MimeType)
-		assert.Contains(t, post.Message, "the text")
-		assert.Contains(t, post.Message, "Attached File Contents:")
-		assert.Contains(t, post.Message, "File Name: foo.txt")
-		assert.Contains(t, post.Message, "Content: hello")
-
-		// Ordering contract: original user text precedes the
-		// "Attached File Contents:" suffix. Without this ordering,
-		// the LLM would see file content inserted before the user's
-		// own message.
-		idxText := strings.Index(post.Message, "the text")
-		idxAttach := strings.Index(post.Message, "Attached File Contents:")
-		require.NotEqual(t, -1, idxText)
-		require.NotEqual(t, -1, idxAttach)
-		assert.Less(t, idxText, idxAttach,
-			"user text must appear in the message before the Attached File Contents suffix")
-	})
-
-	t.Run("multiple text/plain files appear in input order in the message", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc-a").Return(&model.FileInfo{
-			Id: "doc-a", Name: "a.txt", MimeType: "text/plain", Size: 5,
-		}, nil)
-		mmClient.On("GetFile", "doc-a").Return(newFakeReadCloser("AAAAA"), nil)
-		mmClient.On("GetFileInfo", "doc-b").Return(&model.FileInfo{
-			Id: "doc-b", Name: "b.txt", MimeType: "text/plain", Size: 5,
-		}, nil)
-		mmClient.On("GetFile", "doc-b").Return(newFakeReadCloser("BBBBB"), nil)
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeText, Text: "two attachments"},
-			{Type: BlockTypeFile, FileID: "doc-a", Filename: "a.txt", MimeType: "text/plain"},
-			{Type: BlockTypeFile, FileID: "doc-b", Filename: "b.txt", MimeType: "text/plain"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		idxA := strings.Index(post.Message, "File Name: a.txt")
-		idxB := strings.Index(post.Message, "File Name: b.txt")
-		require.NotEqual(t, -1, idxA, "a.txt must appear in the message")
-		require.NotEqual(t, -1, idxB, "b.txt must appear in the message")
-		assert.Less(t, idxA, idxB,
-			"file blocks must appear in input order in the Attached File Contents suffix")
-	})
-
-	t.Run("GetFile error on image is logged and skipped, conversation continues", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "img1").Return(&model.FileInfo{
-			Id:       "img1",
-			Name:     "broken.png",
-			MimeType: "image/png",
-		}, nil)
-		mmClient.On("GetFile", "img1").Return(nil, errors.New("file store offline"))
-		// LogError must actually be invoked — without .Maybe() this fails
-		// if production silently swallows the error (the broken behavior).
-		mmClient.On("LogError", mock.Anything, mock.Anything).Return()
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeText, Text: "still here"},
-			{Type: BlockTypeImage, FileID: "img1", Filename: "broken.png", MimeType: "image/png"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		// Pin that GetFile was actually attempted — production simply
-		// dropping the image without trying to fetch it would still leave
-		// post.Files empty, so the previous broken behavior would pass
-		// without this AssertCalled.
-		mmClient.AssertCalled(t, "GetFile", "img1")
-		assert.Empty(t, post.Files, "GetFile errors must drop the entry, not abort the request")
-		assert.Equal(t, "still here", post.Message,
-			"text content must still appear when an image attachment fails to load")
-	})
-
-	// Pin the inline-vs-descriptor boundary by name: a file whose readable size
-	// is at or below InlineFileMaxBytes is inlined; one byte over becomes a
-	// descriptor (covered by "large text file is surfaced as a descriptor").
-	t.Run("text file at exactly InlineFileMaxBytes is inlined", func(t *testing.T) {
-		body := strings.Repeat("A", int(InlineFileMaxBytes))
-
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id: "doc1", Name: "boundary.txt", MimeType: "text/plain", Size: int64(len(body)),
-		}, nil)
-		mmClient.On("GetFile", "doc1").Return(newFakeReadCloser(body), nil)
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "boundary.txt", MimeType: "text/plain"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		assert.Contains(t, post.Message, "Attached File Contents:")
-		assert.Contains(t, post.Message, "File Name: boundary.txt")
-		assert.NotContains(t, post.Message, "read_file",
-			"a file at the inline threshold must be inlined, not described")
-	})
-
-	t.Run("nil mmClient is safe when no file or image blocks are present", func(t *testing.T) {
-		// Documents the zero-config safety guarantee: a turn with only
-		// text/thinking/tool blocks must not panic when mmClient is nil.
-		blocks := []ContentBlock{
-			{Type: BlockTypeText, Text: "hello"},
-			{Type: BlockTypeThinking, Text: "reason", Signature: "sig"},
-			{Type: BlockTypeToolUse, ID: "tc1", Name: "search", Input: json.RawMessage(`{}`), Status: StatusSuccess, Shared: BoolPtr(true)},
-		}
-
-		require.NotPanics(t, func() {
-			post := BlocksToPost(blocks, "assistant", false, nil, false, 0)
-			assert.Equal(t, "hello", post.Message)
-			assert.Equal(t, "reason", post.Reasoning)
-			require.Len(t, post.ToolUse, 1)
-			assert.Equal(t, "tc1", post.ToolUse[0].ID)
+			post := BlocksToPost(tt.blocks, role, false, mmClient, tt.enableVision, 0)
+			tt.assert(t, mmClient, post)
 		})
-	})
-
-	t.Run("BlockTypeFile with image/* MIME goes through file path, not image path", func(t *testing.T) {
-		// Dispatch must be by block.Type, not by MimeType — a malformed
-		// block (Type=file but MimeType=image/png) must not be sent to
-		// the LLM as an image. With empty FileInfo.Content and a non-text
-		// MIME there is no extractable text, so the block is surfaced as a
-		// metadata descriptor and GetFile must NOT be called.
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id: "doc1", Name: "weird.png", MimeType: "image/png",
-		}, nil)
-		// No GetFile expectation — mockery fails the test if production
-		// fetches bytes anyway (which would happen if dispatch went by
-		// MimeType into the image branch).
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeText, Text: "see attached"},
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "weird.png", MimeType: "image/png"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		mmClient.AssertNotCalled(t, "GetFile", "doc1")
-		assert.Empty(t, post.Files,
-			"a BlockTypeFile must never populate Post.Files even when its MimeType says image/*")
-		assert.Contains(t, post.Message, "see attached")
-		assert.Contains(t, post.Message, "File ID: doc1",
-			"a file block with no extractable text is surfaced as a metadata descriptor")
-	})
-
-	t.Run("FileInfo.Content non-empty wins over GetFile (explicit AssertNotCalled)", func(t *testing.T) {
-		mmClient := mmapimocks.NewMockClient(t)
-		mmClient.On("GetFileInfo", "doc1").Return(&model.FileInfo{
-			Id: "doc1", Name: "extracted.pdf", MimeType: "application/pdf",
-			Content: "server-extracted text",
-		}, nil)
-		// No GetFile expectation: when fileInfo.Content is non-empty,
-		// the byte fetch must be skipped entirely.
-
-		blocks := []ContentBlock{
-			{Type: BlockTypeFile, FileID: "doc1", Filename: "extracted.pdf", MimeType: "application/pdf"},
-		}
-
-		post := BlocksToPost(blocks, "user", false, mmClient, true, 0)
-
-		mmClient.AssertNotCalled(t, "GetFile", "doc1",
-			"pre-extracted FileInfo.Content must short-circuit GetFile to avoid a redundant blob read")
-		assert.Contains(t, post.Message, "Content: server-extracted text")
-	})
+	}
 }

--- a/files/files.go
+++ b/files/files.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Package files serves the text contents of Mattermost file attachments to the
+// LLM on demand. It exists because the server-extracted text (FileInfo.Content,
+// used for PDFs and Office documents) is tagged json:"-" and is never returned
+// over the REST API, so the MCP server's user-scoped client cannot read it.
+// This service reaches that content through the admin plugin API and therefore
+// must enforce the requesting user's channel permissions itself.
+package files
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-agents/mmapi"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+const (
+	// DefaultReadRunes is the window size returned when a caller omits a limit.
+	DefaultReadRunes = 6000
+	// MaxReadRunes caps a single read so one tool call cannot re-blow the
+	// context window the lazy-loading design is meant to protect.
+	MaxReadRunes = 20000
+	// maxDownloadBytes bounds how much of a raw text file is read into memory
+	// when the server has no pre-extracted content for it.
+	maxDownloadBytes = 10 * 1024 * 1024
+)
+
+// ErrForbidden is returned when the requesting user lacks permission to read the
+// file's channel. Callers map it to a 403 / access-denied tool result.
+var ErrForbidden = errors.New("you do not have permission to access this file")
+
+// Content is a ranged slice of a file's text plus the metadata needed to page
+// through the rest of it. Offsets are measured in runes, not bytes, so a
+// multi-byte character is never split across reads.
+type Content struct {
+	Name       string
+	MimeType   string
+	TotalRunes int
+	Offset     int
+	Returned   int
+	HasMore    bool
+	HasText    bool // false means the file has no extractable text (e.g. a binary with no server-side extraction)
+	Text       string
+}
+
+// Service is the shared plugin-side file reader behind both the embedded
+// read_file tool and the /files/content HTTP endpoint.
+type Service struct {
+	mm mmapi.Client
+}
+
+// New creates a file content service backed by the given Mattermost client.
+func New(mm mmapi.Client) *Service {
+	return &Service{mm: mm}
+}
+
+// GetContent returns the [offset, offset+limit) rune window of a file's text for
+// userID, after verifying that user may read the file's channel. Documents use
+// the server-extracted text; plain text files fall back to the raw bytes.
+func (s *Service) GetContent(ctx context.Context, userID, fileID string, offset, limit int) (Content, error) {
+	if !model.IsValidId(fileID) {
+		return Content{}, fmt.Errorf("invalid file id")
+	}
+
+	fileInfo, err := s.mm.GetFileInfo(fileID)
+	if err != nil {
+		return Content{}, fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	// The plugin API is admin-level, so permission must be checked explicitly.
+	if fileInfo.ChannelId == "" || !s.mm.HasPermissionToChannel(userID, fileInfo.ChannelId, model.PermissionReadChannel) {
+		return Content{}, ErrForbidden
+	}
+
+	text := s.extractText(ctx, fileInfo)
+	if text == "" {
+		return Content{Name: fileInfo.Name, MimeType: fileInfo.MimeType, HasText: false}, nil
+	}
+
+	return Slice(fileInfo.Name, fileInfo.MimeType, text, offset, limit), nil
+}
+
+// Slice returns the [offset, offset+limit) rune window of text as a Content,
+// applying the default and maximum read sizes. Offsets are measured in runes so
+// a multibyte character is never split, and they are clamped into range.
+func Slice(name, mimeType, text string, offset, limit int) Content {
+	runes := []rune(text)
+	total := len(runes)
+
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > total {
+		offset = total
+	}
+	if limit <= 0 {
+		limit = DefaultReadRunes
+	}
+	if limit > MaxReadRunes {
+		limit = MaxReadRunes
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+
+	return Content{
+		Name:       name,
+		MimeType:   mimeType,
+		TotalRunes: total,
+		Offset:     offset,
+		Returned:   end - offset,
+		HasMore:    end < total,
+		HasText:    total > 0,
+		Text:       string(runes[offset:end]),
+	}
+}
+
+// extractText prefers the server-extracted content (the only source for PDFs and
+// Office documents) and falls back to the raw bytes for plain text files.
+func (s *Service) extractText(_ context.Context, fileInfo *model.FileInfo) string {
+	if trimmed := strings.TrimSpace(fileInfo.Content); trimmed != "" {
+		return trimmed
+	}
+
+	if !strings.HasPrefix(fileInfo.MimeType, "text/") {
+		return ""
+	}
+
+	reader, err := s.mm.GetFile(fileInfo.Id)
+	if err != nil {
+		s.mm.LogError("failed to get file for read_file", "error", err, "file_id", fileInfo.Id)
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, maxDownloadBytes))
+	if closeErr := reader.Close(); closeErr != nil {
+		s.mm.LogWarn("failed to close file reader for read_file", "error", closeErr, "file_id", fileInfo.Id)
+	}
+	if err != nil {
+		s.mm.LogError("failed to read file for read_file", "error", err, "file_id", fileInfo.Id)
+		return ""
+	}
+	return string(body)
+}

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -1,0 +1,283 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package files
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-agents/mmapi/mocks"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+func TestGetContent(t *testing.T) {
+	userID := model.NewId()
+	channelID := model.NewId()
+	fileID := model.NewId()
+
+	// longText is comfortably larger than MaxReadRunes so cap behavior is exercised.
+	longText := strings.Repeat("a", MaxReadRunes+500)
+
+	tests := []struct {
+		name      string
+		fileID    string
+		offset    int
+		limit     int
+		setup     func(m *mocks.MockClient)
+		expectErr error
+		assert    func(t *testing.T, c Content)
+	}{
+		{
+			name:      "invalid file id is rejected before any lookup",
+			fileID:    "too-short",
+			setup:     func(_ *mocks.MockClient) {},
+			expectErr: nil, // non-nil generic error; checked below
+		},
+		{
+			name:   "missing channel is forbidden without a permission check",
+			fileID: fileID,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{Id: fileID, ChannelId: ""}, nil)
+			},
+			expectErr: ErrForbidden,
+		},
+		{
+			name:   "no channel permission is forbidden",
+			fileID: fileID,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{Id: fileID, ChannelId: channelID}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(false)
+			},
+			expectErr: ErrForbidden,
+		},
+		{
+			name:   "extracted content returned whole",
+			fileID: fileID,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, Name: "report.pdf",
+					MimeType: "application/pdf", Content: "  hello world  ",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.True(t, c.HasText)
+				assert.Equal(t, "hello world", c.Text) // trimmed
+				assert.Equal(t, 11, c.TotalRunes)
+				assert.Equal(t, 11, c.Returned)
+				assert.False(t, c.HasMore)
+				assert.Equal(t, "report.pdf", c.Name)
+			},
+		},
+		{
+			name:   "ranged read reports more remaining",
+			fileID: fileID,
+			offset: 0,
+			limit:  4,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "application/pdf", Content: "abcdefghij",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.Equal(t, "abcd", c.Text)
+				assert.Equal(t, 0, c.Offset)
+				assert.Equal(t, 4, c.Returned)
+				assert.Equal(t, 10, c.TotalRunes)
+				assert.True(t, c.HasMore)
+			},
+		},
+		{
+			name:   "offset past content tail returns empty with no more",
+			fileID: fileID,
+			offset: 8,
+			limit:  100,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "application/pdf", Content: "abcdefghij",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.Equal(t, "ij", c.Text)
+				assert.Equal(t, 8, c.Offset)
+				assert.Equal(t, 2, c.Returned)
+				assert.False(t, c.HasMore)
+			},
+		},
+		{
+			name:   "limit is capped at MaxReadRunes",
+			fileID: fileID,
+			offset: 0,
+			limit:  1_000_000,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "application/pdf", Content: longText,
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.Equal(t, MaxReadRunes, c.Returned)
+				assert.True(t, c.HasMore)
+				assert.Equal(t, len(longText), c.TotalRunes)
+			},
+		},
+		{
+			name:   "text file without extracted content reads raw bytes",
+			fileID: fileID,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "text/plain", Content: "",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+				m.EXPECT().GetFile(fileID).Return(io.NopCloser(strings.NewReader("raw file bytes")), nil)
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.True(t, c.HasText)
+				assert.Equal(t, "raw file bytes", c.Text)
+			},
+		},
+		{
+			name:   "binary without extracted content has no text",
+			fileID: fileID,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "application/zip", Content: "",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.False(t, c.HasText)
+				assert.Empty(t, c.Text)
+			},
+		},
+		{
+			name:   "rune offsets do not split multibyte characters",
+			fileID: fileID,
+			offset: 0,
+			limit:  5,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "application/pdf", Content: "héllo wörld 日本語",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.Equal(t, "héllo", c.Text)
+				assert.Equal(t, 15, c.TotalRunes)
+				assert.True(t, c.HasMore)
+			},
+		},
+		{
+			name:   "non-zero offset is rune-indexed not byte-indexed",
+			fileID: fileID,
+			offset: 7,
+			limit:  4,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "application/pdf", Content: "héllo wörld 日本語",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+			},
+			assert: func(t *testing.T, c Content) {
+				// Runes [7,11) of "héllo wörld 日本語" are "örld". A byte-based
+				// slice would start inside the multibyte 'ö' and differ.
+				assert.Equal(t, "örld", c.Text)
+				assert.Equal(t, 7, c.Offset)
+				assert.Equal(t, 4, c.Returned)
+				assert.True(t, c.HasMore)
+			},
+		},
+		{
+			name:   "explicit limit landing exactly on the end reports no more",
+			fileID: fileID,
+			offset: 0,
+			limit:  10,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "application/pdf", Content: "abcdefghij",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.Equal(t, "abcdefghij", c.Text)
+				assert.Equal(t, 10, c.Returned)
+				assert.False(t, c.HasMore, "an explicit limit that consumes the last rune must not report more")
+			},
+		},
+		{
+			name:   "negative offset is clamped to zero",
+			fileID: fileID,
+			offset: -5,
+			limit:  4,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "application/pdf", Content: "abcdefghij",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.Equal(t, 0, c.Offset)
+				assert.Equal(t, "abcd", c.Text)
+				assert.Equal(t, 4, c.Returned)
+			},
+		},
+		{
+			name:   "whitespace-only extracted content falls back to raw bytes for text files",
+			fileID: fileID,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "text/plain", Content: "   \n",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+				m.EXPECT().GetFile(fileID).Return(io.NopCloser(strings.NewReader("real bytes")), nil)
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.True(t, c.HasText)
+				assert.Equal(t, "real bytes", c.Text)
+			},
+		},
+		{
+			name:   "whitespace-only extracted content on a binary has no text and no download",
+			fileID: fileID,
+			setup: func(m *mocks.MockClient) {
+				m.EXPECT().GetFileInfo(fileID).Return(&model.FileInfo{
+					Id: fileID, ChannelId: channelID, MimeType: "application/zip", Content: "   ",
+				}, nil)
+				m.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionReadChannel).Return(true)
+				// No GetFile expectation: a binary with whitespace-only extracted
+				// content must not trigger a download.
+			},
+			assert: func(t *testing.T, c Content) {
+				assert.False(t, c.HasText)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := mocks.NewMockClient(t)
+			tt.setup(m)
+			svc := New(m)
+
+			c, err := svc.GetContent(context.Background(), userID, tt.fileID, tt.offset, tt.limit)
+
+			switch {
+			case tt.name == "invalid file id is rejected before any lookup":
+				require.Error(t, err)
+			case tt.expectErr != nil:
+				require.ErrorIs(t, err, tt.expectErr)
+			default:
+				require.NoError(t, err)
+				tt.assert(t, c)
+			}
+		})
+	}
+}

--- a/format/format.go
+++ b/format/format.go
@@ -327,14 +327,16 @@ func WriteTeam(w *strings.Builder, entry TeamEntry) {
 // without inlining its contents. The File ID is included so the model can pass
 // it to the read_file tool to fetch the contents on demand.
 type FileDescriptorEntry struct {
-	HeaderLabel string          // e.g. "Attached File 1"; empty to omit
-	FileInfo    *model.FileInfo // the source file
+	// Number is the 1-based position of the file in the attachment list; it
+	// renders as an "Attached File N" header. A zero value omits the header.
+	Number   int
+	FileInfo *model.FileInfo // the source file
 }
 
 // WriteFileDescriptor writes a compact file metadata descriptor to the builder.
 func WriteFileDescriptor(w *strings.Builder, entry FileDescriptorEntry) {
-	if entry.HeaderLabel != "" {
-		fmt.Fprintf(w, "**%s**:\n", entry.HeaderLabel)
+	if entry.Number > 0 {
+		fmt.Fprintf(w, "**Attached File %d**:\n", entry.Number)
 	}
 
 	fmt.Fprintf(w, "Name: %s\n", entry.FileInfo.Name)

--- a/format/format.go
+++ b/format/format.go
@@ -322,3 +322,29 @@ func WriteTeam(w *strings.Builder, entry TeamEntry) {
 		fmt.Fprintf(w, "Member Count: %d\n", entry.MemberCount)
 	}
 }
+
+// FileDescriptorEntry holds metadata for a file attachment surfaced to the LLM
+// without inlining its contents. The File ID is included so the model can pass
+// it to the read_file tool to fetch the contents on demand.
+type FileDescriptorEntry struct {
+	HeaderLabel string          // e.g. "Attached File 1"; empty to omit
+	FileInfo    *model.FileInfo // the source file
+}
+
+// WriteFileDescriptor writes a compact file metadata descriptor to the builder.
+func WriteFileDescriptor(w *strings.Builder, entry FileDescriptorEntry) {
+	if entry.HeaderLabel != "" {
+		fmt.Fprintf(w, "**%s**:\n", entry.HeaderLabel)
+	}
+
+	fmt.Fprintf(w, "Name: %s\n", entry.FileInfo.Name)
+	fmt.Fprintf(w, "File ID: %s\n", entry.FileInfo.Id)
+
+	if entry.FileInfo.MimeType != "" {
+		fmt.Fprintf(w, "Type: %s\n", entry.FileInfo.MimeType)
+	}
+
+	fmt.Fprintf(w, "Size: %d bytes\n", entry.FileInfo.Size)
+
+	w.WriteString("\n")
+}

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -664,3 +664,44 @@ func TestAgentList(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteFileDescriptor(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    FileDescriptorEntry
+		expected string
+	}{
+		{
+			name: "full metadata with header",
+			entry: FileDescriptorEntry{
+				HeaderLabel: "Attached File 1",
+				FileInfo: &model.FileInfo{
+					Id:       "fileid1234567890123456789a",
+					Name:     "report.pdf",
+					MimeType: "application/pdf",
+					Size:     2412345,
+				},
+			},
+			expected: "**Attached File 1**:\nName: report.pdf\nFile ID: fileid1234567890123456789a\nType: application/pdf\nSize: 2412345 bytes\n\n",
+		},
+		{
+			name: "no header and no mime type",
+			entry: FileDescriptorEntry{
+				FileInfo: &model.FileInfo{
+					Id:   "fileid1234567890123456789b",
+					Name: "data.bin",
+					Size: 10,
+				},
+			},
+			expected: "Name: data.bin\nFile ID: fileid1234567890123456789b\nSize: 10 bytes\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf strings.Builder
+			WriteFileDescriptor(&buf, tt.entry)
+			assert.Equal(t, tt.expected, buf.String())
+		})
+	}
+}

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -672,9 +672,9 @@ func TestWriteFileDescriptor(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "full metadata with header",
+			name: "numbered header with full metadata",
 			entry: FileDescriptorEntry{
-				HeaderLabel: "Attached File 1",
+				Number: 1,
 				FileInfo: &model.FileInfo{
 					Id:       "fileid1234567890123456789a",
 					Name:     "report.pdf",
@@ -685,7 +685,7 @@ func TestWriteFileDescriptor(t *testing.T) {
 			expected: "**Attached File 1**:\nName: report.pdf\nFile ID: fileid1234567890123456789a\nType: application/pdf\nSize: 2412345 bytes\n\n",
 		},
 		{
-			name: "no header and no mime type",
+			name: "zero number omits header, no mime type",
 			entry: FileDescriptorEntry{
 				FileInfo: &model.FileInfo{
 					Id:   "fileid1234567890123456789b",

--- a/mcp/tool_policy.go
+++ b/mcp/tool_policy.go
@@ -22,10 +22,10 @@ func (f ToolPolicyFunc) GetToolPolicy(serverBaseURL string, toolName string) (st
 // origins. Unknown or disabled origins never auto-execute.
 func LookupToolPolicy(cfg Config, serverBaseURL, toolName string) (string, bool) {
 	if serverBaseURL == EmbeddedClientKey {
-		toolConfigs := cfg.EmbeddedServer.ToolConfigs
-		if len(toolConfigs) == 0 {
-			toolConfigs = SeedVettedToolConfigs(EmbeddedClientKey)
-		}
+		// Backfill the vetted seed for embedded tools the admin hasn't stored a
+		// config for, so tools added after an install first saved its configs
+		// still get their default policy. Stored entries win.
+		toolConfigs := mergeSeedConfigs(cfg.EmbeddedServer.ToolConfigs, SeedVettedToolConfigs(EmbeddedClientKey))
 		embeddedCfg := &ServerConfig{
 			Name:        EmbeddedServerName,
 			Enabled:     true,

--- a/mcp/tool_policy_lookup_test.go
+++ b/mcp/tool_policy_lookup_test.go
@@ -156,6 +156,45 @@ func TestLookupToolPolicy(t *testing.T) {
 		require.Equal(t, seedTool.Enabled, enabled)
 	})
 
+	t.Run("embedded backfills seed policy for a tool missing from stored configs", func(t *testing.T) {
+		// Non-empty stored configs without read_file (an install that saved
+		// configs before read_file existed) must still get the vetted seed.
+		cfg := Config{
+			EmbeddedServer: EmbeddedServerConfig{
+				Enabled: true,
+				ToolConfigs: []ToolConfig{{
+					Name:    "search_posts",
+					Policy:  ToolPolicyAutoRunInDM,
+					Enabled: true,
+				}},
+			},
+		}
+
+		policy, enabled := LookupToolPolicy(cfg, EmbeddedClientKey, "read_file")
+
+		require.Equal(t, ToolPolicyAutoRunInDM, policy)
+		require.True(t, enabled)
+	})
+
+	t.Run("embedded explicit config overrides the vetted seed", func(t *testing.T) {
+		// An explicitly disabled tool must not be silently re-enabled by the seed.
+		cfg := Config{
+			EmbeddedServer: EmbeddedServerConfig{
+				Enabled: true,
+				ToolConfigs: []ToolConfig{{
+					Name:    "read_file",
+					Policy:  ToolPolicyAsk,
+					Enabled: false,
+				}},
+			},
+		}
+
+		policy, enabled := LookupToolPolicy(cfg, EmbeddedClientKey, "read_file")
+
+		require.Equal(t, ToolPolicyAsk, policy)
+		require.False(t, enabled)
+	})
+
 	t.Run("unknown origin returns ask false", func(t *testing.T) {
 		policy, enabled := LookupToolPolicy(Config{}, "bogus://nowhere", "x")
 

--- a/mcp/vetted_tools.go
+++ b/mcp/vetted_tools.go
@@ -124,6 +124,18 @@ func askToolConfigs(toolNames []string) []ToolConfig {
 	return configs
 }
 
+func autoRunEverywhereToolConfigs(toolNames []string) []ToolConfig {
+	configs := make([]ToolConfig, 0, len(toolNames))
+	for _, toolName := range toolNames {
+		configs = append(configs, ToolConfig{
+			Name:    toolName,
+			Policy:  ToolPolicyAutoRunEverywhere,
+			Enabled: true,
+		})
+	}
+	return configs
+}
+
 // githubSecurityAskTools are GitHub Copilot MCP reads that surface vulnerability
 // and secret-scanning posture; they default to ask rather than auto-run.
 var githubSecurityAskTools = map[string]struct{}{
@@ -242,14 +254,29 @@ var figmaVettedToolConfigs = autoRunInDMToolConfigs([]string{
 	"whoami",
 })
 
-var mattermostVettedToolConfigs = autoRunInDMToolConfigs([]string{
-	"read_post",
-	"read_channel",
-	"get_channel_info",
-	"get_channel_members",
-	"get_team_info",
-	"get_team_members",
-	"search_posts",
-	"search_users",
-	"get_user_channels",
-})
+var mattermostVettedToolConfigs = buildMattermostVettedToolConfigs()
+
+func buildMattermostVettedToolConfigs() []ToolConfig {
+	// Read-only Mattermost tools auto-run in DMs but ask before running in a
+	// channel, where their results would be visible to everyone.
+	configs := autoRunInDMToolConfigs([]string{
+		"read_post",
+		"read_channel",
+		"get_channel_info",
+		"get_channel_members",
+		"get_team_info",
+		"get_team_members",
+		"search_posts",
+		"search_users",
+		"get_user_channels",
+	})
+
+	// read_file auto-runs everywhere. Before lazy file loading, an attachment's
+	// extracted content was inlined into the prompt automatically — in DMs and
+	// channels alike, with no approval. Fetching it on demand via read_file
+	// preserves that behavior rather than introducing an approval step for
+	// content the user already attached and the bot could already read.
+	configs = append(configs, autoRunEverywhereToolConfigs([]string{"read_file"})...)
+
+	return configs
+}

--- a/mcp/vetted_tools.go
+++ b/mcp/vetted_tools.go
@@ -100,6 +100,27 @@ func cloneToolConfigs(src []ToolConfig) []ToolConfig {
 	return dst
 }
 
+// mergeSeedConfigs appends seed entries for tool names missing from stored, so
+// stored entries win. Inputs are not mutated.
+func mergeSeedConfigs(stored, seed []ToolConfig) []ToolConfig {
+	if len(stored) == 0 {
+		return seed
+	}
+
+	present := make(map[string]bool, len(stored))
+	merged := make([]ToolConfig, 0, len(stored)+len(seed))
+	for _, tc := range stored {
+		present[tc.Name] = true
+		merged = append(merged, tc)
+	}
+	for _, tc := range seed {
+		if !present[tc.Name] {
+			merged = append(merged, tc)
+		}
+	}
+	return merged
+}
+
 func autoRunInDMToolConfigs(toolNames []string) []ToolConfig {
 	configs := make([]ToolConfig, 0, len(toolNames))
 	for _, toolName := range toolNames {
@@ -118,18 +139,6 @@ func askToolConfigs(toolNames []string) []ToolConfig {
 		configs = append(configs, ToolConfig{
 			Name:    toolName,
 			Policy:  ToolPolicyAsk,
-			Enabled: true,
-		})
-	}
-	return configs
-}
-
-func autoRunEverywhereToolConfigs(toolNames []string) []ToolConfig {
-	configs := make([]ToolConfig, 0, len(toolNames))
-	for _, toolName := range toolNames {
-		configs = append(configs, ToolConfig{
-			Name:    toolName,
-			Policy:  ToolPolicyAutoRunEverywhere,
 			Enabled: true,
 		})
 	}
@@ -254,29 +263,19 @@ var figmaVettedToolConfigs = autoRunInDMToolConfigs([]string{
 	"whoami",
 })
 
-var mattermostVettedToolConfigs = buildMattermostVettedToolConfigs()
-
-func buildMattermostVettedToolConfigs() []ToolConfig {
-	// Read-only Mattermost tools auto-run in DMs but ask before running in a
-	// channel, where their results would be visible to everyone.
-	configs := autoRunInDMToolConfigs([]string{
-		"read_post",
-		"read_channel",
-		"get_channel_info",
-		"get_channel_members",
-		"get_team_info",
-		"get_team_members",
-		"search_posts",
-		"search_users",
-		"get_user_channels",
-	})
-
-	// read_file auto-runs everywhere. Before lazy file loading, an attachment's
-	// extracted content was inlined into the prompt automatically — in DMs and
-	// channels alike, with no approval. Fetching it on demand via read_file
-	// preserves that behavior rather than introducing an approval step for
-	// content the user already attached and the bot could already read.
-	configs = append(configs, autoRunEverywhereToolConfigs([]string{"read_file"})...)
-
-	return configs
-}
+// Read-only Mattermost tools auto-run in DMs but ask in channels, where results
+// are visible to everyone. read_file belongs here (not auto-run-everywhere): it
+// only checks the caller's own access, so auto-running it in a channel could
+// surface a file the channel can't see.
+var mattermostVettedToolConfigs = autoRunInDMToolConfigs([]string{
+	"read_post",
+	"read_channel",
+	"get_channel_info",
+	"get_channel_members",
+	"get_team_info",
+	"get_team_members",
+	"search_posts",
+	"search_users",
+	"get_user_channels",
+	"read_file",
+})

--- a/mcp/vetted_tools_test.go
+++ b/mcp/vetted_tools_test.go
@@ -118,9 +118,9 @@ func TestSeedVettedToolConfigs(t *testing.T) {
 			wantCount: 8,
 		},
 		{
-			name:      "Mattermost seeds 9 read tools",
+			name:      "Mattermost seeds 10 read tools",
 			baseURL:   EmbeddedClientKey,
-			wantCount: 9,
+			wantCount: 10,
 		},
 		{
 			name:    "unknown host returns nil",
@@ -161,9 +161,13 @@ func TestSeedVettedToolConfigs(t *testing.T) {
 			require.Len(t, got, tt.wantCount)
 			for _, cfg := range got {
 				require.True(t, cfg.Enabled)
-				if strings.Contains(tt.baseURL, "api.githubcopilot.com") {
+				switch {
+				case strings.Contains(tt.baseURL, "api.githubcopilot.com"):
 					require.True(t, cfg.Policy == ToolPolicyAutoRunInDM || cfg.Policy == ToolPolicyAsk)
-				} else {
+				case tt.baseURL == EmbeddedClientKey:
+					// read_file auto-runs everywhere; the rest auto-run in DMs.
+					require.True(t, cfg.Policy == ToolPolicyAutoRunInDM || cfg.Policy == ToolPolicyAutoRunEverywhere)
+				default:
 					require.Equal(t, ToolPolicyAutoRunInDM, cfg.Policy)
 				}
 				require.NotEmpty(t, cfg.Name)
@@ -201,6 +205,9 @@ func TestSeedVettedToolConfigsSpotChecks(t *testing.T) {
 		configs := SeedVettedToolConfigs(EmbeddedClientKey)
 		requireToolConfig(t, configs, "search_posts", ToolPolicyAutoRunInDM, true)
 		requireToolConfig(t, configs, "search_users", ToolPolicyAutoRunInDM, true)
+		// read_file auto-runs everywhere so reading an attached file never needs
+		// approval, matching the pre-lazy-loading auto-inline behavior.
+		requireToolConfig(t, configs, "read_file", ToolPolicyAutoRunEverywhere, true)
 		requireNoToolConfig(t, configs, "create_post")
 	})
 }

--- a/mcp/vetted_tools_test.go
+++ b/mcp/vetted_tools_test.go
@@ -164,9 +164,6 @@ func TestSeedVettedToolConfigs(t *testing.T) {
 				switch {
 				case strings.Contains(tt.baseURL, "api.githubcopilot.com"):
 					require.True(t, cfg.Policy == ToolPolicyAutoRunInDM || cfg.Policy == ToolPolicyAsk)
-				case tt.baseURL == EmbeddedClientKey:
-					// read_file auto-runs everywhere; the rest auto-run in DMs.
-					require.True(t, cfg.Policy == ToolPolicyAutoRunInDM || cfg.Policy == ToolPolicyAutoRunEverywhere)
 				default:
 					require.Equal(t, ToolPolicyAutoRunInDM, cfg.Policy)
 				}
@@ -205,11 +202,58 @@ func TestSeedVettedToolConfigsSpotChecks(t *testing.T) {
 		configs := SeedVettedToolConfigs(EmbeddedClientKey)
 		requireToolConfig(t, configs, "search_posts", ToolPolicyAutoRunInDM, true)
 		requireToolConfig(t, configs, "search_users", ToolPolicyAutoRunInDM, true)
-		// read_file auto-runs everywhere so reading an attached file never needs
-		// approval, matching the pre-lazy-loading auto-inline behavior.
-		requireToolConfig(t, configs, "read_file", ToolPolicyAutoRunEverywhere, true)
+		requireToolConfig(t, configs, "read_file", ToolPolicyAutoRunInDM, true)
 		requireNoToolConfig(t, configs, "create_post")
 	})
+}
+
+func TestMergeSeedConfigs(t *testing.T) {
+	tests := []struct {
+		name   string
+		stored []ToolConfig
+		seed   []ToolConfig
+		want   []ToolConfig
+	}{
+		{
+			name:   "empty stored returns the seed",
+			stored: nil,
+			seed:   []ToolConfig{{Name: "read_file", Policy: ToolPolicyAutoRunInDM, Enabled: true}},
+			want:   []ToolConfig{{Name: "read_file", Policy: ToolPolicyAutoRunInDM, Enabled: true}},
+		},
+		{
+			name:   "tool missing from stored is appended from the seed",
+			stored: []ToolConfig{{Name: "search_posts", Policy: ToolPolicyAutoRunInDM, Enabled: true}},
+			seed:   []ToolConfig{{Name: "read_file", Policy: ToolPolicyAutoRunInDM, Enabled: true}},
+			want: []ToolConfig{
+				{Name: "search_posts", Policy: ToolPolicyAutoRunInDM, Enabled: true},
+				{Name: "read_file", Policy: ToolPolicyAutoRunInDM, Enabled: true},
+			},
+		},
+		{
+			// Conflicting non-default values on both sides prove the stored
+			// entry wins (rather than coinciding with the unconfigured default)
+			// and that no duplicate read_file reaches last-match-wins resolution.
+			name:   "stored entry wins over a conflicting seed entry",
+			stored: []ToolConfig{{Name: "read_file", Policy: ToolPolicyAutoRunEverywhere, Enabled: false}},
+			seed:   []ToolConfig{{Name: "read_file", Policy: ToolPolicyAutoRunInDM, Enabled: true}},
+			want:   []ToolConfig{{Name: "read_file", Policy: ToolPolicyAutoRunEverywhere, Enabled: false}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Callers pass the live config slice as stored, so the merge must
+			// not mutate its inputs.
+			storedBefore := append([]ToolConfig(nil), tt.stored...)
+			seedBefore := append([]ToolConfig(nil), tt.seed...)
+
+			got := mergeSeedConfigs(tt.stored, tt.seed)
+
+			require.Equal(t, tt.want, got)
+			require.Equal(t, storedBefore, tt.stored)
+			require.Equal(t, seedBefore, tt.seed)
+		})
+	}
 }
 
 func requireToolConfig(t *testing.T, configs []ToolConfig, name, policy string, enabled bool) {

--- a/mcpserver/cmd/main.go
+++ b/mcpserver/cmd/main.go
@@ -134,7 +134,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 			PersonalAccessToken: token,
 		}
 
-		mcpServer, err = mcpserver.NewStdioServer(stdioConfig, logger, nil)
+		mcpServer, err = mcpserver.NewStdioServer(stdioConfig, logger, nil, nil)
 	case "http":
 		// Create HTTP transport configuration
 		stateless, _ := cmd.Flags().GetBool("stateless")

--- a/mcpserver/eval_helpers_test.go
+++ b/mcpserver/eval_helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/chunking"
 	"github.com/mattermost/mattermost-plugin-agents/embeddings"
 	"github.com/mattermost/mattermost-plugin-agents/evals"
+	"github.com/mattermost/mattermost-plugin-agents/files"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/mcpserver/testhelpers"
 	"github.com/mattermost/mattermost-plugin-agents/mcpserver/tools"
@@ -635,4 +636,68 @@ func mcpToolsToLLMTools(t *testing.T, mcpServer *gomcp.Server) []llm.Tool {
 		})
 	}
 	return tools
+}
+
+// client4FileContentService implements tools.FileContentService using a Client4
+// admin connection. The eval container has no plugin installed, so the production
+// HTTPFileContentService callback would 404; this reads files directly over REST
+// instead, exercising the real files.Slice ranging logic. Per-user permission
+// enforcement is covered by unit tests, so this trusts the admin token.
+type client4FileContentService struct {
+	serverURL string
+	token     string
+}
+
+func (s *client4FileContentService) GetContent(ctx context.Context, _ string, fileID string, offset, limit int) (files.Content, error) {
+	client := model.NewAPIv4Client(s.serverURL)
+	client.SetToken(s.token)
+
+	info, _, err := client.GetFileInfo(ctx, fileID)
+	if err != nil {
+		return files.Content{}, err
+	}
+
+	// Client4 cannot read server-extracted document text (FileInfo.Content is
+	// json:"-"), so only plain-text files are readable here — which is all the
+	// eval seeds for the readable cases. Non-text files report no extractable
+	// text, exactly as production does.
+	if !strings.HasPrefix(info.MimeType, "text/") {
+		return files.Content{Name: info.Name, MimeType: info.MimeType, HasText: false}, nil
+	}
+
+	data, _, err := client.GetFile(ctx, fileID)
+	if err != nil {
+		return files.Content{}, err
+	}
+
+	return files.Slice(info.Name, info.MimeType, string(data), offset, limit), nil
+}
+
+// seedFileScenario creates a team and channel (the admin is a member as the
+// creator), uploads a file with the given content, and attaches it to a post.
+// Returns the team, channel, and the attached file's info.
+func seedFileScenario(t *testing.T, serverURL, adminToken, filename string, content []byte) (*model.Team, *model.Channel, *model.FileInfo) {
+	t.Helper()
+
+	ctx := context.Background()
+	adminClient := model.NewAPIv4Client(serverURL)
+	adminClient.SetToken(adminToken)
+
+	suffix := model.NewId()[:8]
+	team := testhelpers.CreateTestTeam(t, adminClient, "file-eval-"+suffix, "File Eval Team")
+	channel := testhelpers.CreateTestChannel(t, adminClient, team.Id, "file-eval-"+suffix, "File Eval")
+
+	upload, _, err := adminClient.UploadFile(ctx, content, channel.Id, filename)
+	require.NoError(t, err, "Failed to upload file")
+	require.NotEmpty(t, upload.FileInfos, "Upload should return file info")
+	fileInfo := upload.FileInfos[0]
+
+	_, _, err = adminClient.CreatePost(ctx, &model.Post{
+		ChannelId: channel.Id,
+		Message:   "Here's the file.",
+		FileIds:   []string{fileInfo.Id},
+	})
+	require.NoError(t, err, "Failed to create post with file attachment")
+
+	return team, channel, fileInfo
 }

--- a/mcpserver/http_server.go
+++ b/mcpserver/http_server.go
@@ -78,12 +78,13 @@ func NewHTTPServer(config HTTPConfig, logger loggerlib.Logger) (*MattermostHTTPM
 		nil, // ServerOptions - keeping nil for now
 	)
 
-	// Create HTTP search service for callback to plugin API
+	// Create HTTP search and file content services for callback to plugin API
 	pluginURL := strings.TrimRight(config.GetMMServerURL(), "/") + "/plugins/mattermost-ai"
 	searchService := tools.NewHTTPSemanticSearchService(pluginURL)
+	fileContentService := tools.NewHTTPFileContentService(pluginURL)
 
 	// Register tools with remote access mode
-	mattermostServer.registerTools(tools.AccessModeRemote, searchService)
+	mattermostServer.registerTools(tools.AccessModeRemote, searchService, fileContentService)
 
 	// Create HTTP server with OAuth endpoints and MCP routing
 	addr := fmt.Sprintf("%s:%d", config.HTTPBindAddr, config.HTTPPort)

--- a/mcpserver/inmemory_server.go
+++ b/mcpserver/inmemory_server.go
@@ -24,8 +24,9 @@ type MattermostInMemoryMCPServer struct {
 
 // NewInMemoryServer creates a new in-memory transport MCP server
 // This server is designed to run embedded within the plugin process
-// searchService is optional and can be nil if semantic search is not available
-func NewInMemoryServer(config InMemoryConfig, logger loggerlib.Logger, searchService tools.SemanticSearchService) (*MattermostInMemoryMCPServer, error) {
+// searchService and fileContentService are optional and can be nil when the
+// corresponding capability is unavailable
+func NewInMemoryServer(config InMemoryConfig, logger loggerlib.Logger, searchService tools.SemanticSearchService, fileContentService tools.FileContentService) (*MattermostInMemoryMCPServer, error) {
 	if config.MMServerURL == "" {
 		return nil, fmt.Errorf("mattermost server URL cannot be empty for in-memory transport")
 	}
@@ -63,8 +64,7 @@ func NewInMemoryServer(config InMemoryConfig, logger loggerlib.Logger, searchSer
 	)
 
 	// Register tools with remote access mode (embedded clients are treated as remote)
-	// Pass options for semantic search support
-	mattermostServer.registerTools(tools.AccessModeRemote, searchService)
+	mattermostServer.registerTools(tools.AccessModeRemote, searchService, fileContentService)
 
 	logger.Info("Created in-memory MCP server")
 

--- a/mcpserver/plugin_handlers.go
+++ b/mcpserver/plugin_handlers.go
@@ -135,6 +135,7 @@ func (h *PluginMCPHandlers) buildServer() *mcp.Server {
 	authProvider := auth.NewSessionAuthenticationProvider(h.siteURL, h.internalURL, h.logger)
 	pluginURL := strings.TrimRight(h.siteURL, "/") + "/plugins/mattermost-ai"
 	searchService := tools.NewHTTPSemanticSearchService(pluginURL)
+	fileContentService := tools.NewHTTPFileContentService(pluginURL)
 
 	toolProvider := tools.NewMattermostToolProvider(
 		authProvider,
@@ -142,6 +143,7 @@ func (h *PluginMCPHandlers) buildServer() *mcp.Server {
 		config,
 		tools.AccessModeRemote,
 		searchService,
+		fileContentService,
 	)
 	toolProvider.ProvideTools(mcpServer)
 

--- a/mcpserver/server.go
+++ b/mcpserver/server.go
@@ -20,10 +20,11 @@ type MattermostMCPServer struct {
 	config       types.ServerConfig
 }
 
-// registerTools registers all tools using the tool provider
-// searchService is optional and can be nil if semantic search is not available
-func (s *MattermostMCPServer) registerTools(accessMode tools.AccessMode, searchService tools.SemanticSearchService) {
-	toolProvider := tools.NewMattermostToolProvider(s.authProvider, s.logger, s.config, accessMode, searchService)
+// registerTools registers all tools using the tool provider.
+// searchService and fileContentService are optional and can be nil when the
+// corresponding capability is unavailable.
+func (s *MattermostMCPServer) registerTools(accessMode tools.AccessMode, searchService tools.SemanticSearchService, fileContentService tools.FileContentService) {
+	toolProvider := tools.NewMattermostToolProvider(s.authProvider, s.logger, s.config, accessMode, searchService, fileContentService)
 	toolProvider.ProvideTools(s.mcpServer)
 }
 

--- a/mcpserver/stdio_server.go
+++ b/mcpserver/stdio_server.go
@@ -21,9 +21,9 @@ type MattermostStdioMCPServer struct {
 }
 
 // NewStdioServer creates a new STDIO transport MCP server.
-// searchService is optional — if nil, a default HTTP-based service is created that
-// calls back to the plugin's /api/v1/search/raw endpoint.
-func NewStdioServer(config StdioConfig, logger loggerlib.Logger, searchService tools.SemanticSearchService) (*MattermostStdioMCPServer, error) {
+// searchService and fileContentService are optional — if nil, default HTTP-based
+// services are created that call back to the plugin's /api/v1 endpoints.
+func NewStdioServer(config StdioConfig, logger loggerlib.Logger, searchService tools.SemanticSearchService, fileContentService tools.FileContentService) (*MattermostStdioMCPServer, error) {
 	if config.MMServerURL == "" {
 		return nil, fmt.Errorf("server URL cannot be empty")
 	}
@@ -63,14 +63,17 @@ func NewStdioServer(config StdioConfig, logger loggerlib.Logger, searchService t
 		return nil, fmt.Errorf("startup token validation failed: %w", err)
 	}
 
-	// Use provided search service or create default HTTP callback service
+	// Use provided services or create default HTTP callback services
+	pluginURL := strings.TrimRight(config.GetMMServerURL(), "/") + "/plugins/mattermost-ai"
 	if searchService == nil {
-		pluginURL := strings.TrimRight(config.GetMMServerURL(), "/") + "/plugins/mattermost-ai"
 		searchService = tools.NewHTTPSemanticSearchService(pluginURL)
+	}
+	if fileContentService == nil {
+		fileContentService = tools.NewHTTPFileContentService(pluginURL)
 	}
 
 	// Register tools with local access mode
-	mattermostServer.registerTools(tools.AccessModeLocal, searchService)
+	mattermostServer.registerTools(tools.AccessModeLocal, searchService, fileContentService)
 
 	return mattermostServer, nil
 }

--- a/mcpserver/stdio_server_test.go
+++ b/mcpserver/stdio_server_test.go
@@ -43,7 +43,7 @@ func TestMCPServerConfiguration(t *testing.T) {
 			},
 			PersonalAccessToken: suite.adminToken,
 		}
-		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		require.NoError(t, err, "Valid configuration should not return error")
 		assert.NotNil(t, mcpServer, "MCP server should be created with valid config")
@@ -57,7 +57,7 @@ func TestMCPServerConfiguration(t *testing.T) {
 			},
 			PersonalAccessToken: suite.adminToken,
 		}
-		_, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		_, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		assert.Error(t, err, "Invalid server URL should return error")
 		assert.Contains(t, err.Error(), "startup token validation failed", "Error should mention token validation failure")
@@ -71,7 +71,7 @@ func TestMCPServerConfiguration(t *testing.T) {
 			},
 			PersonalAccessToken: "invalid-token-12345",
 		}
-		_, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		_, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		assert.Error(t, err, "Invalid token should return error")
 		assert.Contains(t, err.Error(), "startup token validation failed", "Error should mention token validation failure")
@@ -85,7 +85,7 @@ func TestMCPServerConfiguration(t *testing.T) {
 			},
 			PersonalAccessToken: "",
 		}
-		_, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		_, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		// Empty token should fail option validation
 		assert.Error(t, err, "Empty token should fail validation")
@@ -100,7 +100,7 @@ func TestMCPServerConfiguration(t *testing.T) {
 			},
 			PersonalAccessToken: suite.adminToken,
 		}
-		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		require.NoError(t, err, "Dev mode configuration should not return error")
 		assert.NotNil(t, mcpServer, "MCP server should be created with dev mode")
@@ -115,7 +115,7 @@ func TestMCPServerConfiguration(t *testing.T) {
 			},
 			PersonalAccessToken: suite.adminToken,
 		}
-		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		require.NoError(t, err, "STDIO server should be created successfully")
 		assert.NotNil(t, mcpServer, "MCP server should be created")
@@ -146,7 +146,7 @@ func TestAuthentication(t *testing.T) {
 			},
 			PersonalAccessToken: suite.adminToken,
 		}
-		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		require.NoError(t, err, "Startup token validation should succeed with valid token")
 		assert.NotNil(t, mcpServer, "MCP server should be created after successful token validation")
@@ -175,7 +175,7 @@ func TestMCPServerStartupValidation(t *testing.T) {
 			},
 			PersonalAccessToken: suite.adminToken,
 		}
-		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		require.NoError(t, err, "Startup validation should succeed")
 		assert.NotNil(t, mcpServer, "MCP server should be created after successful validation")
@@ -189,7 +189,7 @@ func TestMCPServerStartupValidation(t *testing.T) {
 			},
 			PersonalAccessToken: suite.adminToken,
 		}
-		_, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		_, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		assert.Error(t, err, "Startup validation should fail with invalid server")
 		assert.Contains(t, err.Error(), "startup token validation failed", "Error should mention startup validation failure")
@@ -203,7 +203,7 @@ func TestMCPServerStartupValidation(t *testing.T) {
 			},
 			PersonalAccessToken: "unauthorized-token-123",
 		}
-		_, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		_, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		assert.Error(t, err, "Startup validation should fail with unauthorized token")
 		assert.Contains(t, err.Error(), "startup token validation failed", "Error should mention startup validation failure")
@@ -218,7 +218,7 @@ func TestMCPServerStartupValidation(t *testing.T) {
 			},
 			PersonalAccessToken: suite.adminToken,
 		}
-		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil)
+		mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, nil, nil)
 
 		require.NoError(t, err, "Server creation should succeed with valid token")
 		assert.NotNil(t, mcpServer, "MCP server should be created")

--- a/mcpserver/test_helpers_test.go
+++ b/mcpserver/test_helpers_test.go
@@ -143,15 +143,22 @@ func (suite *TestSuite) TearDown() {
 
 // CreateMCPServer creates and configures an MCP server for testing
 func (suite *TestSuite) CreateMCPServer(devMode bool) {
-	suite.createMCPServerWithConfig(devMode, nil)
+	suite.createMCPServerWithConfig(devMode, nil, nil)
 }
 
 // CreateMCPServerWithSearch creates an MCP server with a custom semantic search service
 func (suite *TestSuite) CreateMCPServerWithSearch(devMode bool, searchService tools.SemanticSearchService) {
-	suite.createMCPServerWithConfig(devMode, searchService)
+	suite.createMCPServerWithConfig(devMode, searchService, nil)
 }
 
-func (suite *TestSuite) createMCPServerWithConfig(devMode bool, searchService tools.SemanticSearchService) {
+// CreateMCPServerWithFileService creates an MCP server with a custom file content service.
+// The eval container has no plugin installed, so the production HTTP callback would 404 —
+// tests inject a Client4-backed service instead.
+func (suite *TestSuite) CreateMCPServerWithFileService(devMode bool, fileContentService tools.FileContentService) {
+	suite.createMCPServerWithConfig(devMode, nil, fileContentService)
+}
+
+func (suite *TestSuite) createMCPServerWithConfig(devMode bool, searchService tools.SemanticSearchService, fileContentService tools.FileContentService) {
 	require.NotNil(suite.t, suite.logger, "Logger must be initialized")
 	require.NotEmpty(suite.t, suite.serverURL, "Server URL must be set")
 	require.NotEmpty(suite.t, suite.adminToken, "Admin token must be set")
@@ -163,7 +170,7 @@ func (suite *TestSuite) createMCPServerWithConfig(devMode bool, searchService to
 		},
 		PersonalAccessToken: suite.adminToken,
 	}
-	mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, searchService)
+	mcpServer, err := mcpserver.NewStdioServer(stdioConfig, suite.logger, searchService, fileContentService)
 	require.NoError(suite.t, err, "Failed to create MCP server")
 
 	suite.mcpServer = mcpServer

--- a/mcpserver/tools/files.go
+++ b/mcpserver/tools/files.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-agents/files"
+	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// FileContentService reads the text contents of Mattermost file attachments on
+// behalf of a user, enforcing that user's channel permissions. *files.Service
+// implements it directly for embedded servers; HTTPFileContentService calls back
+// to the plugin endpoint for external servers.
+type FileContentService interface {
+	GetContent(ctx context.Context, userID, fileID string, offset, limit int) (files.Content, error)
+}
+
+// ReadFileArgs represents arguments for the read_file tool.
+type ReadFileArgs struct {
+	FileID string `json:"file_id" jsonschema:"The ID of the file to read; use the File ID shown in the attached-file metadata,minLength=26,maxLength=26"`
+	Offset int    `json:"offset,omitempty" jsonschema:"Character offset to start reading from (default 0). Pass the next offset reported by a previous call to page through a large file."`
+	Limit  int    `json:"limit,omitempty" jsonschema:"Maximum number of characters to return (default 6000, capped at 20000)."`
+}
+
+// getFileTools returns the file-related tools.
+func (p *MattermostToolProvider) getFileTools() []MCPTool {
+	return []MCPTool{
+		{
+			Name:        "read_file",
+			Description: "Read the text contents of a Mattermost file attachment by its File ID. Large attachments in a conversation are shown to you as metadata (name, type, size, File ID) instead of inline content — call this tool with that File ID to read them. Returns extracted text for documents (PDF, Office) and the raw text for plain-text files. Supports ranged reads via offset and limit to page through large files. Parameters: file_id (required), offset (optional), limit (optional). Example: {\"file_id\": \"8xqzn3pfmtbyfkr9hqbw4hheoa\", \"offset\": 0, \"limit\": 6000}",
+			Schema:      NewJSONSchemaForAccessMode[ReadFileArgs](string(p.accessMode)),
+			Resolver:    p.toolReadFile,
+		},
+	}
+}
+
+// toolReadFile implements the read_file tool.
+func (p *MattermostToolProvider) toolReadFile(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
+	var args ReadFileArgs
+	if err := argsGetter(&args); err != nil {
+		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool read_file: %w", err)
+	}
+
+	if !model.IsValidId(args.FileID) {
+		return "invalid file_id format", fmt.Errorf("file_id must be a valid ID")
+	}
+
+	if p.fileContentService == nil {
+		return "file reading is not available", nil
+	}
+
+	content, err := p.fileContentService.GetContent(mcpContext.Ctx, mcpContext.UserID, args.FileID, args.Offset, args.Limit)
+	if err != nil {
+		if errors.Is(err, files.ErrForbidden) {
+			return "you do not have permission to read this file", nil
+		}
+		return "failed to read file", fmt.Errorf("error reading file %s: %w", args.FileID, err)
+	}
+
+	return formatFileContent(content), nil
+}
+
+// formatFileContent renders a ranged file read for the LLM, including paging
+// instructions when more content remains.
+func formatFileContent(c files.Content) string {
+	if !c.HasText {
+		return fmt.Sprintf("File %q (%s) has no extractable text content and cannot be read as text.", c.Name, c.MimeType)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "File: %s", c.Name)
+	if c.MimeType != "" {
+		fmt.Fprintf(&b, " (%s)", c.MimeType)
+	}
+	b.WriteString("\n")
+
+	end := c.Offset + c.Returned
+	fmt.Fprintf(&b, "Showing characters %d-%d of %d.", c.Offset, end, c.TotalRunes)
+	if c.HasMore {
+		fmt.Fprintf(&b, " More content remains; call read_file again with offset=%d to continue.", end)
+	}
+	b.WriteString("\n\n")
+	b.WriteString(c.Text)
+
+	return b.String()
+}

--- a/mcpserver/tools/files_http.go
+++ b/mcpserver/tools/files_http.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-agents/files"
+	"github.com/mattermost/mattermost-plugin-agents/mcpserver/auth"
+)
+
+// HTTPFileContentService reads file contents by calling back to the plugin API.
+// This allows external MCP servers (HTTP, Stdio) to read attachments while the
+// permission check and admin-API extraction stay inside the plugin.
+type HTTPFileContentService struct {
+	pluginURL string
+	client    *http.Client
+}
+
+// NewHTTPFileContentService creates a new HTTP-based file content service.
+// pluginURL should be the base URL to the plugin, e.g., "https://mattermost.example.com/plugins/mattermost-ai"
+func NewHTTPFileContentService(pluginURL string) *HTTPFileContentService {
+	return &HTTPFileContentService{
+		pluginURL: pluginURL,
+		client:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// httpFileContentRequest is the request body sent to the plugin endpoint.
+type httpFileContentRequest struct {
+	FileID string `json:"file_id"`
+	Offset int    `json:"offset,omitempty"`
+	Limit  int    `json:"limit,omitempty"`
+}
+
+// httpFileContentResponse is the response from the plugin endpoint.
+type httpFileContentResponse struct {
+	Name       string `json:"name"`
+	MimeType   string `json:"mime_type"`
+	TotalRunes int    `json:"total_runes"`
+	Offset     int    `json:"offset"`
+	Returned   int    `json:"returned"`
+	HasMore    bool   `json:"has_more"`
+	HasText    bool   `json:"has_text"`
+	Text       string `json:"text"`
+	Error      string `json:"error,omitempty"`
+}
+
+// GetContent reads a ranged slice of a file's text via the plugin's endpoint.
+func (s *HTTPFileContentService) GetContent(ctx context.Context, userID, fileID string, offset, limit int) (files.Content, error) {
+	bodyBytes, err := json.Marshal(httpFileContentRequest{FileID: fileID, Offset: offset, Limit: limit})
+	if err != nil {
+		return files.Content{}, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := s.pluginURL + "/api/v1/files/content"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return files.Content{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if token, ok := ctx.Value(auth.AuthTokenContextKey).(string); ok && token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if ctxUserID, ok := ctx.Value(auth.UserIDContextKey).(string); ok && ctxUserID != "" {
+		req.Header.Set("Mattermost-User-Id", ctxUserID)
+	} else if userID != "" {
+		req.Header.Set("Mattermost-User-Id", userID)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return files.Content{}, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return files.Content{}, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusForbidden {
+		return files.Content{}, files.ErrForbidden
+	}
+	if resp.StatusCode != http.StatusOK {
+		var errResp httpFileContentResponse
+		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
+			return files.Content{}, fmt.Errorf("read file failed: %s", errResp.Error)
+		}
+		return files.Content{}, fmt.Errorf("read file failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var out httpFileContentResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return files.Content{}, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return files.Content{
+		Name:       out.Name,
+		MimeType:   out.MimeType,
+		TotalRunes: out.TotalRunes,
+		Offset:     out.Offset,
+		Returned:   out.Returned,
+		HasMore:    out.HasMore,
+		HasText:    out.HasText,
+		Text:       out.Text,
+	}, nil
+}

--- a/mcpserver/tools/files_http_test.go
+++ b/mcpserver/tools/files_http_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-agents/files"
+	"github.com/mattermost/mattermost-plugin-agents/mcpserver/auth"
+)
+
+func TestHTTPFileContentService_GetContent(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverHandler  http.HandlerFunc
+		userID         string
+		ctxSetup       func(context.Context) context.Context
+		expectError    bool
+		expectForbid   bool
+		errorContains  string
+		validateResult func(t *testing.T, c files.Content)
+		validateReq    func(t *testing.T, r *http.Request)
+	}{
+		{
+			name: "successful read copies all fields",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(httpFileContentResponse{
+					Name: "report.pdf", MimeType: "application/pdf",
+					TotalRunes: 100, Offset: 6, Returned: 4, HasMore: true, HasText: true, Text: "wxyz",
+				})
+			},
+			validateResult: func(t *testing.T, c files.Content) {
+				assert.Equal(t, "report.pdf", c.Name)
+				assert.Equal(t, "application/pdf", c.MimeType)
+				assert.Equal(t, 100, c.TotalRunes)
+				assert.Equal(t, 6, c.Offset)
+				assert.Equal(t, 4, c.Returned)
+				assert.True(t, c.HasMore)
+				assert.True(t, c.HasText)
+				assert.Equal(t, "wxyz", c.Text)
+			},
+		},
+		{
+			name: "403 maps to ErrForbidden",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				_ = json.NewEncoder(w).Encode(httpFileContentResponse{Error: "no access"})
+			},
+			expectError:  true,
+			expectForbid: true,
+		},
+		{
+			name: "server error with JSON error body",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(httpFileContentResponse{Error: "extraction failed"})
+			},
+			expectError:   true,
+			errorContains: "extraction failed",
+		},
+		{
+			name: "server error with non-JSON body includes status",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte("bad gateway"))
+			},
+			expectError:   true,
+			errorContains: "502",
+		},
+		{
+			name: "invalid JSON success body is a parse error",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("{invalid json"))
+			},
+			expectError:   true,
+			errorContains: "failed to parse response",
+		},
+		{
+			name: "auth headers come from context when present",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(httpFileContentResponse{HasText: true})
+			},
+			userID: "param-user",
+			ctxSetup: func(ctx context.Context) context.Context {
+				ctx = context.WithValue(ctx, auth.AuthTokenContextKey, "test-bearer-token")
+				ctx = context.WithValue(ctx, auth.UserIDContextKey, "ctx-user")
+				return ctx
+			},
+			validateReq: func(t *testing.T, r *http.Request) {
+				assert.Equal(t, "Bearer test-bearer-token", r.Header.Get("Authorization"))
+				// The context user ID must win over the param to avoid trusting
+				// a caller-supplied identity over the authenticated one.
+				assert.Equal(t, "ctx-user", r.Header.Get("Mattermost-User-Id"))
+			},
+		},
+		{
+			name: "user id header falls back to the param when context lacks it",
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(httpFileContentResponse{HasText: true})
+			},
+			userID: "param-user",
+			validateReq: func(t *testing.T, r *http.Request) {
+				assert.Equal(t, "param-user", r.Header.Get("Mattermost-User-Id"))
+			},
+		},
+		{
+			name: "request carries file id and range to the correct endpoint",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				var req httpFileContentRequest
+				assert.NoError(t, json.Unmarshal(body, &req))
+				assert.Equal(t, "file-123", req.FileID)
+				assert.Equal(t, 12, req.Offset)
+				assert.Equal(t, 34, req.Limit)
+				_ = json.NewEncoder(w).Encode(httpFileContentResponse{HasText: true})
+			},
+			validateReq: func(t *testing.T, r *http.Request) {
+				assert.Equal(t, "/api/v1/files/content", r.URL.Path)
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.validateReq != nil {
+					tc.validateReq(t, r)
+				}
+				tc.serverHandler(w, r)
+			}))
+			defer server.Close()
+
+			svc := NewHTTPFileContentService(server.URL)
+
+			ctx := context.Background()
+			if tc.ctxSetup != nil {
+				ctx = tc.ctxSetup(ctx)
+			}
+
+			fileID := "file-123"
+			c, err := svc.GetContent(ctx, tc.userID, fileID, 12, 34)
+
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.expectForbid {
+					require.ErrorIs(t, err, files.ErrForbidden)
+				}
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.validateResult != nil {
+				tc.validateResult(t, c)
+			}
+		})
+	}
+}

--- a/mcpserver/tools/files_test.go
+++ b/mcpserver/tools/files_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-agents/files"
+	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+type fakeFileContentService struct {
+	content files.Content
+	err     error
+
+	gotUserID string
+	gotFileID string
+	gotOffset int
+	gotLimit  int
+}
+
+func (f *fakeFileContentService) GetContent(_ context.Context, userID, fileID string, offset, limit int) (files.Content, error) {
+	f.gotUserID = userID
+	f.gotFileID = fileID
+	f.gotOffset = offset
+	f.gotLimit = limit
+	return f.content, f.err
+}
+
+func argsGetterFor(t *testing.T, v any) llm.ToolArgumentGetter {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return func(target any) error { return json.Unmarshal(b, target) }
+}
+
+func TestToolReadFile(t *testing.T) {
+	validID := model.NewId()
+
+	tests := []struct {
+		name         string
+		fileID       string
+		service      FileContentService
+		wantErr      bool
+		wantResult   string   // exact match when set
+		wantContains []string // substring matches
+	}{
+		{
+			name:       "invalid file id",
+			fileID:     "too-short",
+			service:    &fakeFileContentService{},
+			wantErr:    true,
+			wantResult: "invalid file_id format",
+		},
+		{
+			name:       "service unavailable",
+			fileID:     validID,
+			service:    nil,
+			wantResult: "file reading is not available",
+		},
+		{
+			name:       "forbidden",
+			fileID:     validID,
+			service:    &fakeFileContentService{err: files.ErrForbidden},
+			wantResult: "you do not have permission to read this file",
+		},
+		{
+			name:   "success with paging instructions",
+			fileID: validID,
+			service: &fakeFileContentService{content: files.Content{
+				Name: "report.pdf", MimeType: "application/pdf",
+				TotalRunes: 100, Offset: 0, Returned: 6, HasMore: true, HasText: true,
+				Text: "abcdef",
+			}},
+			wantResult: "File: report.pdf (application/pdf)\n" +
+				"Showing characters 0-6 of 100. More content remains; call read_file again with offset=6 to continue.\n\n" +
+				"abcdef",
+		},
+		{
+			name:   "success without more content omits the paging hint",
+			fileID: validID,
+			service: &fakeFileContentService{content: files.Content{
+				Name: "report.pdf", MimeType: "application/pdf",
+				TotalRunes: 6, Offset: 0, Returned: 6, HasMore: false, HasText: true,
+				Text: "abcdef",
+			}},
+			wantResult: "File: report.pdf (application/pdf)\nShowing characters 0-6 of 6.\n\nabcdef",
+		},
+		{
+			name:   "success without a mime type omits the parenthetical",
+			fileID: validID,
+			service: &fakeFileContentService{content: files.Content{
+				Name: "notes", MimeType: "", TotalRunes: 2, Offset: 0, Returned: 2, HasText: true, Text: "hi",
+			}},
+			wantResult: "File: notes\nShowing characters 0-2 of 2.\n\nhi",
+		},
+		{
+			name:   "no extractable text",
+			fileID: validID,
+			service: &fakeFileContentService{content: files.Content{
+				Name: "archive.zip", MimeType: "application/zip", HasText: false,
+			}},
+			wantResult: `File "archive.zip" (application/zip) has no extractable text content and cannot be read as text.`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &MattermostToolProvider{fileContentService: tt.service}
+			ctx := &MCPToolContext{Ctx: context.Background(), UserID: model.NewId()}
+
+			result, err := p.toolReadFile(ctx, argsGetterFor(t, ReadFileArgs{FileID: tt.fileID}))
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.wantResult != "" {
+				assert.Equal(t, tt.wantResult, result)
+			}
+			for _, sub := range tt.wantContains {
+				assert.Contains(t, result, sub)
+			}
+		})
+	}
+}
+
+// TestToolReadFilePassesRequestingUser pins the permission-relevant contract:
+// the read flows the authenticated user's ID and the requested range through to
+// the content service, which is what enforces channel access.
+func TestToolReadFilePassesRequestingUser(t *testing.T) {
+	fake := &fakeFileContentService{content: files.Content{Name: "a.txt", HasText: true, Text: "hi"}}
+	p := &MattermostToolProvider{fileContentService: fake}
+
+	userID := model.NewId()
+	fileID := model.NewId()
+	ctx := &MCPToolContext{Ctx: context.Background(), UserID: userID}
+
+	_, err := p.toolReadFile(ctx, argsGetterFor(t, ReadFileArgs{FileID: fileID, Offset: 12, Limit: 34}))
+	require.NoError(t, err)
+
+	assert.Equal(t, userID, fake.gotUserID)
+	assert.Equal(t, fileID, fake.gotFileID)
+	assert.Equal(t, 12, fake.gotOffset)
+	assert.Equal(t, 34, fake.gotLimit)
+}

--- a/mcpserver/tools/provider.go
+++ b/mcpserver/tools/provider.go
@@ -67,19 +67,20 @@ type SemanticSearchService interface {
 
 // MattermostToolProvider provides Mattermost tools following the mmtools pattern
 type MattermostToolProvider struct {
-	authProvider     auth.AuthenticationProvider
-	logger           logger.Logger
-	mmServerURL      string // Mattermost server URL for API communication (internal URL if set, otherwise external)
-	devMode          bool
-	accessMode       AccessMode
-	trackAIGenerated bool                  // Whether to add ai_generated_by props to posts
-	searchService    SemanticSearchService // Optional semantic search service, can be nil
+	authProvider       auth.AuthenticationProvider
+	logger             logger.Logger
+	mmServerURL        string // Mattermost server URL for API communication (internal URL if set, otherwise external)
+	devMode            bool
+	accessMode         AccessMode
+	trackAIGenerated   bool                  // Whether to add ai_generated_by props to posts
+	searchService      SemanticSearchService // Optional semantic search service, can be nil
+	fileContentService FileContentService    // Optional file content service for read_file, can be nil
 }
 
 // NewMattermostToolProvider creates a new tool provider
 // Now accepts a ServerConfig interface to avoid circular dependencies
 // searchService is optional and can be nil if semantic search is not available
-func NewMattermostToolProvider(authProvider auth.AuthenticationProvider, logger logger.Logger, config types.ServerConfig, accessMode AccessMode, searchService SemanticSearchService) *MattermostToolProvider {
+func NewMattermostToolProvider(authProvider auth.AuthenticationProvider, logger logger.Logger, config types.ServerConfig, accessMode AccessMode, searchService SemanticSearchService, fileContentService FileContentService) *MattermostToolProvider {
 	// Use internal URL for API communication if provided, otherwise fallback to external URL
 	serverURL := config.GetMMInternalServerURL()
 	if serverURL == "" {
@@ -87,13 +88,14 @@ func NewMattermostToolProvider(authProvider auth.AuthenticationProvider, logger 
 	}
 
 	return &MattermostToolProvider{
-		authProvider:     authProvider,
-		logger:           logger,
-		mmServerURL:      serverURL,
-		devMode:          config.GetDevMode(),
-		accessMode:       accessMode,
-		trackAIGenerated: config.GetTrackAIGenerated(),
-		searchService:    searchService,
+		authProvider:       authProvider,
+		logger:             logger,
+		mmServerURL:        serverURL,
+		devMode:            config.GetDevMode(),
+		accessMode:         accessMode,
+		trackAIGenerated:   config.GetTrackAIGenerated(),
+		searchService:      searchService,
+		fileContentService: fileContentService,
 	}
 }
 
@@ -105,6 +107,7 @@ func (p *MattermostToolProvider) mcpTools() []MCPTool {
 	mcpTools = append(mcpTools, p.getChannelTools()...)
 	mcpTools = append(mcpTools, p.getTeamTools()...)
 	mcpTools = append(mcpTools, p.getSearchTools()...)
+	mcpTools = append(mcpTools, p.getFileTools()...)
 	mcpTools = append(mcpTools, p.getAgentTools()...)
 
 	// Automation tools are always registered; availability is checked dynamically

--- a/mcpserver/tools_eval_test.go
+++ b/mcpserver/tools_eval_test.go
@@ -436,7 +436,7 @@ func withFileDescriptor(userMessage string, fileInfo *model.FileInfo) string {
 	var b strings.Builder
 	b.WriteString(userMessage)
 	b.WriteString("\n\nAttached files (call the read_file tool with the File ID to read their contents):\n")
-	format.WriteFileDescriptor(&b, format.FileDescriptorEntry{HeaderLabel: "Attached File 1", FileInfo: fileInfo})
+	format.WriteFileDescriptor(&b, format.FileDescriptorEntry{Number: 1, FileInfo: fileInfo})
 	return b.String()
 }
 

--- a/mcpserver/tools_eval_test.go
+++ b/mcpserver/tools_eval_test.go
@@ -5,6 +5,7 @@ package mcpserver_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-plugin-agents/evals"
+	"github.com/mattermost/mattermost-plugin-agents/files"
+	"github.com/mattermost/mattermost-plugin-agents/format"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/prompts"
 	"github.com/mattermost/mattermost-plugin-agents/toolrunner"
@@ -402,5 +405,148 @@ func TestBroadcastDMToTeamFlowEval(t *testing.T) {
 				break
 			}
 		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// read_file Evals
+//
+// These exercise the lazy file-loading flow: an attachment is shown to the LLM
+// as a metadata descriptor (what conversation assembly emits for a large file),
+// and the LLM must call read_file to fetch the contents on demand. The user
+// asks are intentionally vague — no file names, IDs, or tool hints — so the
+// model has to connect intent to the attached file itself.
+// ---------------------------------------------------------------------------
+
+// getAdminUser returns the user the MCP session authenticates as (the file
+// content service trusts this identity for reads).
+func getAdminUser(t *testing.T, suite *TestSuite) *model.User {
+	t.Helper()
+	client := model.NewAPIv4Client(suite.serverURL)
+	client.SetToken(suite.adminToken)
+	user, _, err := client.GetMe(context.Background(), "")
+	require.NoError(t, err, "Failed to get admin user")
+	return user
+}
+
+// withFileDescriptor appends the production-style attached-file metadata block
+// (what conversation assembly shows the LLM for a non-inlined file) to a user
+// message, so the eval prompt matches what the model sees in production.
+func withFileDescriptor(userMessage string, fileInfo *model.FileInfo) string {
+	var b strings.Builder
+	b.WriteString(userMessage)
+	b.WriteString("\n\nAttached files (call the read_file tool with the File ID to read their contents):\n")
+	format.WriteFileDescriptor(&b, format.FileDescriptorEntry{HeaderLabel: "Attached File 1", FileInfo: fileInfo})
+	return b.String()
+}
+
+func fileEvalService(suite *TestSuite) *client4FileContentService {
+	return &client4FileContentService{serverURL: suite.serverURL, token: suite.adminToken}
+}
+
+// TestReadFileOnDemandFlowEval: given only metadata for an attached checklist,
+// the LLM must read it and surface a fact that exists only inside the file.
+func TestReadFileOnDemandFlowEval(t *testing.T) {
+	evals.NumEvalsOrSkip(t)
+
+	suite := SetupTestSuite(t)
+	defer suite.TearDown()
+
+	checklist := strings.Join([]string{
+		"Pre-launch checklist:",
+		"1. Freeze the deploy pipeline at 5pm Friday.",
+		"2. Notify the support team about the maintenance window.",
+		"3. Rotate the staging TLS certificate before the cutover.",
+		"4. Snapshot the primary database.",
+		"5. Update the public status page once traffic is migrated.",
+	}, "\n")
+
+	team, _, fileInfo := seedFileScenario(t, suite.serverURL, suite.adminToken, "launch-checklist.txt", []byte(checklist))
+	suite.CreateMCPServerWithFileService(false, fileEvalService(suite))
+	adminUser := getAdminUser(t, suite)
+
+	evals.Run(t, "read_file on-demand flow", func(e *evals.EvalT) {
+		runAgenticFlowEval(e, suite, adminUser, team,
+			withFileDescriptor(
+				// Vague, real-user phrasing: no file name, no ID, no mention of tools.
+				"I'm prepping for the Friday launch and I have a nagging feeling there's something I'm supposed to do with our certs beforehand. Can you check and remind me?",
+				fileInfo,
+			),
+			[]string{
+				"Mentions rotating (or renewing) the staging TLS certificate before the cutover",
+				"The answer is grounded in the attached checklist rather than generic launch advice",
+				"Does not claim it is unable to see, open, or read the attached file",
+			},
+			[]string{"read_file"},
+		)
+	})
+}
+
+// TestReadFilePagingFlowEval: the answer lives past a single read window, so the
+// LLM must page with offset to find it.
+func TestReadFilePagingFlowEval(t *testing.T) {
+	evals.NumEvalsOrSkip(t)
+
+	suite := SetupTestSuite(t)
+	defer suite.TearDown()
+
+	// Build a log well past the max single-read window so the model cannot get
+	// the planted secret in one call and must page with offset to reach the end.
+	var log strings.Builder
+	for i := 0; i < 1500; i++ {
+		fmt.Fprintf(&log, "2026-05-01T10:%02d:%02dZ [info] request %d handled in %dms\n", i%60, i%60, i, i%200)
+	}
+	log.WriteString("2026-05-01T11:00:00Z [warn] leaked credential detected: api_key=zephyr-9931-omega\n")
+	for i := 0; i < 50; i++ {
+		log.WriteString("2026-05-01T11:00:01Z [info] worker shutting down\n")
+	}
+	require.Greater(t, len([]rune(log.String())), files.MaxReadRunes, "log must exceed one read window to force paging")
+
+	team, _, fileInfo := seedFileScenario(t, suite.serverURL, suite.adminToken, "server-debug.txt", []byte(log.String()))
+	suite.CreateMCPServerWithFileService(false, fileEvalService(suite))
+	adminUser := getAdminUser(t, suite)
+
+	evals.Run(t, "read_file paging flow", func(e *evals.EvalT) {
+		runAgenticFlowEval(e, suite, adminUser, team,
+			withFileDescriptor(
+				"Someone told me an API key accidentally got dumped into that debug log I shared. Dig through it and tell me exactly what the leaked key is.",
+				fileInfo,
+			),
+			[]string{
+				"States the leaked API key value zephyr-9931-omega",
+				"Does not fabricate a different API key or claim that no key could be found",
+			},
+			[]string{"read_file"},
+		)
+	})
+}
+
+// TestReadFileUnreadableBinaryEval: a binary attachment has no extractable text,
+// so the LLM must say it cannot read it instead of inventing contents.
+func TestReadFileUnreadableBinaryEval(t *testing.T) {
+	evals.NumEvalsOrSkip(t)
+
+	suite := SetupTestSuite(t)
+	defer suite.TearDown()
+
+	// Bytes named .png are stored as image/png (extension-based), which has no
+	// server-extractable text — read_file reports no readable content.
+	pngBytes := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05}
+	team, _, fileInfo := seedFileScenario(t, suite.serverURL, suite.adminToken, "architecture.png", pngBytes)
+	suite.CreateMCPServerWithFileService(false, fileEvalService(suite))
+	adminUser := getAdminUser(t, suite)
+
+	evals.Run(t, "read_file unreadable binary", func(e *evals.EvalT) {
+		runAgenticFlowEval(e, suite, adminUser, team,
+			withFileDescriptor(
+				"Can you take a look at the file I just dropped in and give me a quick rundown of what's in it?",
+				fileInfo,
+			),
+			[]string{
+				"Indicates it cannot read or extract the text contents of the file",
+				"Does not invent or describe specific contents of the file",
+			},
+			[]string{"read_file"},
+		)
 	})
 }

--- a/server/embedded_mcp_server.go
+++ b/server/embedded_mcp_server.go
@@ -24,8 +24,9 @@ type EmbeddedMCPServer struct {
 }
 
 // NewEmbeddedMCPServer creates a new embedded MCP server instance
-// searchService is optional and can be nil if semantic search is not available
-func NewEmbeddedMCPServer(pluginAPI *pluginapi.Client, logger pluginapi.LogService, searchService tools.SemanticSearchService) (*EmbeddedMCPServer, error) {
+// searchService and fileContentService are optional and can be nil when the
+// corresponding capability is unavailable
+func NewEmbeddedMCPServer(pluginAPI *pluginapi.Client, logger pluginapi.LogService, searchService tools.SemanticSearchService, fileContentService tools.FileContentService) (*EmbeddedMCPServer, error) {
 	// Get site URL from plugin configuration
 	siteURL := ""
 	if config := pluginAPI.Configuration.GetConfig(); config != nil && config.ServiceSettings.SiteURL != nil {
@@ -58,7 +59,7 @@ func NewEmbeddedMCPServer(pluginAPI *pluginapi.Client, logger pluginapi.LogServi
 	mcpLogger := NewPluginAPILoggerAdapter(logger)
 
 	// Create the in-memory MCP server
-	server, err := mcpserver.NewInMemoryServer(config, mcpLogger, searchService)
+	server, err := mcpserver.NewInMemoryServer(config, mcpLogger, searchService, fileContentService)
 	if err != nil {
 		return nil, err
 	}

--- a/server/inmemory_basic_test.go
+++ b/server/inmemory_basic_test.go
@@ -22,7 +22,7 @@ func TestInMemoryServerCreation(t *testing.T) {
 	mcpLogger, err := logger.CreateLoggerWithOptions(false, "")
 	require.NoError(t, err)
 
-	server, err := mcpserver.NewInMemoryServer(config, mcpLogger, nil)
+	server, err := mcpserver.NewInMemoryServer(config, mcpLogger, nil, nil)
 	require.NoError(t, err)
 
 	// Test creating a client transport (without validation by passing nil resolver)

--- a/server/main.go
+++ b/server/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/customprompts"
 	"github.com/mattermost/mattermost-plugin-agents/embeddings"
 	"github.com/mattermost/mattermost-plugin-agents/enterprise"
+	"github.com/mattermost/mattermost-plugin-agents/files"
 	"github.com/mattermost/mattermost-plugin-agents/i18n"
 	"github.com/mattermost/mattermost-plugin-agents/indexer"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
@@ -383,8 +384,9 @@ func (p *Plugin) OnActivate() error {
 
 	// Embedded MCP is always available after PR #617, even if older configs still
 	// have the legacy toggle stored as false.
+	fileContentService := files.New(mmClient)
 	var embeddedMCPServer mcp.EmbeddedMCPServer
-	embeddedMCPServer, err = NewEmbeddedMCPServer(pluginAPI, pluginAPI.Log, searchService)
+	embeddedMCPServer, err = NewEmbeddedMCPServer(pluginAPI, pluginAPI.Log, searchService, fileContentService)
 	if err != nil {
 		pluginAPI.Log.Error("Failed to create embedded MCP server", "error", err)
 		// Continue without embedded server
@@ -402,7 +404,7 @@ func (p *Plugin) OnActivate() error {
 	}
 	mcpClientManager := mcp.NewClientManager(p.configuration.MCP(), pluginAPI.Log, pluginAPI, mcp.NewOAuthManager(mmClient, oauthCallbackURL, untrustedHTTPClient, serverConfigLookup), embeddedMCPServer, untrustedHTTPClient, mmClient)
 	p.configuration.RegisterUpdateListener(func() {
-		embeddedServer, embeddedErr := NewEmbeddedMCPServer(pluginAPI, pluginAPI.Log, searchService)
+		embeddedServer, embeddedErr := NewEmbeddedMCPServer(pluginAPI, pluginAPI.Log, searchService, fileContentService)
 		if embeddedErr != nil {
 			pluginAPI.Log.Error("Failed to create embedded MCP server on config update", "error", embeddedErr)
 		}


### PR DESCRIPTION
#### Summary

Large file attachments were inlined into the LLM context on every turn — the dominant cause of context-window blowouts (a single 5 MB text file is ~1.25M tokens, re-sent on every turn, after which truncation drops whole posts). This PR makes file loading lazy:

- **Small files** (≤ 8 KiB of readable text) are still inlined directly, to avoid an extra round trip.
- **Larger files** are shown to the LLM as a compact metadata descriptor (name, type, size, File ID) instead of their contents. The model fetches the text on demand via a new `read_file` MCP tool with ranged reads, so a large document costs almost nothing until it's actually needed. Once fetched, the tool result persists in conversation history, so it isn't re-read on later turns.

`read_file` lives on the embedded Mattermost MCP server, backed by a new authenticated plugin endpoint (`POST /api/v1/files/content`). This is necessary because the server-extracted text of PDFs/Office docs (`FileInfo.Content`) is never returned over the core REST API, so it must be read plugin-side with an explicit per-user channel-permission check. `read_file` is vetted to **auto-run in DMs** (no approval needed, matching the previous auto-inline UX), but **asks before running in a channel** — it only verifies the requesting user's own file access, not that the file belongs to the current thread, so auto-running it where other members would see the result is gated behind approval.

Images are unchanged (their token cost is negligible on modern context windows).

##### QA test steps
1. DM a bot a small `.txt` → its contents are still inlined (no tool call).
2. DM a bot a large `.txt` and a PDF → the prompt shows only metadata; ask about them → the bot calls `read_file` and answers from the contents; a follow-up turn does not re-fetch.
3. Verify a file you can access is readable, and a file in a channel you cannot access is refused.
4. `make evals-ci` (or `GOEVALS=1 LLM_PROVIDER=anthropic go test ./mcpserver/ -run TestReadFile`) — three agentic evals cover on-demand reads, paging through a large file, and unreadable binaries.

#### Ticket Link
NONE

#### Release Note
```release-note
Large file attachments are now loaded into the AI context on demand via a new read_file tool instead of being inlined automatically, sharply reducing context-window usage for conversations with attachments. Added an authenticated plugin API endpoint POST /api/v1/files/content.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read_file tool for on‑demand retrieval of file attachment text (respecting user channel permissions).
  * Supports paginated/ranged reads, rune-aware slicing, and automatic extraction from PDFs/Office with text/* fallback.
  * Introduced descriptor-only metadata for large or binary attachments and an “Attached files” descriptor section to enable lazy on‑demand reads.
  * read_file included in Mattermost‑vetted auto-run-in-DM tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
