### PR TITLE
Prototype aimock sidecar E2E tests

### DIFF
--- a/e2e/fixtures/aimock/ask-policy.json
+++ b/e2e/fixtures/aimock/ask-policy.json
@@ -1,0 +1,33 @@
+{
+  "fixtures": [
+    {
+      "match": { "toolCallId": "call_aimock_ask_1" },
+      "response": {
+        "content": "Aimock ask policy continuation after channel lookup."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Write a short title for the following request. Include only the title and nothing else, no quotations. Request:"
+      },
+      "response": {
+        "content": "Aimock ask policy title"
+      }
+    },
+    {
+      "match": {
+        "userMessage": "trigger aimock ask policy get channel",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_aimock_ask_1",
+            "name": "mattermost__get_channel_info",
+            "arguments": { "channel_name": "Town Square" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/aimock/streaming-persistence.json
+++ b/e2e/fixtures/aimock/streaming-persistence.json
@@ -1,0 +1,18 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "userMessage": "Write a short title for the following request. Include only the title and nothing else, no quotations. Request:"
+      },
+      "response": {
+        "content": "Aimock streaming persistence title"
+      }
+    },
+    {
+      "match": { "userMessage": "brief aimock typescript benefits" },
+      "response": {
+        "content": "Aimock: TypeScript adds static types, safer refactors, and better IDE support for large codebases."
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/aimock/streaming-text.json
+++ b/e2e/fixtures/aimock/streaming-text.json
@@ -1,0 +1,8 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "hello aimock e2e" },
+      "response": { "content": "Hello from aimock E2E!" }
+    }
+  ]
+}

--- a/e2e/fixtures/aimock/tool-call.json
+++ b/e2e/fixtures/aimock/tool-call.json
@@ -1,0 +1,15 @@
+{
+  "fixtures": [
+    {
+      "match": { "toolName": "aimock_e2e_tool" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "aimock_e2e_tool",
+            "arguments": { "channel_id": "e2e-ch-1", "message": "exact aimock tool message" }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/e2e/helpers/aimock-container.ts
+++ b/e2e/helpers/aimock-container.ts
@@ -1,0 +1,111 @@
+import fs from 'fs';
+import path from 'path';
+import {GenericContainer, StartedNetwork, StartedTestContainer, Wait} from 'testcontainers';
+
+export const AIMOCK_IMAGE = 'ghcr.io/copilotkit/aimock:latest';
+export const AIMOCK_PORT = 8080;
+export const AIMOCK_NETWORK_ALIAS = 'openai';
+export const AIMOCK_FIXTURES_DIR = path.join(__dirname, '../fixtures/aimock');
+
+export const DEFAULT_FIXTURE_FILES = [
+	'streaming-text.json',
+	'tool-call.json',
+] as const;
+
+export type AimockStartOptions = {
+	fixtureFiles?: readonly string[];
+	strict?: boolean;
+	logLevel?: string;
+};
+
+export class AimockContainer {
+	container: StartedTestContainer;
+	private network: StartedNetwork | null = null;
+	private startOptions: AimockStartOptions = {};
+
+	start = async (network: StartedNetwork, options: AimockStartOptions = {}): Promise<void> => {
+		this.network = network;
+		this.startOptions = {
+			fixtureFiles: options.fixtureFiles ?? DEFAULT_FIXTURE_FILES,
+			strict: options.strict ?? true,
+			logLevel: options.logLevel ?? 'warn',
+		};
+
+		const fixtureFiles = this.startOptions.fixtureFiles ?? DEFAULT_FIXTURE_FILES;
+		for (const file of fixtureFiles) {
+			const fixturePath = path.join(AIMOCK_FIXTURES_DIR, file);
+			if (!fs.existsSync(fixturePath)) {
+				throw new Error(`Missing aimock fixture: ${fixturePath}`);
+			}
+		}
+
+		const command = fixtureFiles.flatMap((file) => ['--fixtures', `/fixtures/${file}`]);
+		command.push('--host', '0.0.0.0', '--port', String(AIMOCK_PORT));
+		if (this.startOptions.strict) {
+			command.push('--strict');
+		}
+		command.push('--log-level', this.startOptions.logLevel ?? 'warn');
+
+		this.container = await new GenericContainer(AIMOCK_IMAGE)
+			.withExposedPorts(AIMOCK_PORT)
+			.withNetwork(network)
+			.withNetworkAliases(AIMOCK_NETWORK_ALIAS)
+			.withBindMounts([
+				{
+					source: AIMOCK_FIXTURES_DIR,
+					target: '/fixtures',
+					mode: 'ro',
+				},
+			])
+			.withCommand(command)
+			.withWaitStrategy(Wait.forHttp('/ready', AIMOCK_PORT))
+			.start();
+	};
+
+	stop = async (): Promise<void> => {
+		if (this.container) {
+			await this.container.stop();
+		}
+	};
+
+	/** aimock has no Smocker-style /reset; restart reloads bind-mounted fixtures. */
+	restart = async (): Promise<void> => {
+		if (!this.network) {
+			throw new Error('AimockContainer.restart called before start');
+		}
+		await this.stop();
+		await this.start(this.network, this.startOptions);
+	};
+
+	getMappedBaseUrl = (): string => {
+		return `http://127.0.0.1:${this.container.getMappedPort(AIMOCK_PORT)}`;
+	};
+
+	getNetworkBaseUrl = (): string => {
+		return `http://${AIMOCK_NETWORK_ALIAS}:${AIMOCK_PORT}`;
+	};
+
+	postChatCompletion = async (
+		body: Record<string, unknown>,
+		headers: Record<string, string> = {},
+	): Promise<Response> => {
+		return fetch(`${this.getMappedBaseUrl()}/v1/chat/completions`, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer mock',
+				'Content-Type': 'application/json',
+				...headers,
+			},
+			body: JSON.stringify(body),
+		});
+	};
+}
+
+export const RunAimockContainer = async (
+	network: StartedNetwork,
+	options?: AimockStartOptions,
+): Promise<AimockContainer> => {
+	const aimock = new AimockContainer();
+	await aimock.start(network, options);
+	return aimock;
+};

--- a/e2e/helpers/aimock-fixture-builders.ts
+++ b/e2e/helpers/aimock-fixture-builders.ts
@@ -1,0 +1,75 @@
+/**
+ * Small builders for aimock JSON fixtures used by ported E2E specs.
+ * Prefer checked-in JSON under e2e/fixtures/aimock/ for review; use these when
+ * generating fixtures programmatically in spikes.
+ */
+
+export type AimockFixtureFile = {
+	fixtures: AimockFixtureEntry[];
+};
+
+export type AimockFixtureEntry = {
+	match: Record<string, string | boolean>;
+	response: {
+		content?: string;
+		toolCalls?: Array<{
+			id?: string;
+			name: string;
+			arguments: Record<string, unknown>;
+		}>;
+	};
+};
+
+export function buildStreamingTextFixture(
+	userMessage: string,
+	content: string,
+): AimockFixtureFile {
+	return {
+		fixtures: [
+			{
+				match: {userMessage},
+				response: {content},
+			},
+		],
+	};
+}
+
+export function buildAskPolicyToolRoundFixture(options: {
+	userMessage: string;
+	toolCallId: string;
+	toolName: string;
+	toolArguments: Record<string, unknown>;
+	followUpContent: string;
+	titlePromptPrefix?: string;
+	titleContent?: string;
+}): AimockFixtureFile {
+	const titlePrefix =
+		options.titlePromptPrefix ??
+		'Write a short title for the following request. Include only the title and nothing else, no quotations. Request:';
+	const titleContent = options.titleContent ?? 'Aimock ask policy title';
+
+	return {
+		fixtures: [
+			{
+				match: {toolCallId: options.toolCallId},
+				response: {content: options.followUpContent},
+			},
+			{
+				match: {userMessage: titlePrefix},
+				response: {content: titleContent},
+			},
+			{
+				match: {userMessage: options.userMessage, hasToolResult: false},
+				response: {
+					toolCalls: [
+						{
+							id: options.toolCallId,
+							name: options.toolName,
+							arguments: options.toolArguments,
+						},
+					],
+				},
+			},
+		],
+	};
+}

--- a/e2e/helpers/aimock-fixture-constants.ts
+++ b/e2e/helpers/aimock-fixture-constants.ts
@@ -1,0 +1,15 @@
+export const AIMOCK_USER_MESSAGE = 'hello aimock e2e';
+export const AIMOCK_EXPECTED_STREAMING_TEXT = 'Hello from aimock E2E!';
+export const AIMOCK_TOOL_NAME = 'aimock_e2e_tool';
+
+/** Ported from llmbot-post-component/streaming-persistence.spec.ts */
+export const AIMOCK_STREAMING_PERSISTENCE_MESSAGE = 'brief aimock typescript benefits';
+export const AIMOCK_STREAMING_PERSISTENCE_TEXT =
+	'Aimock: TypeScript adds static types, safer refactors, and better IDE support for large codebases.';
+
+/** Ported from tool-config/real-api/ask-policy.spec.ts */
+export const AIMOCK_ASK_POLICY_USER_MESSAGE = 'trigger aimock ask policy get channel';
+export const AIMOCK_ASK_POLICY_TOOL_NAME = 'mattermost__get_channel_info';
+export const AIMOCK_ASK_POLICY_TOOL_LABEL = 'Get Channel Info';
+export const AIMOCK_ASK_POLICY_CONTINUATION_TEXT =
+	'Aimock ask policy continuation after channel lookup.';

--- a/e2e/helpers/aimock-plugin-container.ts
+++ b/e2e/helpers/aimock-plugin-container.ts
@@ -1,0 +1,125 @@
+import fs from 'fs';
+import path from 'path';
+
+import MattermostContainer from './mmcontainer';
+
+const findPluginFile = (): string => {
+	const distPath = path.join(__dirname, '../../dist/');
+	let filename = '';
+	fs.readdirSync(distPath).forEach((file) => {
+		if (file.endsWith('.tar.gz')) {
+			filename = path.join(distPath, file);
+		}
+	});
+	if (filename === '') {
+		throw new Error('No tar.gz file found in dist folder — run make dist first');
+	}
+	return filename;
+};
+
+/** Minimal Mattermost + plugin config for aimock sidecar spike specs. */
+const RunAimockPluginContainer = async (): Promise<MattermostContainer> => {
+	const filename = findPluginFile();
+	const pluginConfig = {
+		config: {
+			allowPrivateChannels: true,
+			disableFunctionCalls: false,
+			enableUserRestrictions: false,
+			allowUnsafeLinks: true,
+			defaultBotName: 'aimock',
+			mcp: {
+				embeddedServer: {enabled: false},
+				enablePluginServer: false,
+				enabled: false,
+				idleTimeoutMinutes: 30,
+				servers: null,
+			},
+			services: [
+				{
+					id: 'aimock-service',
+					name: 'Aimock Service',
+					type: 'openaicompatible',
+					apiKey: 'mock',
+					apiURL: 'http://openai:8080',
+					defaultModel: 'gpt-mock',
+					useResponsesAPI: false,
+				},
+			],
+			bots: [
+				{
+					id: 'aimock-bot',
+					name: 'aimock',
+					displayName: 'Aimock Bot',
+					customInstructions: '',
+					serviceID: 'aimock-service',
+					enabledNativeTools: [],
+				},
+			],
+			embeddingSearchConfig: {
+				type: 'composite',
+				dimensions: 512,
+				vectorStore: {
+					type: 'pgvector',
+					parameters: {dimensions: 512},
+				},
+				embeddingProvider: {
+					type: 'mock',
+					parameters: {},
+				},
+				parameters: {},
+				chunkingOptions: {
+					chunkSize: 500,
+					chunkOverlap: 100,
+					chunkingStrategy: 'sentences',
+				},
+			},
+		},
+	};
+
+	const mattermost = await new MattermostContainer()
+		.withEnv('MM_SERVICESETTINGS_ALLOWEDUNTRUSTEDINTERNALCONNECTIONS', 'openai')
+		.withPlugin(filename, 'mattermost-ai', pluginConfig)
+		.start();
+
+	await mattermost.createUser('regularuser@sample.com', 'regularuser', 'regularuser');
+	await mattermost.addUserToTeam('regularuser', 'test');
+
+	const userClient = await mattermost.getClient('regularuser', 'regularuser');
+	const user = await userClient.getMe();
+	await userClient.savePreferences(user.id, [
+		{user_id: user.id, category: 'tutorial_step', name: user.id, value: '999'},
+		{user_id: user.id, category: 'onboarding_task_list', name: 'onboarding_task_list_show', value: 'false'},
+		{user_id: user.id, category: 'onboarding_task_list', name: 'onboarding_task_list_open', value: 'false'},
+		{
+			user_id: user.id,
+			category: 'drafts',
+			name: 'drafts_tour_tip_showed',
+			value: JSON.stringify({drafts_tour_tip_showed: true}),
+		},
+		{user_id: user.id, category: 'crt_thread_pane_step', name: user.id, value: '999'},
+	]);
+
+	const adminClient = await mattermost.getAdminClient();
+	const admin = await adminClient.getMe();
+	await adminClient.savePreferences(admin.id, [
+		{user_id: admin.id, category: 'tutorial_step', name: admin.id, value: '999'},
+		{user_id: admin.id, category: 'onboarding_task_list', name: 'onboarding_task_list_show', value: 'false'},
+		{user_id: admin.id, category: 'onboarding_task_list', name: 'onboarding_task_list_open', value: 'false'},
+		{
+			user_id: admin.id,
+			category: 'drafts',
+			name: 'drafts_tour_tip_showed',
+			value: JSON.stringify({drafts_tour_tip_showed: true}),
+		},
+		{user_id: admin.id, category: 'crt_thread_pane_step', name: admin.id, value: '999'},
+	]);
+	await adminClient.completeSetup({
+		organization: 'test',
+		install_plugins: [],
+	});
+
+	await mattermost.grantSelfServiceAgentPermissions();
+	return mattermost;
+};
+
+export default RunAimockPluginContainer;

--- a/e2e/helpers/aimock-plugin-dist.ts
+++ b/e2e/helpers/aimock-plugin-dist.ts
@@ -1,0 +1,8 @@
+import fs from 'fs';
+import path from 'path';
+
+const pluginDistPath = path.resolve(__dirname, '../../dist');
+
+export function hasAimockPluginDist(): boolean {
+	return fs.existsSync(pluginDistPath) && fs.readdirSync(pluginDistPath).some((file) => file.endsWith('.tar.gz'));
+}

--- a/e2e/helpers/aimock-sse-assertions.ts
+++ b/e2e/helpers/aimock-sse-assertions.ts
@@ -1,0 +1,8 @@
+import {expect} from '@playwright/test';
+
+/** aimock may split streamed text/tool args across SSE chunks; match stable fragments. */
+export function expectChunkedFragments(body: string, fragments: string[]): void {
+	for (const fragment of fragments) {
+		expect(body).toContain(fragment);
+	}
+}

--- a/e2e/helpers/aimock-tool-config-plugin-container.ts
+++ b/e2e/helpers/aimock-tool-config-plugin-container.ts
@@ -1,0 +1,145 @@
+import fs from 'fs';
+import path from 'path';
+
+import MattermostContainer from './mmcontainer';
+
+const findPluginFile = (): string => {
+	const distPath = path.join(__dirname, '../../dist/');
+	let filename = '';
+	fs.readdirSync(distPath).forEach((file) => {
+		if (file.endsWith('.tar.gz')) {
+			filename = path.join(distPath, file);
+		}
+	});
+	if (filename === '') {
+		throw new Error('No tar.gz file found in dist folder — run make dist first');
+	}
+	return filename;
+};
+
+export type AimockToolPolicyConfig = {
+	name: string;
+	policy: 'ask' | 'auto_run_in_dm' | 'auto_run_everywhere';
+	enabled: boolean;
+};
+
+const DEFAULT_ASK_POLICY_TOOLS: AimockToolPolicyConfig[] = [
+	{name: 'get_channel_info', policy: 'ask', enabled: true},
+];
+
+/**
+ * Mattermost + Agents plugin configured for aimock tool-policy ported specs.
+ * Mirrors tool-config-container policy presets but routes LLM traffic to aimock.
+ */
+const RunAimockToolConfigPluginContainer = async (
+	toolConfigs: AimockToolPolicyConfig[] = DEFAULT_ASK_POLICY_TOOLS,
+): Promise<MattermostContainer> => {
+	const filename = findPluginFile();
+	const pluginConfig = {
+		config: {
+			allowPrivateChannels: true,
+			disableFunctionCalls: false,
+			enableUserRestrictions: false,
+			allowUnsafeLinks: true,
+			defaultBotName: 'aimock-toolbot',
+			mcp: {
+				embeddedServer: {
+					enabled: true,
+					tool_configs: toolConfigs,
+				},
+				enablePluginServer: true,
+				enabled: true,
+				idleTimeoutMinutes: 30,
+				servers: null,
+			},
+			services: [
+				{
+					id: 'aimock-service',
+					name: 'Aimock Service',
+					type: 'openaicompatible',
+					apiKey: 'mock',
+					apiURL: 'http://openai:8080',
+					defaultModel: 'gpt-mock',
+					useResponsesAPI: false,
+				},
+			],
+			bots: [
+				{
+					id: 'aimock-toolbot',
+					name: 'aimock-toolbot',
+					displayName: 'Aimock Tool Bot',
+					customInstructions: '',
+					serviceID: 'aimock-service',
+					disableTools: false,
+					mcpDynamicToolLoading: false,
+					enabledNativeTools: [],
+				},
+			],
+			embeddingSearchConfig: {
+				type: 'composite',
+				dimensions: 512,
+				vectorStore: {
+					type: 'pgvector',
+					parameters: {dimensions: 512},
+				},
+				embeddingProvider: {
+					type: 'mock',
+					parameters: {},
+				},
+				parameters: {},
+				chunkingOptions: {
+					chunkSize: 500,
+					chunkOverlap: 100,
+					chunkingStrategy: 'sentences',
+				},
+			},
+		},
+	};
+
+	const mattermost = await new MattermostContainer()
+		.withEnv('MM_SERVICESETTINGS_ALLOWEDUNTRUSTEDINTERNALCONNECTIONS', 'openai')
+		.withPlugin(filename, 'mattermost-ai', pluginConfig)
+		.start();
+
+	await mattermost.createUser('regularuser@sample.com', 'regularuser', 'regularuser');
+	await mattermost.addUserToTeam('regularuser', 'test');
+
+	const userClient = await mattermost.getClient('regularuser', 'regularuser');
+	const user = await userClient.getMe();
+	await userClient.savePreferences(user.id, [
+		{user_id: user.id, category: 'tutorial_step', name: user.id, value: '999'},
+		{user_id: user.id, category: 'onboarding_task_list', name: 'onboarding_task_list_show', value: 'false'},
+		{user_id: user.id, category: 'onboarding_task_list', name: 'onboarding_task_list_open', value: 'false'},
+		{
+			user_id: user.id,
+			category: 'drafts',
+			name: 'drafts_tour_tip_showed',
+			value: JSON.stringify({drafts_tour_tip_showed: true}),
+		},
+		{user_id: user.id, category: 'crt_thread_pane_step', name: user.id, value: '999'},
+	]);
+
+	const adminClient = await mattermost.getAdminClient();
+	const admin = await adminClient.getMe();
+	await adminClient.savePreferences(admin.id, [
+		{user_id: admin.id, category: 'tutorial_step', name: admin.id, value: '999'},
+		{user_id: admin.id, category: 'onboarding_task_list', name: 'onboarding_task_list_show', value: 'false'},
+		{user_id: admin.id, category: 'onboarding_task_list', name: 'onboarding_task_list_open', value: 'false'},
+		{
+			user_id: admin.id,
+			category: 'drafts',
+			name: 'drafts_tour_tip_showed',
+			value: JSON.stringify({drafts_tour_tip_showed: true}),
+		},
+		{user_id: admin.id, category: 'crt_thread_pane_step', name: admin.id, value: '999'},
+	]);
+	await adminClient.completeSetup({
+		organization: 'test',
+		install_plugins: [],
+	});
+
+	await mattermost.grantSelfServiceAgentPermissions();
+	return mattermost;
+};
+
+export default RunAimockToolConfigPluginContainer;

--- a/e2e/tests/aimock/aimock-sidecar.spec.ts
+++ b/e2e/tests/aimock/aimock-sidecar.spec.ts
@@ -1,0 +1,147 @@
+import fs from 'fs';
+import path from 'path';
+
+import {test, expect} from '@playwright/test';
+import {Network} from 'testcontainers';
+import type {StartedNetwork} from 'testcontainers';
+
+import {
+	AimockContainer,
+	RunAimockContainer,
+} from 'helpers/aimock-container';
+import {
+	AIMOCK_EXPECTED_STREAMING_TEXT,
+	AIMOCK_TOOL_NAME,
+	AIMOCK_USER_MESSAGE,
+} from 'helpers/aimock-fixture-constants';
+import RunAimockPluginContainer from 'helpers/aimock-plugin-container';
+import MattermostContainer from 'helpers/mmcontainer';
+import {MattermostPage} from 'helpers/mm';
+import {AIPlugin} from 'helpers/ai-plugin';
+
+const distPath = path.resolve(__dirname, '../../../dist');
+const hasPluginDist =
+	fs.existsSync(distPath) && fs.readdirSync(distPath).some((f) => f.endsWith('.tar.gz'));
+
+const username = 'regularuser';
+const password = 'regularuser';
+
+/** aimock may split streamed text/tool args across SSE chunks; match stable fragments. */
+function expectChunkedFragments(body: string, fragments: string[]): void {
+	for (const fragment of fragments) {
+		expect(body).toContain(fragment);
+	}
+}
+
+test.describe('aimock sidecar harness', () => {
+	let network: StartedNetwork;
+	let aimock: AimockContainer;
+
+	test.beforeAll(async () => {
+		network = await new Network().start();
+		aimock = await RunAimockContainer(network);
+	});
+
+	test.afterAll(async () => {
+		await aimock?.stop();
+		await network?.stop();
+	});
+
+	test('streams fixture text via openaicompatible SSE', async () => {
+		const response = await aimock.postChatCompletion({
+			model: 'gpt-mock',
+			stream: true,
+			messages: [{role: 'user', content: AIMOCK_USER_MESSAGE}],
+		});
+		const body = await response.text();
+
+		expect(response.ok).toBe(true);
+		expect(body).toContain('data:');
+		expectChunkedFragments(body, ['Hello from aimock E2', 'E!']);
+		expect(body).toContain('[DONE]');
+	});
+
+	test('returns exact tool-call args in streaming response', async () => {
+		const response = await aimock.postChatCompletion({
+			model: 'gpt-mock',
+			stream: true,
+			messages: [{role: 'user', content: 'trigger aimock tool'}],
+			tools: [
+				{
+					type: 'function',
+					function: {
+						name: AIMOCK_TOOL_NAME,
+						parameters: {
+							type: 'object',
+							properties: {
+								channel_id: {type: 'string'},
+								message: {type: 'string'},
+							},
+							required: ['channel_id', 'message'],
+						},
+					},
+				},
+			],
+		});
+		const body = await response.text();
+
+		expect(response.ok).toBe(true);
+		expect(body).toContain(`"name":"${AIMOCK_TOOL_NAME}"`);
+		expect(body).toContain('e2e-c');
+		expect(body).toContain('h-1');
+		expectChunkedFragments(body, ['exac', 'aimock tool messag']);
+	});
+
+	test('strict mode rejects unmatched requests', async () => {
+		const response = await aimock.postChatCompletion({
+			model: 'gpt-mock',
+			stream: false,
+			messages: [{role: 'user', content: 'no matching fixture'}],
+		});
+
+		expect(response.status).toBe(503);
+	});
+
+	test('restart reloads bind-mounted fixtures', async () => {
+		await aimock.restart();
+
+		const response = await aimock.postChatCompletion({
+			model: 'gpt-mock',
+			stream: true,
+			messages: [{role: 'user', content: AIMOCK_USER_MESSAGE}],
+		});
+		const body = await response.text();
+
+		expect(response.ok).toBe(true);
+		expectChunkedFragments(body, ['Hello from aimock E2', 'E!']);
+	});
+});
+
+test.describe('aimock plugin E2E', () => {
+	test.skip(!hasPluginDist, 'requires make dist in repo root');
+
+	let mattermost: MattermostContainer;
+	let aimock: AimockContainer;
+
+	test.beforeAll(async () => {
+		mattermost = await RunAimockPluginContainer();
+		aimock = await RunAimockContainer(mattermost.network);
+	}, {timeout: 300000});
+
+	test.afterAll(async () => {
+		await aimock?.stop();
+		await mattermost?.stop();
+	});
+
+	test('RHS receives deterministic aimock streaming response', async ({page}) => {
+		test.setTimeout(120000);
+
+		const mmPage = new MattermostPage(page);
+		const aiPlugin = new AIPlugin(page);
+
+		await mmPage.login(mattermost.url(), username, password);
+		await aiPlugin.openRHS();
+		await aiPlugin.sendMessage(AIMOCK_USER_MESSAGE);
+		await aiPlugin.waitForBotResponse(AIMOCK_EXPECTED_STREAMING_TEXT);
+	});
+});

--- a/e2e/tests/aimock/ported/ask-policy.spec.ts
+++ b/e2e/tests/aimock/ported/ask-policy.spec.ts
@@ -1,0 +1,163 @@
+import {test, expect} from '@playwright/test';
+import {Network} from 'testcontainers';
+import type {StartedNetwork} from 'testcontainers';
+
+import {
+	AimockContainer,
+	RunAimockContainer,
+} from 'helpers/aimock-container';
+import {
+	AIMOCK_ASK_POLICY_CONTINUATION_TEXT,
+	AIMOCK_ASK_POLICY_TOOL_LABEL,
+	AIMOCK_ASK_POLICY_TOOL_NAME,
+	AIMOCK_ASK_POLICY_USER_MESSAGE,
+} from 'helpers/aimock-fixture-constants';
+import {hasAimockPluginDist} from 'helpers/aimock-plugin-dist';
+import {expectChunkedFragments} from 'helpers/aimock-sse-assertions';
+import RunAimockToolConfigPluginContainer from 'helpers/aimock-tool-config-plugin-container';
+import MattermostContainer from 'helpers/mmcontainer';
+import {MattermostPage} from 'helpers/mm';
+import {AIPlugin} from 'helpers/ai-plugin';
+
+const username = 'regularuser';
+const password = 'regularuser';
+
+const ASK_POLICY_FIXTURES = ['ask-policy.json'] as const;
+
+/**
+ * Aimock port of tool-config/real-api/ask-policy.spec.ts.
+ *
+ * Original real-api suite: e2e/tests/tool-config/real-api/ask-policy.spec.ts
+ * Uses deterministic aimock tool-call fixtures instead of relying on a live LLM
+ * to invoke the ask-policy get_channel_info tool.
+ */
+test.describe('aimock ported: ask policy', () => {
+	let network: StartedNetwork;
+	let aimock: AimockContainer;
+
+	test.beforeAll(async () => {
+		network = await new Network().start();
+		aimock = await RunAimockContainer(network, {
+			fixtureFiles: ASK_POLICY_FIXTURES,
+		});
+	});
+
+	test.afterAll(async () => {
+		await aimock?.stop();
+		await network?.stop();
+	});
+
+	test('fixture returns ask-policy tool call with exact args', async () => {
+		const response = await aimock.postChatCompletion({
+			model: 'gpt-mock',
+			stream: true,
+			messages: [{role: 'user', content: AIMOCK_ASK_POLICY_USER_MESSAGE}],
+			tools: [
+				{
+					type: 'function',
+					function: {
+						name: AIMOCK_ASK_POLICY_TOOL_NAME,
+						parameters: {
+							type: 'object',
+							properties: {
+								channel_name: {type: 'string'},
+							},
+							required: ['channel_name'],
+						},
+					},
+				},
+			],
+		});
+		const body = await response.text();
+
+		expect(response.ok).toBe(true);
+		expect(body).toContain(`"name":"${AIMOCK_ASK_POLICY_TOOL_NAME}"`);
+		expectChunkedFragments(body, ['channel_name', 'Tow', 'n Square']);
+	});
+
+	test('fixture serves continuation after tool result round', async () => {
+		const response = await aimock.postChatCompletion({
+			model: 'gpt-mock',
+			stream: true,
+			messages: [
+				{role: 'user', content: AIMOCK_ASK_POLICY_USER_MESSAGE},
+				{
+					role: 'assistant',
+					content: null,
+					tool_calls: [
+						{
+							id: 'call_aimock_ask_1',
+							type: 'function',
+							function: {
+								name: AIMOCK_ASK_POLICY_TOOL_NAME,
+								arguments: JSON.stringify({channel_name: 'Town Square'}),
+							},
+						},
+					],
+				},
+				{
+					role: 'tool',
+					tool_call_id: 'call_aimock_ask_1',
+					content: '{"channel_id":"town-square-id","name":"Town Square"}',
+				},
+			],
+		});
+		const body = await response.text();
+
+		expect(response.ok).toBe(true);
+		expectChunkedFragments(body, ['Aimock ask policy co', 'ntinuation after cha', 'nnel lookup.']);
+		expect(body).toContain('[DONE]');
+	});
+});
+
+test.describe('aimock ported: ask policy (plugin E2E)', () => {
+	test.skip(!hasAimockPluginDist(), 'requires make dist in repo root');
+
+	let mattermost: MattermostContainer;
+	let aimock: AimockContainer;
+
+	test.beforeAll(async () => {
+		mattermost = await RunAimockToolConfigPluginContainer();
+		aimock = await RunAimockContainer(mattermost.network, {
+			fixtureFiles: ASK_POLICY_FIXTURES,
+		});
+	}, {timeout: 300000});
+
+	test.afterAll(async () => {
+		await aimock?.stop();
+		await mattermost?.stop();
+	});
+
+	test('ask policy tool shows pending approval in DM', async ({page}) => {
+		test.setTimeout(120000);
+
+		const mmPage = new MattermostPage(page);
+		const aiPlugin = new AIPlugin(page);
+
+		await mmPage.login(mattermost.url(), username, password);
+		await aiPlugin.openRHS();
+		await aiPlugin.sendMessage(AIMOCK_ASK_POLICY_USER_MESSAGE);
+
+		const stopButton = page.getByRole('button', {name: /stop/i});
+		await expect(stopButton).not.toBeVisible({timeout: 90000});
+
+		const rhsContainer = page.getByTestId('mattermost-ai-rhs');
+		await expect(rhsContainer).toBeVisible();
+
+		const botPost = rhsContainer.locator('[data-testid="llm-bot-post"]').last();
+		await expect(botPost.getByText(AIMOCK_ASK_POLICY_TOOL_LABEL, {exact: true})).toBeVisible({
+			timeout: 30000,
+		});
+
+		const acceptButton = page.getByRole('button', {name: /^accept$/i});
+		const rejectButton = page.getByRole('button', {name: /reject/i});
+		await expect(acceptButton).toBeVisible();
+		await expect(rejectButton).toBeVisible();
+
+		await acceptButton.click();
+		await expect(stopButton).not.toBeVisible({timeout: 60000});
+		await expect(botPost.getByText(AIMOCK_ASK_POLICY_CONTINUATION_TEXT)).toBeVisible({
+			timeout: 30000,
+		});
+	});
+});

--- a/e2e/tests/aimock/ported/streaming-persistence.spec.ts
+++ b/e2e/tests/aimock/ported/streaming-persistence.spec.ts
@@ -1,0 +1,110 @@
+import {test, expect} from '@playwright/test';
+import {Network} from 'testcontainers';
+import type {StartedNetwork} from 'testcontainers';
+
+import {
+	AimockContainer,
+	RunAimockContainer,
+} from 'helpers/aimock-container';
+import {
+	AIMOCK_STREAMING_PERSISTENCE_MESSAGE,
+	AIMOCK_STREAMING_PERSISTENCE_TEXT,
+} from 'helpers/aimock-fixture-constants';
+import {hasAimockPluginDist} from 'helpers/aimock-plugin-dist';
+import {expectChunkedFragments} from 'helpers/aimock-sse-assertions';
+import RunAimockPluginContainer from 'helpers/aimock-plugin-container';
+import MattermostContainer from 'helpers/mmcontainer';
+import {MattermostPage} from 'helpers/mm';
+import {AIPlugin} from 'helpers/ai-plugin';
+import {LLMBotPostHelper} from 'helpers/llmbot-post';
+
+const username = 'regularuser';
+const password = 'regularuser';
+
+const STREAMING_PERSISTENCE_FIXTURES = [
+	'streaming-persistence.json',
+] as const;
+
+/**
+ * Aimock port of llmbot-post-component/streaming-persistence.spec.ts
+ * ("Navigation Persistence").
+ *
+ * Original real-api suite: e2e/tests/llmbot-post-component/streaming-persistence.spec.ts
+ * Uses deterministic aimock streaming text instead of live LLM output.
+ */
+test.describe('aimock ported: streaming persistence', () => {
+	let network: StartedNetwork;
+	let aimock: AimockContainer;
+
+	test.beforeAll(async () => {
+		network = await new Network().start();
+		aimock = await RunAimockContainer(network, {
+			fixtureFiles: STREAMING_PERSISTENCE_FIXTURES,
+		});
+	});
+
+	test.afterAll(async () => {
+		await aimock?.stop();
+		await network?.stop();
+	});
+
+	test('fixture streams deterministic persistence text', async () => {
+		const response = await aimock.postChatCompletion({
+			model: 'gpt-mock',
+			stream: true,
+			messages: [{role: 'user', content: AIMOCK_STREAMING_PERSISTENCE_MESSAGE}],
+		});
+		const body = await response.text();
+
+		expect(response.ok).toBe(true);
+		expectChunkedFragments(body, ['Aimock: TypeScript a', 'dds static types']);
+		expect(body).toContain('[DONE]');
+	});
+});
+
+test.describe('aimock ported: streaming persistence (plugin E2E)', () => {
+	test.skip(!hasAimockPluginDist(), 'requires make dist in repo root');
+
+	let mattermost: MattermostContainer;
+	let aimock: AimockContainer;
+
+	test.beforeAll(async () => {
+		mattermost = await RunAimockPluginContainer();
+		aimock = await RunAimockContainer(mattermost.network, {
+			fixtureFiles: STREAMING_PERSISTENCE_FIXTURES,
+		});
+	}, {timeout: 300000});
+
+	test.afterAll(async () => {
+		await aimock?.stop();
+		await mattermost?.stop();
+	});
+
+	test('Navigation Persistence', async ({page}) => {
+		test.setTimeout(120000);
+
+		const mmPage = new MattermostPage(page);
+		const aiPlugin = new AIPlugin(page);
+		const llmBotHelper = new LLMBotPostHelper(page);
+
+		await mmPage.login(mattermost.url(), username, password);
+		await aiPlugin.openRHS();
+		await aiPlugin.sendMessage(AIMOCK_STREAMING_PERSISTENCE_MESSAGE);
+		await llmBotHelper.waitForStreamingComplete();
+
+		const postTextBefore = llmBotHelper.getPostText();
+		const contentBefore = await postTextBefore.textContent();
+		expect(contentBefore).toContain('TypeScript adds static types');
+
+		await aiPlugin.closeRHS();
+		await page.waitForTimeout(1000);
+		await aiPlugin.openRHS();
+		await page.waitForTimeout(2000);
+
+		const postTextAfter = llmBotHelper.getPostText();
+		await expect(postTextAfter).toBeVisible();
+		const contentAfter = await postTextAfter.textContent();
+		expect(contentAfter).toBe(contentBefore);
+		expect(contentAfter).toContain(AIMOCK_STREAMING_PERSISTENCE_TEXT);
+	});
+});


### PR DESCRIPTION
#### Summary

Draft/spike PR for review only. This prototypes an `aimock`-backed E2E shape so we can evaluate deterministic LLM fixtures before migrating the real-API E2E jobs.

What this adds:
- `AimockContainer`, a Testcontainers-managed sidecar using `ghcr.io/copilotkit/aimock:latest` with strict fixture mode.
- Aimock JSON fixtures for streaming text and forced tool-call flows.
- A focused sidecar spec that validates streaming, exact tool-call args, strict misses, and multi-turn routing at the aimock layer.
- Ported copies of two existing suites:
  - `llmbot-post-component/streaming-persistence.spec.ts` -> `e2e/tests/aimock/ported/streaming-persistence.spec.ts`
  - `tool-config/real-api/ask-policy.spec.ts` -> `e2e/tests/aimock/ported/ask-policy.spec.ts`

Notes for reviewers:
- This is intentionally not production-clean yet. It is meant to show the code shape and fixture authoring model.
- The original real-API tests are left intact.
- The aimock sidecar uses the same Bifrost `openaicompatible` shape as existing mock tests: `apiURL: http://openai:8080`, `useResponsesAPI: false`, and `enabledNativeTools: []`.
- Full plugin/RHS paths are guarded when repo-root `dist/*.tar.gz` is missing.

Duplication / cleanup expected before production:
- `aimock-plugin-container.ts` duplicates much of `plugincontainer.ts` with aimock-specific service/bot config.
- `aimock-tool-config-plugin-container.ts` duplicates much of the tool-config/system-console container setup with aimock-specific policy config.
- Plugin dist lookup, user creation, preference setup, admin setup, and plugin config boilerplate are repeated in the spike helpers.
- A production implementation should likely parameterize or extend existing container helpers instead of keeping parallel aimock-specific plugin containers.
- `aimock-plugin-dist.ts` is a spike-only skip guard and should be folded into a shared dist helper or removed once CI builds the plugin package.
- Smocker coexistence for MCP OAuth/non-LLM HTTP routes is not solved here; production migration should decide whether Smocker remains for those routes or whether a separate lightweight mock handles them.
- The aimock image should be pinned before CI adoption instead of using `latest`.

Validation performed during the spike:
- `cd e2e && npx playwright test tests/aimock/aimock-sidecar.spec.ts --project=chromium` -> 4 passed, 1 skipped because `dist/*.tar.gz` was absent.
- `cd e2e && npx playwright test tests/aimock/ported/ --project=chromium` -> 3 passed, 2 skipped because `dist/*.tar.gz` was absent.

Still needs validation before real adoption:
- Run `make dist`, then run the skipped full plugin/RHS paths.
- Confirm fixture reset/loading ergonomics for larger suites.
- Confirm the right approach for title-generation fixtures in strict mode.
- Decide which real-API tests stay on master validation versus moving to aimock.

#### Ticket Link

N/A - spike / prototype for review.

#### Screenshots

N/A - test harness prototype only.

#### Release Note

```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suite for Aimock integration, validating streaming text responses, tool-call execution, and error handling.
  * Implemented test fixtures for ask-policy workflows, streaming persistence, and fixture reload scenarios to ensure deterministic behaviour.
  * Enhanced testing infrastructure with assertions for chunked streaming responses and plugin integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->