### PR TITLE
Add diagnostics data to Support Packet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,8 @@ require (
 	golang.org/x/net v0.53.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.36.0
+	github.com/hashicorp/go-multierror v1.1.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-shiori/go-readability v0.0.0-20251205110129-5db1dc9836f0
 	github.com/google/jsonschema-go v0.4.2
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.12.0
 	github.com/mattermost/mattermost/server/public v0.3.1-0.20260402155910-d9d71af83e3f
@@ -34,7 +35,6 @@ require (
 	golang.org/x/net v0.53.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.36.0
-	github.com/hashicorp/go-multierror v1.1.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -123,7 +123,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -228,7 +227,6 @@ require (
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.67.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/server/support_packet.go
+++ b/server/support_packet.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
+	"github.com/mattermost/mattermost-plugin-agents/telemetry"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 )
@@ -18,12 +19,12 @@ import (
 type SupportPacket struct {
 	Version string `yaml:"version"`
 
-	// Agent counts
-	TotalAgents int `yaml:"total_agents"`
+	// Agent counts — omitted (not printed) when the DB query fails.
+	TotalAgents *int `yaml:"total_agents,omitempty"`
 
 	// LLM service configuration (no secrets)
-	TotalLLMServices      int      `yaml:"total_llm_services"`
-	LLMServiceTypes       []string `yaml:"llm_service_types"`
+	TotalLLMServices int      `yaml:"total_llm_services"`
+	LLMServiceTypes  []string `yaml:"llm_service_types"`
 
 	// MCP configuration
 	MCPEnabled        bool `yaml:"mcp_enabled"`
@@ -45,9 +46,12 @@ func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, erro
 
 	cfg := p.configuration.Config()
 
+	var totalAgents *int
 	agentCount, err := p.store.CountActiveAgents()
 	if err != nil {
 		result = multierror.Append(result, errors.Wrap(err, "failed to get agent count for Support Packet"))
+	} else {
+		totalAgents = &agentCount
 	}
 
 	serviceTypes := make([]string, 0, len(cfg.Services))
@@ -62,13 +66,15 @@ func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, erro
 		}
 	}
 
+	telemetryMode := telemetry.OutputMode(cfg.TelemetryOutput)
+
 	packet := SupportPacket{
 		Version: manifest.Version,
 
-		TotalAgents: agentCount,
+		TotalAgents: totalAgents,
 
-		TotalLLMServices:      len(cfg.Services),
-		LLMServiceTypes:       serviceTypes,
+		TotalLLMServices: len(cfg.Services),
+		LLMServiceTypes:  serviceTypes,
 
 		MCPEnabled:        cfg.MCP.Enabled,
 		TotalMCPServers:   len(cfg.MCP.Servers),
@@ -80,7 +86,7 @@ func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, erro
 		AllowNativeWebSearchInChannels:  cfg.AllowNativeWebSearchInChannels,
 		WebSearchEnabled:                cfg.WebSearch.Enabled,
 		EmbeddingSearchEnabled:          cfg.EmbeddingSearchConfig.Type != "",
-		TelemetryEnabled:                cfg.TelemetryOutput != "",
+		TelemetryEnabled:                telemetryMode != "" && telemetryMode != telemetry.OutputModeOff,
 	}
 
 	body, err := yaml.Marshal(packet)

--- a/server/support_packet.go
+++ b/server/support_packet.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+)
+
+// SupportPacket contains diagnostics data included in the Mattermost Support Packet.
+type SupportPacket struct {
+	Version string `yaml:"version"`
+
+	// Agent counts
+	TotalAgents int `yaml:"total_agents"`
+
+	// LLM service configuration (no secrets)
+	TotalLLMServices      int      `yaml:"total_llm_services"`
+	LLMServiceTypes       []string `yaml:"llm_service_types"`
+
+	// MCP configuration
+	MCPEnabled        bool `yaml:"mcp_enabled"`
+	TotalMCPServers   int  `yaml:"total_mcp_servers"`
+	EnabledMCPServers int  `yaml:"enabled_mcp_servers"`
+
+	// Feature flags
+	EnableCallSummary               bool `yaml:"enable_call_summary"`
+	EnableTokenUsageLogging         bool `yaml:"enable_token_usage_logging"`
+	EnableChannelMentionToolCalling bool `yaml:"enable_channel_mention_tool_calling"`
+	AllowNativeWebSearchInChannels  bool `yaml:"allow_native_web_search_in_channels"`
+	WebSearchEnabled                bool `yaml:"web_search_enabled"`
+	EmbeddingSearchEnabled          bool `yaml:"embedding_search_enabled"`
+	TelemetryEnabled                bool `yaml:"telemetry_enabled"`
+}
+
+func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, error) {
+	var result *multierror.Error
+
+	cfg := p.configuration.Config()
+
+	agentCount, err := p.store.CountActiveAgents()
+	if err != nil {
+		result = multierror.Append(result, errors.Wrap(err, "failed to get agent count for Support Packet"))
+	}
+
+	serviceTypes := make([]string, 0, len(cfg.Services))
+	for _, svc := range cfg.Services {
+		serviceTypes = append(serviceTypes, svc.Type)
+	}
+
+	enabledMCPServers := 0
+	for _, s := range cfg.MCP.Servers {
+		if s.Enabled {
+			enabledMCPServers++
+		}
+	}
+
+	packet := SupportPacket{
+		Version: manifest.Version,
+
+		TotalAgents: agentCount,
+
+		TotalLLMServices:      len(cfg.Services),
+		LLMServiceTypes:       serviceTypes,
+
+		MCPEnabled:        cfg.MCP.Enabled,
+		TotalMCPServers:   len(cfg.MCP.Servers),
+		EnabledMCPServers: enabledMCPServers,
+
+		EnableCallSummary:               cfg.EnableCallSummary,
+		EnableTokenUsageLogging:         cfg.EnableTokenUsageLogging,
+		EnableChannelMentionToolCalling: cfg.EnableChannelMentionToolCalling,
+		AllowNativeWebSearchInChannels:  cfg.AllowNativeWebSearchInChannels,
+		WebSearchEnabled:                cfg.WebSearch.Enabled,
+		EmbeddingSearchEnabled:          cfg.EmbeddingSearchConfig.Type != "",
+		TelemetryEnabled:                cfg.TelemetryOutput != "",
+	}
+
+	body, err := yaml.Marshal(packet)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal diagnostics")
+	}
+
+	return []*model.FileData{{
+		Filename: filepath.Join(manifest.Id, "diagnostics.yaml"),
+		Body:     body,
+	}}, result.ErrorOrNil()
+}

