### PR TITLE
webapp: refresh agent quota header after deleting last visible agent

### DIFF
--- a/webapp/src/components/agents/agents_list.test.tsx
+++ b/webapp/src/components/agents/agents_list.test.tsx
@@ -78,13 +78,13 @@ jest.mock('./delete_agent_dialog', () => ({
                 type='button'
                 onClick={onConfirm}
             >
-                Confirm delete
+                {'Confirm delete'}
             </button>
             <button
                 type='button'
                 onClick={onCancel}
             >
-                Cancel delete
+                {'Cancel delete'}
             </button>
         </div>
     ),
@@ -194,10 +194,10 @@ describe('AgentsList delete quota refresh', () => {
 
     test('refetches quota after deleting last visible agent and re-enables Create when server count is 0', async () => {
         mockUseIsMultiLLMLicensed.mockReturnValue(false);
-        mockGetAgents
-            .mockResolvedValueOnce({agents: [makeAgent('a1')], activeAgentCount: 1})
-            .mockResolvedValueOnce({agents: [], activeAgentCount: 0});
-        mockDeleteAgent.mockResolvedValue(undefined);
+        mockGetAgents.
+            mockResolvedValueOnce({agents: [makeAgent('a1')], activeAgentCount: 1}).
+            mockResolvedValueOnce({agents: [], activeAgentCount: 0});
+        mockDeleteAgent.mockImplementation(() => Promise.resolve());
 
         renderList();
 
@@ -213,10 +213,10 @@ describe('AgentsList delete quota refresh', () => {
 
     test('refetches quota after delete and keeps Create disabled when invisible agents remain', async () => {
         mockUseIsMultiLLMLicensed.mockReturnValue(false);
-        mockGetAgents
-            .mockResolvedValueOnce({agents: [makeAgent('a1')], activeAgentCount: 1})
-            .mockResolvedValueOnce({agents: [], activeAgentCount: 1});
-        mockDeleteAgent.mockResolvedValue(undefined);
+        mockGetAgents.
+            mockResolvedValueOnce({agents: [makeAgent('a1')], activeAgentCount: 1}).
+            mockResolvedValueOnce({agents: [], activeAgentCount: 1});
+        mockDeleteAgent.mockImplementation(() => Promise.resolve());
 
         renderList();
 

--- a/webapp/src/components/agents/agents_list.test.tsx
+++ b/webapp/src/components/agents/agents_list.test.tsx
@@ -2,10 +2,10 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {render, screen, waitFor} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {useSelector} from 'react-redux';
 
-import {getAgents, getServices} from '@/client';
+import {deleteAgent, getAgents, getServices} from '@/client';
 import {useIsMultiLLMLicensed} from '@/license';
 import {userHasSystemPermission} from '@/utils/permissions';
 import {UserAgent} from '@/types/agents';
@@ -52,7 +52,17 @@ jest.mock('@/utils/permissions', () => ({
 
 jest.mock('./agent_row', () => ({
     __esModule: true,
-    default: ({agent}: {agent: UserAgent}) => <div data-testid='agent-row'>{agent.displayName}</div>,
+    default: ({agent, onDelete}: {agent: UserAgent; onDelete: (agent: UserAgent) => void}) => (
+        <div data-testid='agent-row'>
+            {agent.displayName}
+            <button
+                type='button'
+                onClick={() => onDelete(agent)}
+            >
+                {`Delete ${agent.displayName}`}
+            </button>
+        </div>
+    ),
 }));
 
 jest.mock('./agent_config_view', () => ({
@@ -62,13 +72,29 @@ jest.mock('./agent_config_view', () => ({
 
 jest.mock('./delete_agent_dialog', () => ({
     __esModule: true,
-    default: () => null,
+    default: ({onConfirm, onCancel}: {onConfirm: () => void; onCancel: () => void}) => (
+        <div data-testid='delete-agent-dialog'>
+            <button
+                type='button'
+                onClick={onConfirm}
+            >
+                Confirm delete
+            </button>
+            <button
+                type='button'
+                onClick={onCancel}
+            >
+                Cancel delete
+            </button>
+        </div>
+    ),
 }));
 
 const mockUseSelector = useSelector as unknown as jest.Mock;
 const mockUseIsMultiLLMLicensed = useIsMultiLLMLicensed as unknown as jest.Mock;
 const mockGetAgents = getAgents as unknown as jest.Mock;
 const mockGetServices = getServices as unknown as jest.Mock;
+const mockDeleteAgent = deleteAgent as unknown as jest.Mock;
 const mockUserHasSystemPermission = userHasSystemPermission as unknown as jest.Mock;
 
 const tooltipText = 'Multiple self-service agents require a qualifying Mattermost plan';
@@ -155,5 +181,50 @@ describe('AgentsList create-button gating', () => {
         const button = screen.getByRole('button', {name: 'Create agent'});
         expect((button as HTMLButtonElement).disabled).toBe(false);
         expect(screen.queryByText(tooltipText)).toBeNull();
+    });
+});
+
+describe('AgentsList delete quota refresh', () => {
+    async function deleteLastVisibleAgent() {
+        fireEvent.click(screen.getByRole('button', {name: 'Delete Agent a1'}));
+        fireEvent.click(screen.getByRole('button', {name: 'Confirm delete'}));
+        await waitFor(() => expect(mockDeleteAgent).toHaveBeenCalledWith('a1'));
+        await waitFor(() => expect(mockGetAgents).toHaveBeenCalledTimes(2));
+    }
+
+    test('refetches quota after deleting last visible agent and re-enables Create when server count is 0', async () => {
+        mockUseIsMultiLLMLicensed.mockReturnValue(false);
+        mockGetAgents
+            .mockResolvedValueOnce({agents: [makeAgent('a1')], activeAgentCount: 1})
+            .mockResolvedValueOnce({agents: [], activeAgentCount: 0});
+        mockDeleteAgent.mockResolvedValue(undefined);
+
+        renderList();
+
+        await screen.findByText('Agent a1');
+        expect((screen.getByRole('button', {name: 'Create agent'}) as HTMLButtonElement).disabled).toBe(true);
+
+        await deleteLastVisibleAgent();
+
+        const button = screen.getByRole('button', {name: 'Create agent'});
+        expect((button as HTMLButtonElement).disabled).toBe(false);
+        expect(screen.queryByText(tooltipText)).toBeNull();
+    });
+
+    test('refetches quota after delete and keeps Create disabled when invisible agents remain', async () => {
+        mockUseIsMultiLLMLicensed.mockReturnValue(false);
+        mockGetAgents
+            .mockResolvedValueOnce({agents: [makeAgent('a1')], activeAgentCount: 1})
+            .mockResolvedValueOnce({agents: [], activeAgentCount: 1});
+        mockDeleteAgent.mockResolvedValue(undefined);
+
+        renderList();
+
+        await screen.findByText('Agent a1');
+        await deleteLastVisibleAgent();
+
+        const button = screen.getByRole('button', {name: 'Create agent'});
+        expect((button as HTMLButtonElement).disabled).toBe(true);
+        expect(screen.getByText(tooltipText)).not.toBeNull();
     });
 });

--- a/webapp/src/components/agents/agents_list.tsx
+++ b/webapp/src/components/agents/agents_list.tsx
@@ -98,14 +98,18 @@ const AgentsList = () => {
         setDeleteInFlight(true);
         try {
             await deleteAgentAPI(deletingAgent.id);
-            setAgents((prev) => prev.filter((a) => a.id !== deletingAgent.id));
+            const nextAgents = agents.filter((a) => a.id !== deletingAgent.id);
+            setAgents(nextAgents);
+            if (nextAgents.length === 0) {
+                fetchAgents();
+            }
         } catch (e: any) {
             setError(intl.formatMessage({defaultMessage: 'Failed to delete agent.'}));
         } finally {
             setDeleteInFlight(false);
             setDeletingAgent(null);
         }
-    }, [deletingAgent, deleteInFlight, intl]);
+    }, [agents, deletingAgent, deleteInFlight, fetchAgents, intl]);
 
     const handleDeleteCancel = useCallback(() => {
         setDeletingAgent(null);


### PR DESCRIPTION
#### Summary

Fixes stale free-tier Create gating after deleting the last visible agent on the Agents page.

When a user deleted their only visible agent on a non-multi-LLM server, the local `agents` list updated but `X-Agent-Active-Count` stayed at `1`, so the Create button remained disabled until a hard refresh.

This change refetches agents when the visible list becomes empty after a successful delete, so quota gating uses an updated server-wide count from the response header. If invisible agents remain on the server, the refetch keeps Create disabled correctly.

#### Ticket Link

N/A — follow-up to #816 / Codex review on cherry-pick PR #825

#### Screenshots

N/A

#### Release Note
```release-note
Fixed the Agents page Create button staying disabled after deleting the only visible agent on free-tier servers until the page was reloaded.
```

#### Test plan

- [x] `npm test -- --testPathPattern=agents_list.test.tsx`
- [ ] On a free-tier server with one agent, delete the agent and confirm Create becomes enabled without reloading
- [ ] On a free-tier server where quota is reached by an agent the user cannot see, confirm Create stays disabled after delete + refetch


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved agent deletion so the list refreshes correctly after removing the last visible agent.
* Updated UI behavior after deletion, including re-enabling the “Create agent” button based on refreshed availability.

## Tests
* Added coverage for delete flows, quota refresh, and related UI gating to ensure tooltips and button states update as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->