### PR TITLE
Update real-API E2E tests to Claude Sonnet 4.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
     - name: Run LLMBot tests with real APIs for ${{ matrix.shard.name }}
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       shell: bash
       run: |
@@ -173,6 +174,7 @@ jobs:
     - name: Run Channel Analysis tests with real APIs
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       shell: bash
       run: |
@@ -220,6 +222,7 @@ jobs:
     - name: Run System Console tests with real APIs
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       shell: bash
       run: |
@@ -267,6 +270,7 @@ jobs:
     - name: Run Tool Config tests with real APIs
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       shell: bash
       run: |
@@ -323,6 +327,7 @@ jobs:
     - name: Run Tool Calling tests with real APIs for ${{ matrix.provider.display_name }}
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         E2E_PROVIDER: ${{ matrix.provider.name }}
       shell: bash

--- a/e2e/helpers/api-config.ts
+++ b/e2e/helpers/api-config.ts
@@ -9,7 +9,7 @@
  */
 
 // Default models for each provider. Update these when bumping model versions.
-export const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-20250514';
+export const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
 export const DEFAULT_OPENAI_MODEL = 'gpt-5.2';
 
 /**


### PR DESCRIPTION
## Summary
- Bump the default Anthropic model for real-API E2E tests from deprecated `claude-sonnet-4-20250514` (Sonnet 4) to `claude-sonnet-4-6`.
- Pass `ANTHROPIC_MODEL` explicitly in all real-API E2E CI jobs, matching the evals workflow pattern and allowing override via the `ANTHROPIC_MODEL` repository variable.

## Test plan
- [ ] CI real-API E2E jobs (`e2e-llmbot-real-apis`, `e2e-channel-analysis-real-apis`, `e2e-system-console-real-apis`, `e2e-tool-config-real-apis`, `e2e-tool-calling`) pass with the updated model.
- [ ] Local real-API E2E runs pick up `claude-sonnet-4-6` when `ANTHROPIC_MODEL` is unset.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated default AI model configuration used in test environments to ensure compatibility with current service versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->