--- a/server/support_packet.go
+++ b/server/support_packet.go
@@ -10,10 +10,16 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
+	"github.com/mattermost/mattermost-plugin-agents/config"
 	"github.com/mattermost/mattermost-plugin-agents/telemetry"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 )
+
+// agentCounter is the subset of the store used by support packet generation.
+type agentCounter interface {
+	CountActiveAgents() (int, error)
+}
 
 // SupportPacket contains diagnostics data included in the Mattermost Support Packet.
 type SupportPacket struct {
@@ -42,12 +48,30 @@ type SupportPacket struct {
 }
 
 func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, error) {
+	packet, err := buildSupportPacket(p.store, p.configuration.Config(), manifest.Version)
+	if err != nil {
+		// Non-fatal: return whatever partial data we have.
+		p.pluginAPI.Log.Warn("Support packet generated with errors", "error", err)
+	}
+
+	body, marshalErr := yaml.Marshal(packet)
+	if marshalErr != nil {
+		return nil, errors.Wrap(marshalErr, "failed to marshal diagnostics")
+	}
+
+	return []*model.FileData{{
+		Filename: filepath.Join(manifest.Id, "diagnostics.yaml"),
+		Body:     body,
+	}}, err
+}
+
+// buildSupportPacket assembles the diagnostics struct from config and the store.
+// It returns a partially-populated packet alongside any non-fatal errors.
+func buildSupportPacket(store agentCounter, cfg *config.Config, version string) (*SupportPacket, error) {
 	var result *multierror.Error
 
-	cfg := p.configuration.Config()
-
 	var totalAgents *int
-	agentCount, err := p.store.CountActiveAgents()
+	agentCount, err := store.CountActiveAgents()
 	if err != nil {
 		result = multierror.Append(result, errors.Wrap(err, "failed to get agent count for Support Packet"))
 	} else {
@@ -68,8 +92,8 @@ func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, erro
 
 	telemetryMode := telemetry.OutputMode(cfg.TelemetryOutput)
 
-	packet := SupportPacket{
-		Version: manifest.Version,
+	return &SupportPacket{
+		Version: version,
 
 		TotalAgents: totalAgents,
 
@@ -87,15 +111,5 @@ func (p *Plugin) GenerateSupportData(_ *plugin.Context) ([]*model.FileData, erro
 		WebSearchEnabled:                cfg.WebSearch.Enabled,
 		EmbeddingSearchEnabled:          cfg.EmbeddingSearchConfig.Type != "",
 		TelemetryEnabled:                telemetryMode != "" && telemetryMode != telemetry.OutputModeOff,
-	}
-
-	body, err := yaml.Marshal(packet)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal diagnostics")
-	}
-
-	return []*model.FileData{{
-		Filename: filepath.Join(manifest.Id, "diagnostics.yaml"),
-		Body:     body,
-	}}, result.ErrorOrNil()
+	}, result.ErrorOrNil()
 }

--- a/server/support_packet_test.go
+++ b/server/support_packet_test.go
@@ -48,120 +48,117 @@ func fullTestConfig() *config.Config {
 	}
 }
 
