### PR TITLE
Cherry pick mm 67913

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "support_url": "https://github.com/mattermost/mattermost-plugin-agents/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-agents",
   "icon_path": "assets/bot_icon.png",
-  "min_server_version": "6.2.1",
+  "min_server_version": "11.7.3",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/webapp/src/components/agents/agents_page.tsx
+++ b/webapp/src/components/agents/agents_page.tsx
@@ -15,19 +15,14 @@ export const AGENTS_ROUTE = `/plug/${manifest.id}/agents`;
 // No URL-matching or overlay needed; Mattermost's product routing handles it.
 const AgentsPage = () => {
     useEffect(() => {
-        // ChannelController normally sets these classes, but it's not loaded in
-        // product views. Without them the global header loses its themed colors.
-        // Playbooks and Boards do the same thing in their top-level components.
-        document.body.classList.add('app__body');
+        // The host webapp owns `app__body` on document.body (see MM-67913 / Boards #188).
+        // ChannelController normally sets `channel-view` on #root, but it's not loaded in
+        // product views. Without it the global header loses its themed colors.
 
         const root = document.getElementById('root');
         if (root && !root.classList.contains('channel-view')) {
             root.classList.add('channel-view');
         }
-
-        return () => {
-            document.body.classList.remove('app__body');
-        };
     }, []);
 
     return (


### PR DESCRIPTION


#### Summary
Cherry pick https://github.com/mattermost/mattermost/pull/36774
#### Ticket Link
<!--
If applicable, please include both or either of the following links:

Fixes https://github.com/mattermost/mattermost/issues/XXX
Jira https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum required Mattermost server version to 11.7.3 to ensure compatibility with the latest platform features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->