### PR TITLE
Bump minimum server version to 11.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             group: e2e-shard-4
     name: e2e-${{ matrix.shard.name }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermostdevelopment/mattermost-enterprise-edition:release-11.9' }}
       EXCLUDE_REAL_API_TESTS: 'true'
     defaults:
       run:
@@ -104,7 +104,7 @@ jobs:
             group: llmbot-real-edge-cases
     name: e2e-llmbot-real-apis-${{ matrix.shard.name }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermostdevelopment/mattermost-enterprise-edition:release-11.9' }}
     defaults:
       run:
         working-directory: ./e2e
@@ -152,7 +152,7 @@ jobs:
     timeout-minutes: 180
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermostdevelopment/mattermost-enterprise-edition:release-11.9' }}
     defaults:
       run:
         working-directory: ./e2e
@@ -200,7 +200,7 @@ jobs:
     timeout-minutes: 180
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermostdevelopment/mattermost-enterprise-edition:release-11.9' }}
     defaults:
       run:
         working-directory: ./e2e
@@ -248,7 +248,7 @@ jobs:
     timeout-minutes: 180
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermostdevelopment/mattermost-enterprise-edition:release-11.9' }}
     defaults:
       run:
         working-directory: ./e2e
@@ -305,7 +305,7 @@ jobs:
             display_name: OpenAI
     name: e2e-tool-calling-${{ matrix.provider.name }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermostdevelopment/mattermost-enterprise-edition:release-11.9' }}
     defaults:
       run:
         working-directory: ./e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             group: e2e-shard-4
     name: e2e-${{ matrix.shard.name }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.8' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
       EXCLUDE_REAL_API_TESTS: 'true'
     defaults:
       run:
@@ -104,7 +104,7 @@ jobs:
             group: llmbot-real-edge-cases
     name: e2e-llmbot-real-apis-${{ matrix.shard.name }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.8' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
     defaults:
       run:
         working-directory: ./e2e
@@ -152,7 +152,7 @@ jobs:
     timeout-minutes: 180
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.8' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
     defaults:
       run:
         working-directory: ./e2e
@@ -200,7 +200,7 @@ jobs:
     timeout-minutes: 180
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.8' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
     defaults:
       run:
         working-directory: ./e2e
@@ -248,7 +248,7 @@ jobs:
     timeout-minutes: 180
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.8' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
     defaults:
       run:
         working-directory: ./e2e
@@ -305,7 +305,7 @@ jobs:
             display_name: OpenAI
     name: e2e-tool-calling-${{ matrix.provider.name }}
     env:
-      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.8' }}
+      MM_IMAGE: ${{ vars.MM_IMAGE || 'mattermost/mattermost-enterprise-edition:release-11.9' }}
     defaults:
       run:
         working-directory: ./e2e

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -8,7 +8,7 @@ This guide covers installing, configuring, and managing the Mattermost Agents pl
 
 Before installing the Agents plugin, ensure your environment meets these requirements:
 
-- Mattermost Server v11.8.0+
+- Mattermost Server v11.9.0+
 - PostgreSQL database
 - For semantic search: PostgreSQL with pgvector extension
 - Network access to your chosen LLM provider

--- a/e2e/helpers/mmcontainer.ts
+++ b/e2e/helpers/mmcontainer.ts
@@ -17,7 +17,7 @@ const defaultUsername        = "admin";
 const defaultPassword        = "admin";
 const defaultTeamName        = "test";
 const defaultTeamDisplayName = "Test";
-const defaultMattermostImage = "mattermost/mattermost-enterprise-edition:release-11.9";
+const defaultMattermostImage = "mattermostdevelopment/mattermost-enterprise-edition:release-11.9";
 
 type PluginConfig = Record<string, unknown>;
 type PluginConfigInput = PluginConfig | {config: PluginConfig};

--- a/e2e/helpers/mmcontainer.ts
+++ b/e2e/helpers/mmcontainer.ts
@@ -17,7 +17,7 @@ const defaultUsername        = "admin";
 const defaultPassword        = "admin";
 const defaultTeamName        = "test";
 const defaultTeamDisplayName = "Test";
-const defaultMattermostImage = "mattermost/mattermost-enterprise-edition:release-11.8";
+const defaultMattermostImage = "mattermost/mattermost-enterprise-edition:release-11.9";
 
 type PluginConfig = Record<string, unknown>;
 type PluginConfigInput = PluginConfig | {config: PluginConfig};

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "support_url": "https://github.com/mattermost/mattermost-plugin-agents/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-agents",
   "icon_path": "assets/bot_icon.png",
-  "min_server_version": "11.8.0",
+  "min_server_version": "11.9.0",
   "server": {
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
#### Summary
WIP/Draft: bumps the Agents plugin minimum supported Mattermost server version to 11.9.0 across plugin metadata, docs, CI, and E2E container defaults.

Status:
- This PR is intentionally WIP/draft.
- Waiting for the `release-11.9` branch and `mattermost/mattermost-enterprise-edition:release-11.9` image to exist before final validation/merge.
- Safe validation already passed: `make manifest-check`, `make check-style`, `make test`, `make dist`.
- Final follow-up before marking ready: rerun E2E against the real `release-11.9` image.

#### Ticket Link
N/A

#### Screenshots
N/A - no UI changes.

#### Release Note
```release-note
Changed the minimum supported Mattermost server version for the Agents plugin to 11.9.0.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated compatibility requirements to require Mattermost Server version 11.9.0 or later.

* **Documentation**
  * Updated the admin guide prerequisites to reflect Mattermost Server version 11.9.0+ requirements.

* **Tests**
  * Updated the end-to-end test environment to run against the Mattermost Server 11.9 release image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->