-func TestBuildSupportPacket_HappyPath(t *testing.T) {
-	store := stubAgentCounter{count: 7}
-	cfg := fullTestConfig()
+func TestBuildSupportPacket(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		store := stubAgentCounter{count: 7}
+		cfg := fullTestConfig()
 
-	packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
+		packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
 
-	require.NoError(t, err)
-	require.NotNil(t, packet)
+		require.NoError(t, err)
+		require.NotNil(t, packet)
 
-	assert.Equal(t, 7, *packet.TotalAgents)
-	assert.Equal(t, 2, packet.TotalLLMServices)
-	assert.Equal(t, []string{"openai", "anthropic"}, packet.LLMServiceTypes)
-	assert.True(t, packet.MCPEnabled)
-	assert.Equal(t, 3, packet.TotalMCPServers)
-	assert.Equal(t, 2, packet.EnabledMCPServers)
-	assert.True(t, packet.EnableCallSummary)
-	assert.True(t, packet.EnableTokenUsageLogging)
-	assert.True(t, packet.EnableChannelMentionToolCalling)
-	assert.True(t, packet.AllowNativeWebSearchInChannels)
-	assert.True(t, packet.WebSearchEnabled)
-	assert.True(t, packet.EmbeddingSearchEnabled)
-	assert.True(t, packet.TelemetryEnabled)
-}
+		assert.Equal(t, 7, *packet.TotalAgents)
+		assert.Equal(t, 2, packet.TotalLLMServices)
+		assert.Equal(t, []string{"openai", "anthropic"}, packet.LLMServiceTypes)
+		assert.True(t, packet.MCPEnabled)
+		assert.Equal(t, 3, packet.TotalMCPServers)
+		assert.Equal(t, 2, packet.EnabledMCPServers)
+		assert.True(t, packet.EnableCallSummary)
+		assert.True(t, packet.EnableTokenUsageLogging)
+		assert.True(t, packet.EnableChannelMentionToolCalling)
+		assert.True(t, packet.AllowNativeWebSearchInChannels)
+		assert.True(t, packet.WebSearchEnabled)
+		assert.True(t, packet.EmbeddingSearchEnabled)
+		assert.True(t, packet.TelemetryEnabled)
+	})
 
-func TestBuildSupportPacket_StoreError(t *testing.T) {
-	store := stubAgentCounter{err: errors.New("db unavailable")}
-	cfg := fullTestConfig()
+	t.Run("store error omits agent count but returns other fields", func(t *testing.T) {
+		store := stubAgentCounter{err: errors.New("db unavailable")}
+		cfg := fullTestConfig()
 
-	packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
+		packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "db unavailable")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db unavailable")
 
-	// Packet is still returned with all config-derived fields populated.
-	require.NotNil(t, packet)
-	assert.Nil(t, packet.TotalAgents, "TotalAgents must be omitted when the count fails")
-	assert.Equal(t, 2, packet.TotalLLMServices)
-	assert.True(t, packet.TelemetryEnabled)
+		require.NotNil(t, packet)
+		assert.Nil(t, packet.TotalAgents, "TotalAgents must be omitted when the count fails")
+		assert.Equal(t, 2, packet.TotalLLMServices)
+		assert.True(t, packet.TelemetryEnabled)
 
-	// Verify TotalAgents is absent from the marshalled YAML.
-	body, marshalErr := yaml.Marshal(packet)
-	require.NoError(t, marshalErr)
-	assert.NotContains(t, string(body), "total_agents")
-}
+		body, marshalErr := yaml.Marshal(packet)
+		require.NoError(t, marshalErr)
+		assert.NotContains(t, string(body), "total_agents")
+	})
 
