### PR TITLE
MM-67913: keep app__body on Agents page

### DIFF
--- a/webapp/src/components/agents/agents_page.test.tsx
+++ b/webapp/src/components/agents/agents_page.test.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+
+import AgentsPage from './agents_page';
+
+jest.mock('@/manifest', () => ({
+    __esModule: true,
+    default: {id: 'mattermost-ai'},
+}), {virtual: true});
+
+jest.mock('./agents_license_gate', () => ({
+    __esModule: true,
+    default: ({children}: {children: React.ReactNode}) => <>{children}</>,
+}));
+
+jest.mock('./agents_list', () => ({
+    __esModule: true,
+    default: () => <div data-testid='agents-list'/>,
+}));
+
+describe('AgentsPage', () => {
+    beforeEach(() => {
+        document.body.classList.remove('app__body');
+        document.body.innerHTML = '<div id="root"></div>';
+    });
+
+    afterEach(() => {
+        document.body.classList.remove('app__body');
+        document.body.innerHTML = '';
+    });
+
+    test('adds app classes on mount and leaves them after unmount', () => {
+        expect(document.body.classList.contains('app__body')).toBe(false);
+        expect(document.getElementById('root')?.classList.contains('channel-view')).toBe(false);
+
+        const {unmount} = render(<AgentsPage/>);
+
+        expect(screen.getByTestId('agents-list')).not.toBeNull();
+        expect(document.body.classList.contains('app__body')).toBe(true);
+        expect(document.getElementById('root')?.classList.contains('channel-view')).toBe(true);
+
+        unmount();
+
+        expect(document.body.classList.contains('app__body')).toBe(true);
+        expect(document.getElementById('root')?.classList.contains('channel-view')).toBe(true);
+    });
+});

--- a/webapp/src/components/agents/agents_page.tsx
+++ b/webapp/src/components/agents/agents_page.tsx
@@ -24,10 +24,6 @@ const AgentsPage = () => {
         if (root && !root.classList.contains('channel-view')) {
             root.classList.add('channel-view');
         }
-
-        return () => {
-            document.body.classList.remove('app__body');
-        };
     }, []);
 
     return (


### PR DESCRIPTION
#### Summary
Backports the `app__body` compatibility fix to `release-2.0` without increasing the plugin minimum server version. The Agents product page now sticky-adds `document.body.app__body` and keeps `#root.channel-view` for header theming, with no cleanup that would remove `app__body` after navigation.

Added a focused Jest regression test for the sticky add/no-cleanup behavior. `plugin.json` remains at `min_server_version: "6.2.1"`.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67913

#### Screenshots
N/A

#### Release Note
```release-note
Fixed Agents product page header styling on older compatible Mattermost server versions.
```

Made with [Cursor](https://cursor.com)