### PR TITLE
Notify core when AI post menu opens

### DIFF
--- a/webapp/src/components/post_menu.tsx
+++ b/webapp/src/components/post_menu.tsx
@@ -27,6 +27,7 @@ import {DropdownBotSelector} from './bot_selector';
 
 type Props = {
     post: Post,
+    handleDropdownOpened?: (open: boolean) => void,
 }
 
 const PostMenu = (props: Props) => {
@@ -56,6 +57,7 @@ const PostMenu = (props: Props) => {
             title={intl.formatMessage({defaultMessage: 'AI Actions'})}
             dropdownMenu={StyledDropdownMenu}
             testId='ai-actions-menu'
+            onOpenChange={props.handleDropdownOpened}
         >
             <DropdownBotSelector
                 bots={bots ?? []}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Reports the AI post menu open state to Mattermost core so the menu stays mounted while users move the mouse to another post.

Companion Mattermost core PR: https://github.com/mattermost/mattermost/pull/36991

QA: Opened the Agents plugin AI Actions menu on one post, hovered another post, and confirmed the menu stayed open.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-68323

#### Screenshots
<a href="https://cursor.com/agents/bc-896f105e-4916-4a0f-9678-f15d18b05d3b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagents_plugin_menu_hover_persistence_clean_demo.mp4"><img src="https://cursor.com/artifacts/c/art-784b4386-82d3-472e-8342-9370d1bea887" alt="agents_plugin_menu_hover_persistence_clean_demo.mp4" /></a>

![Agents menu stays open while hovering another post](https://cursor.com/artifacts/c/art-1bc23c59-822d-461b-9fb9-e496281d1746)

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-896f105e-4916-4a0f-9678-f15d18b05d3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-896f105e-4916-4a0f-9678-f15d18b05d3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved menu interactions and component communication for better responsiveness to dropdown state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->