-func TestBuildSupportPacket_TelemetryEnabled(t *testing.T) {
-	tests := []struct {
-		telemetryOutput string
-		wantEnabled     bool
-	}{
-		{"", false},
-		{"off", false},
-		{"logs", true},
-		{"otlp", true},
-	}
+	t.Run("telemetry enabled flag", func(t *testing.T) {
+		tests := []struct {
+			telemetryOutput string
+			wantEnabled     bool
+		}{
+			{"", false},
+			{"off", false},
+			{"logs", true},
+			{"otlp", true},
+		}
 
-	store := stubAgentCounter{count: 0}
+		store := stubAgentCounter{}
+		for _, tt := range tests {
+			t.Run(tt.telemetryOutput, func(t *testing.T) {
+				cfg := &config.Config{TelemetryOutput: tt.telemetryOutput}
+				packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantEnabled, packet.TelemetryEnabled)
+			})
+		}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.telemetryOutput, func(t *testing.T) {
-			cfg := &config.Config{TelemetryOutput: tt.telemetryOutput}
-			packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantEnabled, packet.TelemetryEnabled)
-		})
-	}
-}
+	t.Run("embedding search enabled flag", func(t *testing.T) {
+		tests := []struct {
+			embeddingType string
+			wantEnabled   bool
+		}{
+			{"", false},
+			{"postgres", true},
+			{"other", true},
+		}
 
-func TestBuildSupportPacket_EmbeddingSearchEnabled(t *testing.T) {
-	tests := []struct {
-		embeddingType string
-		wantEnabled   bool
-	}{
-		{"", false},
-		{"postgres", true},
-		{"other", true},
-	}
+		store := stubAgentCounter{}
+		for _, tt := range tests {
+			t.Run(tt.embeddingType, func(t *testing.T) {
+				cfg := &config.Config{
+					EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{Type: tt.embeddingType},
+				}
+				packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantEnabled, packet.EmbeddingSearchEnabled)
+			})
+		}
+	})
 
-	store := stubAgentCounter{count: 0}
+	t.Run("MCP server counting", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			servers     []config.MCPServerConfig
+			wantTotal   int
+			wantEnabled int
+		}{
+			{"no servers", nil, 0, 0},
+			{"all disabled", []config.MCPServerConfig{{Enabled: false}, {Enabled: false}}, 2, 0},
+			{"all enabled", []config.MCPServerConfig{{Enabled: true}, {Enabled: true}}, 2, 2},
+			{"mixed", []config.MCPServerConfig{{Enabled: true}, {Enabled: false}, {Enabled: true}}, 3, 2},
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.embeddingType, func(t *testing.T) {
-			cfg := &config.Config{
-				EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{Type: tt.embeddingType},
-			}
-			packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantEnabled, packet.EmbeddingSearchEnabled)
-		})
-	}
-}
-
-func TestBuildSupportPacket_MCPServerCounting(t *testing.T) {
-	tests := []struct {
-		name            string
-		servers         []config.MCPServerConfig
-		wantTotal       int
-		wantEnabled     int
-	}{
-		{"no servers", nil, 0, 0},
-		{"all disabled", []config.MCPServerConfig{{Enabled: false}, {Enabled: false}}, 2, 0},
-		{"all enabled", []config.MCPServerConfig{{Enabled: true}, {Enabled: true}}, 2, 2},
-		{"mixed", []config.MCPServerConfig{{Enabled: true}, {Enabled: false}, {Enabled: true}}, 3, 2},
-	}
-
-	store := stubAgentCounter{count: 0}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config.Config{MCP: config.MCPConfig{Servers: tt.servers}}
-			packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantTotal, packet.TotalMCPServers)
-			assert.Equal(t, tt.wantEnabled, packet.EnabledMCPServers)
-		})
-	}
+		store := stubAgentCounter{}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				cfg := &config.Config{MCP: config.MCPConfig{Servers: tt.servers}}
+				packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantTotal, packet.TotalMCPServers)
+				assert.Equal(t, tt.wantEnabled, packet.EnabledMCPServers)
+			})
+		}
+	})
 }

