### PR TITLE
webapp: fix crash on null bot channelIDs in channel filtering

### DIFF
--- a/webapp/src/bots.tsx
+++ b/webapp/src/bots.tsx
@@ -23,7 +23,7 @@ export interface LLMBot {
     lastIconUpdate: number;
     dmChannelID: string;
     channelAccessLevel: ChannelAccessLevel;
-    channelIDs: string[];
+    channelIDs: string[] | null; // backend omits/nulls this when no channels are configured
     userAccessLevel: UserAccessLevel;
     userIDs: string[];
     teamIDs: string[];
@@ -94,9 +94,10 @@ export const useBotlistForChannel = (channelId: string) => {
         }
 
         const filtered = bots.filter((bot: LLMBot) => {
+            const channelIDs = bot.channelIDs ?? [];
             return bot.channelAccessLevel === ChannelAccessLevel.All ||
-				(bot.channelAccessLevel === ChannelAccessLevel.Allow && bot.channelIDs.includes(channelId)) ||
-				(bot.channelAccessLevel === ChannelAccessLevel.Block && !bot.channelIDs.includes(channelId));
+				(bot.channelAccessLevel === ChannelAccessLevel.Allow && channelIDs.includes(channelId)) ||
+				(bot.channelAccessLevel === ChannelAccessLevel.Block && !channelIDs.includes(channelId));
         });
 
         setFilteredBots(filtered);

--- a/webapp/src/components/system_console/bot.tsx
+++ b/webapp/src/components/system_console/bot.tsx
@@ -44,7 +44,7 @@ export type LLMBotConfig = {
     enableVision: boolean
     disableTools: boolean
     channelAccessLevel: ChannelAccessLevel
-    channelIDs: string[]
+    channelIDs: string[] | null // backend omits/nulls this when no channels are configured
     userAccessLevel: UserAccessLevel
     userIDs: string[]
     teamIDs: string[]

--- a/webapp/src/types/agents.ts
+++ b/webapp/src/types/agents.ts
@@ -39,7 +39,7 @@ export type UserAgent = {
     enableVision: boolean;
     disableTools: boolean;
     channelAccessLevel: ChannelAccessLevel;
-    channelIDs: string[];
+    channelIDs: string[] | null; // backend omits/nulls this when no channels are configured
     userAccessLevel: UserAccessLevel;
     userIDs: string[];
     teamIDs: string[];


### PR DESCRIPTION
#### Summary
Fixes a production crash in the webapp: `TypeError: can't access property "includes", e.channelIDs is null`. The error originates in the `mattermost-ai` bundle and propagates through React, taking down the whole client (other plugins like `com.mattermost.agenda` just catch the same thrown error in their global handlers).

Root cause: `useBotlistForChannel` in `webapp/src/bots.tsx` filters bots with `bot.channelIDs.includes(channelId)`. The `LLMBot` type declared `channelIDs: string[]`, but the backend can send `null` when a bot has no channels configured. For any bot with `channelAccessLevel` of `Allow` or `Block`, `null.includes(...)` throws. This runs in a `useEffect` reached on the channel route, so it crashes on render.

Changes:
- **Runtime guard**: `const channelIDs = bot.channelIDs ?? []` before the `.includes()` calls. Semantics are preserved — a `null`/empty list means "no channels listed", so `Allow` matches nowhere and `Block` blocks nowhere.
- **Type fix**: changed `channelIDs: string[]` to `string[] | null` on the three types that mirror this backend field — `LLMBot` (`bots.tsx`), `UserAgent` (`types/agents.ts`), and `LLMBotConfig` (`system_console/bot.tsx`). All other read sites already guarded with `?? []`; this makes the type honest so the unguarded `.includes()` is now a compile error and the bug can't silently return.

QA test steps:
1. Configure a bot/agent with channel access level set to "Allow" or "Block" and no channels selected (so the backend stores `null`/empty `channelIDs`).
2. Open a channel in the webapp.
3. Before: the client crashes with the `TypeError` above. After: the channel and AI controls load normally.

#### Ticket Link
NONE

#### Screenshots
NONE — no visual changes; this fixes a render-time crash.

#### Release Note
```release-note
Fixed a crash that could take down the webapp when a bot or agent had no channels configured for its channel access level.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot and user agent channel configuration handling to properly support cases where channels may be absent or undefined. The system now robustly manages channel filtering and configuration operations in all scenarios, preventing potential errors and ensuring reliable, consistent behaviour throughout the application when channel configurations are omitted or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->