### PR TITLE
fix: honor responses API toggle for native tools

### DIFF
--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -1585,10 +1585,24 @@ func (b *LLM) providerSupportsNativeTools() bool {
 	return supportsNativeToolsProvider(b.provider)
 }
 
+func (b *LLM) providerCanAutoUseResponsesAPI() bool {
+	switch b.provider {
+	case schemas.OpenAI, schemas.Azure:
+		// Direct OpenAI always sets useResponsesAPI. OpenAI-compatible and Azure
+		// services must not have native tools silently override their service toggle.
+		return b.useResponsesAPI
+	default:
+		return true
+	}
+}
+
 // shouldUseResponsesAPI determines if the Responses API should be used for this request.
 func (b *LLM) shouldUseResponsesAPI(cfg llm.LanguageModelConfig) bool {
 	if b.useResponsesAPI {
 		return true
+	}
+	if !b.providerCanAutoUseResponsesAPI() {
+		return false
 	}
 	if b.providerSupportsNativeTools() && len(b.enabledNativeTools) > 0 {
 		return true

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -538,21 +538,29 @@ func TestShouldUseResponsesAPI(t *testing.T) {
 		expected           bool
 	}{
 		{
-			name:               "native tools configured returns true",
+			name:               "OpenAI native tools require Responses API service flag",
 			provider:           schemas.OpenAI,
+			enabledNativeTools: []string{"web_search"},
+			expected:           false,
+		},
+		{
+			name:               "OpenAI native tools with Responses API service flag returns true",
+			provider:           schemas.OpenAI,
+			useResponsesAPI:    true,
 			enabledNativeTools: []string{"web_search"},
 			expected:           true,
 		},
 		{
-			name:               "NativeWebSearchAllowed with web_search enabled returns true",
+			name:               "OpenAI NativeWebSearchAllowed requires Responses API service flag",
 			provider:           schemas.OpenAI,
 			enabledNativeTools: []string{"web_search"},
 			cfg:                llm.LanguageModelConfig{NativeWebSearchAllowed: true},
-			expected:           true,
+			expected:           false,
 		},
 		{
-			name:               "NativeWebSearchAllowed without web_search in tools returns true",
+			name:               "OpenAI NativeWebSearchAllowed with Responses API service flag returns true",
 			provider:           schemas.OpenAI,
+			useResponsesAPI:    true,
 			enabledNativeTools: nil,
 			cfg:                llm.LanguageModelConfig{NativeWebSearchAllowed: true},
 			expected:           true,

--- a/bifrost/config.go
+++ b/bifrost/config.go
@@ -78,6 +78,27 @@ func filterNativeToolsForServiceType(serviceType string, tools []string) []strin
 	return filtered
 }
 
+func serviceAllowsNativeTools(svc llm.ServiceConfig) bool {
+	switch svc.Type {
+	case llm.ServiceTypeOpenAI, llm.ServiceTypeAnthropic, llm.ServiceTypeGemini, llm.ServiceTypeVertex:
+		return true
+	case llm.ServiceTypeOpenAICompatible, llm.ServiceTypeAzure:
+		return llm.ServiceUsesResponsesAPI(svc)
+	default:
+		return false
+	}
+}
+
+func nativeToolsForService(svc llm.ServiceConfig, tools []string) []string {
+	if len(tools) == 0 {
+		return tools
+	}
+	if !serviceAllowsNativeTools(svc) {
+		return []string{}
+	}
+	return filterNativeToolsForServiceType(svc.Type, tools)
+}
+
 // NewFromServiceConfig creates a LLM instance from ServiceConfig and BotConfig.
 // fallbackServices is an ordered slice of fallback services resolved from the
 // primary service's fallback chain (see llm.ResolveFallbackChain). Each fallback
@@ -105,7 +126,7 @@ func NewFromServiceConfig(serviceConfig llm.ServiceConfig, botConfig llm.BotConf
 		UseResponsesAPI:  llm.ServiceUsesResponsesAPI(serviceConfig),
 
 		// Bot-specific configuration
-		EnabledNativeTools: filterNativeToolsForServiceType(serviceConfig.Type, botConfig.EnabledNativeTools),
+		EnabledNativeTools: nativeToolsForService(serviceConfig, botConfig.EnabledNativeTools),
 		ReasoningEnabled:   botConfig.ReasoningEnabled,
 		ReasoningEffort:    botConfig.ReasoningEffort,
 		ThinkingBudget:     botConfig.ThinkingBudget,

--- a/bifrost/config_test.go
+++ b/bifrost/config_test.go
@@ -64,6 +64,53 @@ func TestFilterNativeToolsForServiceType(t *testing.T) {
 	}
 }
 
+func TestNativeToolsForService(t *testing.T) {
+	tools := []string{"web_search"}
+
+	tests := []struct {
+		name string
+		svc  llm.ServiceConfig
+		want []string
+	}{
+		{
+			name: "OpenAI compatible without Responses API drops stale native tools",
+			svc:  llm.ServiceConfig{Type: llm.ServiceTypeOpenAICompatible, UseResponsesAPI: false},
+			want: []string{},
+		},
+		{
+			name: "OpenAI compatible with Responses API keeps native tools",
+			svc:  llm.ServiceConfig{Type: llm.ServiceTypeOpenAICompatible, UseResponsesAPI: true},
+			want: tools,
+		},
+		{
+			name: "Azure without Responses API drops stale native tools",
+			svc:  llm.ServiceConfig{Type: llm.ServiceTypeAzure, UseResponsesAPI: false},
+			want: []string{},
+		},
+		{
+			name: "OpenAI direct keeps native tools",
+			svc:  llm.ServiceConfig{Type: llm.ServiceTypeOpenAI, UseResponsesAPI: false},
+			want: tools,
+		},
+		{
+			name: "Anthropic keeps native tools",
+			svc:  llm.ServiceConfig{Type: llm.ServiceTypeAnthropic, UseResponsesAPI: false},
+			want: tools,
+		},
+		{
+			name: "unsupported service drops native tools",
+			svc:  llm.ServiceConfig{Type: llm.ServiceTypeCohere, UseResponsesAPI: true},
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nativeToolsForService(tt.svc, tools)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestNewFromServiceConfigOpenAIForcesResponsesAPI(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -95,6 +142,25 @@ func TestNewFromServiceConfigOpenAIForcesResponsesAPI(t *testing.T) {
 			assert.Equal(t, tt.wantUseResponsesAPI, llmInstance.useResponsesAPI)
 		})
 	}
+}
+
+func TestNewFromServiceConfigFiltersNativeToolsWhenResponsesAPIDisabled(t *testing.T) {
+	service := llm.ServiceConfig{
+		ID:              "test",
+		Type:            llm.ServiceTypeOpenAICompatible,
+		APIKey:          "key",
+		APIURL:          "http://localhost",
+		UseResponsesAPI: false,
+	}
+	bot := llm.BotConfig{
+		EnabledNativeTools: []string{"web_search"},
+	}
+
+	llmInstance, err := NewFromServiceConfig(service, bot, nil)
+	require.NoError(t, err)
+	defer llmInstance.Shutdown()
+
+	assert.Empty(t, llmInstance.enabledNativeTools)
 }
 
 // TestNewFromServiceConfigPropagatesInputTokenLimit pins the contract that a

--- a/bots/bot.go
+++ b/bots/bot.go
@@ -52,6 +52,9 @@ func (b *Bot) HasNativeWebSearchEnabled() bool {
 	if !bifrost.SupportsNativeTools(b.service.Type) {
 		return false
 	}
+	if !llm.ServiceUsesResponsesAPI(b.service) && (b.service.Type == llm.ServiceTypeOpenAICompatible || b.service.Type == llm.ServiceTypeAzure) {
+		return false
+	}
 	for _, tool := range b.cfg.EnabledNativeTools {
 		if tool == "web_search" {
 			return true

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -1079,3 +1079,25 @@ func TestHasNativeWebSearchEnabledSupportedServiceType(t *testing.T) {
 	)
 	require.True(t, b.HasNativeWebSearchEnabled())
 }
+
+func TestHasNativeWebSearchEnabledOpenAICompatibleRequiresResponsesAPI(t *testing.T) {
+	tests := []struct {
+		name            string
+		useResponsesAPI bool
+		want            bool
+	}{
+		{name: "disabled", useResponsesAPI: false, want: false},
+		{name: "enabled", useResponsesAPI: true, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBot(
+				llm.BotConfig{EnabledNativeTools: []string{"web_search"}},
+				llm.ServiceConfig{Type: llm.ServiceTypeOpenAICompatible, UseResponsesAPI: tt.useResponsesAPI},
+				&model.Bot{UserId: "b1"},
+				nil,
+			)
+			require.Equal(t, tt.want, b.HasNativeWebSearchEnabled())
+		})
+	}
+}

--- a/webapp/src/components/agents/tabs/config_tab.tsx
+++ b/webapp/src/components/agents/tabs/config_tab.tsx
@@ -41,6 +41,23 @@ type Props = {
 const visionToolServiceTypes = ['openai', 'openaicompatible', 'azure', 'anthropic', 'cohere', 'mistral', 'gemini', 'vertex'];
 const openAIStructuredOutputServiceTypes = ['openai', 'openaicompatible', 'azure'];
 
+function serviceSupportsNativeTools(service?: Pick<ServiceInfo, 'type' | 'useResponsesAPI'>): boolean {
+    if (!service) {
+        return false;
+    }
+    if (service.type === 'openai' || service.type === 'anthropic' || service.type === 'gemini' || service.type === 'vertex') {
+        return true;
+    }
+    if (service.type === 'openaicompatible' || service.type === 'azure') {
+        return service.useResponsesAPI;
+    }
+    return false;
+}
+
+function defaultNativeToolsForService(service?: Pick<ServiceInfo, 'type' | 'useResponsesAPI'>): string[] {
+    return serviceSupportsNativeTools(service) ? ['web_search'] : [];
+}
+
 const ConfigTab = (props: Props) => {
     const {draft, onChange, onAvatarChange, services, errors = {}, usernameLocked = false} = props;
     const intl = useIntl();
@@ -73,7 +90,7 @@ const ConfigTab = (props: Props) => {
                 ...(sameServiceType ?
                     {} :
                     {
-                        enabledNativeTools: ['web_search'],
+                        enabledNativeTools: defaultNativeToolsForService(nextSvc),
                         reasoningEnabled: true,
                         reasoningEffort: 'medium',
                         thinkingBudget: 0,
@@ -85,6 +102,13 @@ const ConfigTab = (props: Props) => {
     }, [draft.serviceId, onChange, services]);
 
     const selectedService = services.find((s) => s.id === draft.serviceId);
+    const supportsNativeTools = serviceSupportsNativeTools(selectedService);
+
+    useEffect(() => {
+        if (selectedService && !supportsNativeTools && draft.enabledNativeTools.length > 0) {
+            onChange({enabledNativeTools: []});
+        }
+    }, [draft.enabledNativeTools.length, onChange, selectedService, supportsNativeTools]);
 
     const supportsModelFetching = Boolean(selectedService &&
         (selectedService.type === 'anthropic' ||

--- a/webapp/src/components/system_console/bot.tsx
+++ b/webapp/src/components/system_console/bot.tsx
@@ -148,6 +148,19 @@ type ModelInfo = {
     displayName: string
 }
 
+function serviceSupportsNativeTools(service?: LLMService): boolean {
+    if (!service) {
+        return false;
+    }
+    if (service.type === 'openai' || service.type === 'anthropic' || service.type === 'gemini' || service.type === 'vertex') {
+        return true;
+    }
+    if (service.type === 'openaicompatible' || service.type === 'azure') {
+        return service.useResponsesAPI;
+    }
+    return false;
+}
+
 const Bot = (props: Props) => {
     const [open, setOpen] = useState(false);
     const intl = useIntl();
@@ -161,6 +174,8 @@ const Bot = (props: Props) => {
 
     // Find the selected service
     const selectedService = props.services.find((s) => s.id === props.bot.serviceID);
+    const supportsNativeTools = serviceSupportsNativeTools(selectedService);
+    const enabledNativeToolsLength = (props.bot.enabledNativeTools || []).length;
     const supportsModelFetching = selectedService &&
         (selectedService.type === 'anthropic' ||
          selectedService.type === 'openai' ||
@@ -168,6 +183,12 @@ const Bot = (props: Props) => {
          selectedService.type === 'openaicompatible' ||
          selectedService.type === 'gemini' ||
          selectedService.type === 'vertex');
+
+    useEffect(() => {
+        if (selectedService && !supportsNativeTools && enabledNativeToolsLength > 0) {
+            props.onChange({...props.bot, enabledNativeTools: []});
+        }
+    }, [enabledNativeToolsLength, props.bot, props.onChange, selectedService, supportsNativeTools]);
 
     // Fetch models when the service changes
     useEffect(() => {


### PR DESCRIPTION
#### Summary
Fixes OpenAI Compatible and Azure services with Use Responses API disabled still routing through `/v1/responses` when an agent had stale native tool configuration.

- Treat OpenAI-compatible/Azure `Use Responses API=false` as a hard limit for native-tool-triggered Responses API routing.
- Filter stale native tools out when constructing the Bifrost LLM config.
- Prevent native web search request options from re-enabling Responses API for those services.
- Clear hidden native tool selections in both the Agents UI and legacy System Console bot form when the selected service does not support native tools.

Validation:
- `go test ./bifrost -run 'Test(NativeToolsForService|NewFromServiceConfig(OpenAIForcesResponsesAPI|FiltersNativeTools|FiltersNativeToolsWhenResponsesAPIDisabled)|ShouldUseResponsesAPI)'`
- `go test ./bots -run 'TestHasNativeWebSearchEnabled'`
- `npm --prefix webapp run check-types`
- `npm --prefix webapp run lint -- --no-cache`

Note: full `go test ./bifrost ./bots` leaves existing `TestEnvProxyRouting` failing in this environment because the request is not tunneled through the configured proxy; `./bots` passes.

#### Ticket Link
NONE

#### Screenshots
NONE

#### Release Note
```release-note
Fixed OpenAI Compatible and Azure services with Responses API disabled still routing through the Responses API when agents had stale native tool configuration.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Native web search and tools now properly validate LLM service API compatibility before enabling, preventing activation on unsupported services
* Improved validation logic to automatically clear incompatible tool settings when switching between services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->