--- a/server/support_packet_test.go
+++ b/server/support_packet_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/mattermost/mattermost-plugin-agents/config"
+	"github.com/mattermost/mattermost-plugin-agents/embeddings"
+	"github.com/mattermost/mattermost-plugin-agents/llm"
+)
+
+// stubAgentCounter is a minimal agentCounter for support packet tests.
+type stubAgentCounter struct {
+	count int
+	err   error
+}
+
+func (s stubAgentCounter) CountActiveAgents() (int, error) { return s.count, s.err }
+
+func fullTestConfig() *config.Config {
+	return &config.Config{
+		Services: []llm.ServiceConfig{
+			{Type: "openai"},
+			{Type: "anthropic"},
+		},
+		MCP: config.MCPConfig{
+			Enabled: true,
+			Servers: []config.MCPServerConfig{
+				{Name: "server-a", Enabled: true},
+				{Name: "server-b", Enabled: false},
+				{Name: "server-c", Enabled: true},
+			},
+		},
+		EnableCallSummary:               true,
+		EnableTokenUsageLogging:         true,
+		EnableChannelMentionToolCalling: true,
+		AllowNativeWebSearchInChannels:  true,
+		WebSearch:                       config.WebSearchConfig{Enabled: true},
+		EmbeddingSearchConfig:           embeddings.EmbeddingSearchConfig{Type: "postgres"},
+		TelemetryOutput:                 "logs",
+	}
+}
+
+func TestBuildSupportPacket_HappyPath(t *testing.T) {
+	store := stubAgentCounter{count: 7}
+	cfg := fullTestConfig()
+
+	packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
+
+	require.NoError(t, err)
+	require.NotNil(t, packet)
+
+	assert.Equal(t, 7, *packet.TotalAgents)
+	assert.Equal(t, 2, packet.TotalLLMServices)
+	assert.Equal(t, []string{"openai", "anthropic"}, packet.LLMServiceTypes)
+	assert.True(t, packet.MCPEnabled)
+	assert.Equal(t, 3, packet.TotalMCPServers)
+	assert.Equal(t, 2, packet.EnabledMCPServers)
+	assert.True(t, packet.EnableCallSummary)
+	assert.True(t, packet.EnableTokenUsageLogging)
+	assert.True(t, packet.EnableChannelMentionToolCalling)
+	assert.True(t, packet.AllowNativeWebSearchInChannels)
+	assert.True(t, packet.WebSearchEnabled)
+	assert.True(t, packet.EmbeddingSearchEnabled)
+	assert.True(t, packet.TelemetryEnabled)
+}
+
+func TestBuildSupportPacket_StoreError(t *testing.T) {
+	store := stubAgentCounter{err: errors.New("db unavailable")}
+	cfg := fullTestConfig()
+
+	packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db unavailable")
+
+	// Packet is still returned with all config-derived fields populated.
+	require.NotNil(t, packet)
+	assert.Nil(t, packet.TotalAgents, "TotalAgents must be omitted when the count fails")
+	assert.Equal(t, 2, packet.TotalLLMServices)
+	assert.True(t, packet.TelemetryEnabled)
+
+	// Verify TotalAgents is absent from the marshalled YAML.
+	body, marshalErr := yaml.Marshal(packet)
+	require.NoError(t, marshalErr)
+	assert.NotContains(t, string(body), "total_agents")
+}
+
+func TestBuildSupportPacket_TelemetryEnabled(t *testing.T) {
+	tests := []struct {
+		telemetryOutput string
+		wantEnabled     bool
+	}{
+		{"", false},
+		{"off", false},
+		{"logs", true},
+		{"otlp", true},
+	}
+
+	store := stubAgentCounter{count: 0}
+
+	for _, tt := range tests {
+		t.Run(tt.telemetryOutput, func(t *testing.T) {
+			cfg := &config.Config{TelemetryOutput: tt.telemetryOutput}
+			packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEnabled, packet.TelemetryEnabled)
+		})
+	}
+}
+
+func TestBuildSupportPacket_EmbeddingSearchEnabled(t *testing.T) {
+	tests := []struct {
+		embeddingType string
+		wantEnabled   bool
+	}{
+		{"", false},
+		{"postgres", true},
+		{"other", true},
+	}
+
+	store := stubAgentCounter{count: 0}
+
+	for _, tt := range tests {
+		t.Run(tt.embeddingType, func(t *testing.T) {
+			cfg := &config.Config{
+				EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{Type: tt.embeddingType},
+			}
+			packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEnabled, packet.EmbeddingSearchEnabled)
+		})
+	}
+}
+
+func TestBuildSupportPacket_MCPServerCounting(t *testing.T) {
+	tests := []struct {
+		name            string
+		servers         []config.MCPServerConfig
+		wantTotal       int
+		wantEnabled     int
+	}{
+		{"no servers", nil, 0, 0},
+		{"all disabled", []config.MCPServerConfig{{Enabled: false}, {Enabled: false}}, 2, 0},
+		{"all enabled", []config.MCPServerConfig{{Enabled: true}, {Enabled: true}}, 2, 2},
+		{"mixed", []config.MCPServerConfig{{Enabled: true}, {Enabled: false}, {Enabled: true}}, 3, 2},
+	}
+
+	store := stubAgentCounter{count: 0}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{MCP: config.MCPConfig{Servers: tt.servers}}
+			packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTotal, packet.TotalMCPServers)
+			assert.Equal(t, tt.wantEnabled, packet.EnabledMCPServers)
+		})
+	}
+}

