### PR TITLE
MM-67913: keep app__body on Agents page

### DIFF
--- a/webapp/src/components/agents/agents_page.test.tsx
+++ b/webapp/src/components/agents/agents_page.test.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+
+import AgentsPage from './agents_page';
+
+jest.mock('@/manifest', () => ({
+    __esModule: true,
+    default: {id: 'mattermost-ai'},
+}));
+
+jest.mock('./agents_license_gate', () => ({
+    __esModule: true,
+    default: ({children}: {children: React.ReactNode}) => <>{children}</>,
+}));
+
+jest.mock('./agents_list', () => ({
+    __esModule: true,
+    default: () => <div data-testid='agents-list'/>,
+}));
+
+describe('AgentsPage', () => {
+    beforeEach(() => {
+        document.body.classList.remove('app__body');
+        document.body.innerHTML = '<div id="root"></div>';
+    });
+
+    afterEach(() => {
+        document.body.classList.remove('app__body');
+        document.body.innerHTML = '';
+    });
+
+    test('adds app classes on mount and leaves them after unmount', () => {
+        expect(document.body.classList.contains('app__body')).toBe(false);
+        expect(document.getElementById('root')?.classList.contains('channel-view')).toBe(false);
+
+        const {unmount} = render(<AgentsPage/>);
+
+        expect(screen.getByTestId('agents-list')).not.toBeNull();
+        expect(document.body.classList.contains('app__body')).toBe(true);
+        expect(document.getElementById('root')?.classList.contains('channel-view')).toBe(true);
+
+        unmount();
+
+        expect(document.body.classList.contains('app__body')).toBe(true);
+        expect(document.getElementById('root')?.classList.contains('channel-view')).toBe(true);
+    });
+});

--- a/webapp/src/components/agents/agents_page.tsx
+++ b/webapp/src/components/agents/agents_page.tsx
@@ -11,17 +11,12 @@ import AgentsList from './agents_list';
 
 export const AGENTS_ROUTE = `/plug/${manifest.id}/agents`;
 
-// Product mainComponent — rendered by registerProduct when the route matches.
-// No URL-matching or overlay needed; Mattermost's product routing handles it.
 const AgentsPage = () => {
     useEffect(() => {
-        // The host webapp owns `app__body` on document.body (see MM-67913 / Boards #188).
-        // ChannelController normally sets `channel-view` on #root, but it's not loaded in
-        // product views. Without it the global header loses its themed colors.
         const root = document.getElementById('root');
-        if (root && !root.classList.contains('channel-view')) {
-            root.classList.add('channel-view');
-        }
+
+        document.body.classList.add('app__body');
+        root?.classList.add('channel-view');
     }, []);
 
     return (


### PR DESCRIPTION
#### Summary
Keeps the Agents product page compatible with Mattermost versions where the host webapp still depends on `document.body.app__body` for header theming. The page now sticky-adds `app__body` on mount and keeps `channel-view` on `#root` without cleaning either class up on unmount.

Added a focused Jest test covering the sticky add/no-cleanup behavior. `plugin.json` remains at `min_server_version: "6.2.1"`.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67913

#### Screenshots
N/A

#### Release Note
```release-note
Fixed Agents product page header styling on older compatible Mattermost server versions.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive testing for the Agents page component to ensure styling classes are properly applied during initialization and correctly maintained throughout the complete component lifecycle.

* **Refactor**
  * Enhanced overall code quality by streamlining the styling class application process, eliminating unnecessary logic whilst maintaining all existing functionality and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->