### PR TITLE
Cherry-pick #795 to release-2.0

### DIFF
--- a/webapp/src/bots.tsx
+++ b/webapp/src/bots.tsx
@@ -23,7 +23,7 @@ export interface LLMBot {
     lastIconUpdate: number;
     dmChannelID: string;
     channelAccessLevel: ChannelAccessLevel;
-    channelIDs: string[];
+    channelIDs: string[] | null; // backend omits/nulls this when no channels are configured
     userAccessLevel: UserAccessLevel;
     userIDs: string[];
     teamIDs: string[];
@@ -94,9 +94,10 @@ export const useBotlistForChannel = (channelId: string) => {
         }
 
         const filtered = bots.filter((bot: LLMBot) => {
+            const channelIDs = bot.channelIDs ?? [];
             return bot.channelAccessLevel === ChannelAccessLevel.All ||
-				(bot.channelAccessLevel === ChannelAccessLevel.Allow && bot.channelIDs.includes(channelId)) ||
-				(bot.channelAccessLevel === ChannelAccessLevel.Block && !bot.channelIDs.includes(channelId));
+				(bot.channelAccessLevel === ChannelAccessLevel.Allow && channelIDs.includes(channelId)) ||
+				(bot.channelAccessLevel === ChannelAccessLevel.Block && !channelIDs.includes(channelId));
         });
 
         setFilteredBots(filtered);

--- a/webapp/src/components/system_console/bot.tsx
+++ b/webapp/src/components/system_console/bot.tsx
@@ -44,7 +44,7 @@ export type LLMBotConfig = {
     enableVision: boolean
     disableTools: boolean
     channelAccessLevel: ChannelAccessLevel
-    channelIDs: string[]
+    channelIDs: string[] | null // backend omits/nulls this when no channels are configured
     userAccessLevel: UserAccessLevel
     userIDs: string[]
     teamIDs: string[]

--- a/webapp/src/types/agents.ts
+++ b/webapp/src/types/agents.ts
@@ -39,7 +39,7 @@ export type UserAgent = {
     enableVision: boolean;
     disableTools: boolean;
     channelAccessLevel: ChannelAccessLevel;
-    channelIDs: string[];
+    channelIDs: string[] | null; // backend omits/nulls this when no channels are configured
     userAccessLevel: UserAccessLevel;
     userIDs: string[];
     teamIDs: string[];


### PR DESCRIPTION
#### Summary
Cherry-pick of https://github.com/mattermost/mattermost-plugin-agents/commit/4722e85f1d76bd14584a8d728cc39af519da4a83 to release-2.0.

#### Ticket Link
Original PR: https://github.com/mattermost/mattermost-plugin-agents/pull/795

#### Screenshots
N/A

#### Release Note
```release-note
Fixed a crash when filtering bot channels with missing channel ID data.
```

Made with [Cursor](https://cursor.com)