--- a/server/support_packet_test.go
+++ b/server/support_packet_test.go
@@ -94,18 +94,19 @@ func TestBuildSupportPacket(t *testing.T) {
 
 	t.Run("telemetry enabled flag", func(t *testing.T) {
 		tests := []struct {
+			name            string
 			telemetryOutput string
 			wantEnabled     bool
 		}{
-			{"", false},
-			{"off", false},
-			{"logs", true},
-			{"otlp", true},
+			{"empty", "", false},
+			{"off", "off", false},
+			{"logs", "logs", true},
+			{"otlp", "otlp", true},
 		}
 
 		store := stubAgentCounter{}
 		for _, tt := range tests {
-			t.Run(tt.telemetryOutput, func(t *testing.T) {
+			t.Run(tt.name, func(t *testing.T) {
 				cfg := &config.Config{TelemetryOutput: tt.telemetryOutput}
 				packet, err := buildSupportPacket(store, cfg, "1.0.0-test")
 				require.NoError(t, err)
@@ -116,17 +117,18 @@ func TestBuildSupportPacket(t *testing.T) {
 
 	t.Run("embedding search enabled flag", func(t *testing.T) {
 		tests := []struct {
+			name          string
 			embeddingType string
 			wantEnabled   bool
 		}{
-			{"", false},
-			{"postgres", true},
-			{"other", true},
+			{"empty", "", false},
+			{"postgres", "postgres", true},
+			{"other", "other", true},
 		}
 
 		store := stubAgentCounter{}
 		for _, tt := range tests {
-			t.Run(tt.embeddingType, func(t *testing.T) {
+			t.Run(tt.name, func(t *testing.T) {
 				cfg := &config.Config{
 					EmbeddingSearchConfig: embeddings.EmbeddingSearchConfig{Type: tt.embeddingType},
 				}


### PR DESCRIPTION
Implements GenerateSupportData to populate the Mattermost Support Packet
with plugin diagnostics: agent count, LLM service inventory, MCP server
counts, and feature-flag states. No secrets are exposed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added diagnostic support-packet generation that exports system diagnostics as a YAML file, including plugin version, optional agent counts, LLM and MCP service summaries, and telemetry/feature-flag indicators.

- **Tests**
  - Added comprehensive tests for packet generation covering success, agent-count failures, telemetry behavior, embedding-search flagging, and MCP server counting.

- **Chores**
  - Moved select dependencies from indirect to direct declarations in module requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->