### PR TITLE
MM-69180: Cherry-pick embedded MCP TLS internal URL fix to release-2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
     - name: Run LLMBot tests with real APIs for ${{ matrix.shard.name }}
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       shell: bash
       run: |
@@ -173,6 +174,7 @@ jobs:
     - name: Run Channel Analysis tests with real APIs
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       shell: bash
       run: |
@@ -220,6 +222,7 @@ jobs:
     - name: Run System Console tests with real APIs
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       shell: bash
       run: |
@@ -267,6 +270,7 @@ jobs:
     - name: Run Tool Config tests with real APIs
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       shell: bash
       run: |
@@ -323,6 +327,7 @@ jobs:
     - name: Run Tool Calling tests with real APIs for ${{ matrix.provider.display_name }}
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         E2E_PROVIDER: ${{ matrix.provider.name }}
       shell: bash

--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -29,6 +29,19 @@ const (
 	DefaultStreamingTimeout = 5 * time.Minute
 )
 
+type webSearchFallbackSource struct {
+	URL   string
+	Title string
+}
+
+type pendingAnnotationPosition struct {
+	index        int
+	missingStart bool
+	missingEnd   bool
+}
+
+const missingContentIndex = -1
+
 // LLM implements the llm.LanguageModel interface using the Bifrost gateway.
 type LLM struct {
 	client           *bifrostcore.Bifrost
@@ -1544,8 +1557,10 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 
 	// Annotation buffer and text position tracking
 	var annotations []llm.Annotation
-	var textLen int       // cumulative byte length of all streamed text
-	var blockStartPos int // byte position where current text block started
+	var fallbackSources []webSearchFallbackSource
+	pendingAnnotationPositions := make(map[int][]pendingAnnotationPosition)
+	var textLen int       // cumulative UTF-16 length of all streamed text
+	var blockStartPos int // UTF-16 position where current text block started
 
 	// Watchdog timer for streaming timeout
 	watchdog := make(chan struct{})
@@ -1613,7 +1628,7 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 						Type:  llm.EventTypeText,
 						Value: *resp.Delta,
 					}
-					textLen += len(*resp.Delta)
+					textLen += llm.UTF16CodeUnitCount(*resp.Delta)
 				}
 
 			case schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta:
@@ -1644,8 +1659,10 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 				if resp.Annotation != nil {
 					if ann := convertBifrostAnnotation(resp.Annotation, len(annotations)+1); ann != nil {
 						// Bifrost doesn't provide output-text positions during Anthropic streaming.
-						// Compute them from tracked block boundaries, matching the approach used by
-						// the old Anthropic SDK implementation (extractAnnotations).
+						// Attach those citations to the current text block and correct the end
+						// position when output_text.done arrives.
+						missingStart := resp.Annotation.StartIndex == nil
+						missingEnd := resp.Annotation.EndIndex == nil
 						if resp.Annotation.StartIndex == nil {
 							ann.StartIndex = blockStartPos
 						}
@@ -1653,6 +1670,20 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 							ann.EndIndex = textLen
 						}
 						annotations = append(annotations, *ann)
+						if missingStart || missingEnd {
+							contentIndex := missingContentIndex
+							if resp.ContentIndex != nil {
+								contentIndex = *resp.ContentIndex
+							}
+							pendingAnnotationPositions[contentIndex] = append(
+								pendingAnnotationPositions[contentIndex],
+								pendingAnnotationPosition{
+									index:        len(annotations) - 1,
+									missingStart: missingStart,
+									missingEnd:   missingEnd,
+								},
+							)
+						}
 					}
 				}
 
@@ -1663,6 +1694,17 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 				// Text block complete - emit accumulated annotations and advance block position.
 				// Keep the annotation buffer so subsequent output_text_done events can include
 				// citations accumulated across the full response.
+				contentIndex := missingContentIndex
+				if resp.ContentIndex != nil {
+					contentIndex = *resp.ContentIndex
+				}
+				flushPendingAnnotationPositions(
+					annotations,
+					pendingAnnotationPositions,
+					contentIndex,
+					blockStartPos,
+					textLen,
+				)
 				if len(annotations) > 0 {
 					output <- llm.TextStreamEvent{
 						Type:  llm.EventTypeAnnotations,
@@ -1729,6 +1771,7 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 				}
 
 			case schemas.ResponsesStreamResponseTypeOutputItemDone:
+				fallbackSources = appendFirstWebSearchFallbackSource(fallbackSources, resp.Item)
 				// Output item completed - finalize function call if any
 				if resp.Item != nil && resp.Item.Type != nil {
 					if *resp.Item.Type == schemas.ResponsesMessageTypeFunctionCall && resp.Item.ResponsesToolMessage != nil {
@@ -1765,6 +1808,13 @@ func (b *LLM) streamResponses(request llm.CompletionRequest, cfg llm.LanguageMod
 				}
 
 				// Emit any accumulated annotations
+				for contentIndex, positions := range pendingAnnotationPositions {
+					applyPendingAnnotationPositions(annotations, positions, blockStartPos, textLen)
+					delete(pendingAnnotationPositions, contentIndex)
+				}
+				if len(annotations) == 0 && len(fallbackSources) > 0 {
+					annotations = buildFallbackAnnotations(fallbackSources, textLen)
+				}
 				if len(annotations) > 0 {
 					output <- llm.TextStreamEvent{
 						Type:  llm.EventTypeAnnotations,
@@ -1881,4 +1931,75 @@ func convertBifrostAnnotation(ann *schemas.ResponsesOutputMessageContentTextAnno
 	}
 
 	return result
+}
+
+func appendFirstWebSearchFallbackSource(sources []webSearchFallbackSource, item *schemas.ResponsesMessage) []webSearchFallbackSource {
+	if item == nil || item.Type == nil || *item.Type != schemas.ResponsesMessageTypeWebSearchCall {
+		return sources
+	}
+	if item.Action == nil || item.Action.ResponsesWebSearchToolCallAction == nil {
+		return sources
+	}
+
+	for _, source := range item.Action.ResponsesWebSearchToolCallAction.Sources {
+		if source.URL == "" || hasFallbackSource(sources, source.URL) {
+			continue
+		}
+		title := ""
+		if source.Title != nil {
+			title = *source.Title
+		}
+		sources = append(sources, webSearchFallbackSource{
+			URL:   source.URL,
+			Title: title,
+		})
+	}
+	return sources
+}
+
+func hasFallbackSource(sources []webSearchFallbackSource, url string) bool {
+	for _, source := range sources {
+		if source.URL == url {
+			return true
+		}
+	}
+	return false
+}
+
+func buildFallbackAnnotations(sources []webSearchFallbackSource, endIndex int) []llm.Annotation {
+	annotations := make([]llm.Annotation, 0, len(sources))
+	for i, source := range sources {
+		annotations = append(annotations, llm.Annotation{
+			Type:       llm.AnnotationTypeURLCitation,
+			StartIndex: endIndex,
+			EndIndex:   endIndex,
+			URL:        source.URL,
+			Title:      source.Title,
+			Index:      i + 1,
+		})
+	}
+	return annotations
+}
+
+func applyPendingAnnotationPositions(annotations []llm.Annotation, positions []pendingAnnotationPosition, startIndex, endIndex int) {
+	for _, position := range positions {
+		if position.index < 0 || position.index >= len(annotations) {
+			continue
+		}
+		if position.missingStart {
+			annotations[position.index].StartIndex = startIndex
+		}
+		if position.missingEnd {
+			annotations[position.index].EndIndex = endIndex
+		}
+	}
+}
+
+func flushPendingAnnotationPositions(
+	annotations []llm.Annotation,
+	pending map[int][]pendingAnnotationPosition,
+	contentIndex, startIndex, endIndex int,
+) {
+	applyPendingAnnotationPositions(annotations, pending[contentIndex], startIndex, endIndex)
+	delete(pending, contentIndex)
 }

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -847,6 +847,97 @@ func TestConvertBifrostAnnotation(t *testing.T) {
 	}
 }
 
+func TestAppendFirstWebSearchFallbackSource(t *testing.T) {
+	sourceTitle := "Example Source"
+	item := &schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			Action: &schemas.ResponsesToolMessageActionStruct{
+				ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
+					Sources: []schemas.ResponsesWebSearchToolCallActionSearchSource{
+						{Type: "url", URL: "https://example.com/one", Title: &sourceTitle},
+						{Type: "url", URL: "https://example.com/two"},
+					},
+				},
+			},
+		},
+	}
+
+	sources := appendFirstWebSearchFallbackSource(nil, item)
+	require.Len(t, sources, 2)
+	assert.Equal(t, webSearchFallbackSource{
+		URL:   "https://example.com/one",
+		Title: "Example Source",
+	}, sources[0])
+	assert.Equal(t, webSearchFallbackSource{
+		URL:   "https://example.com/two",
+		Title: "",
+	}, sources[1])
+
+	sources = appendFirstWebSearchFallbackSource(sources, item)
+	require.Len(t, sources, 2)
+}
+
+func TestBuildFallbackAnnotations(t *testing.T) {
+	annotations := buildFallbackAnnotations([]webSearchFallbackSource{
+		{URL: "https://example.com/one", Title: "One"},
+		{URL: "https://example.com/two", Title: "Two"},
+	}, 42)
+
+	require.Len(t, annotations, 2)
+	assert.Equal(t, llm.Annotation{
+		Type:       llm.AnnotationTypeURLCitation,
+		StartIndex: 42,
+		EndIndex:   42,
+		URL:        "https://example.com/one",
+		Title:      "One",
+		Index:      1,
+	}, annotations[0])
+	assert.Equal(t, llm.Annotation{
+		Type:       llm.AnnotationTypeURLCitation,
+		StartIndex: 42,
+		EndIndex:   42,
+		URL:        "https://example.com/two",
+		Title:      "Two",
+		Index:      2,
+	}, annotations[1])
+}
+
+func TestApplyPendingAnnotationPositions(t *testing.T) {
+	annotations := []llm.Annotation{
+		{Type: llm.AnnotationTypeURLCitation, StartIndex: 0, EndIndex: 0, URL: "https://example.com/one", Index: 1},
+		{Type: llm.AnnotationTypeURLCitation, StartIndex: 5, EndIndex: 10, URL: "https://example.com/two", Index: 2},
+	}
+
+	applyPendingAnnotationPositions(annotations, []pendingAnnotationPosition{
+		{index: 0, missingStart: true, missingEnd: true},
+		{index: 1, missingEnd: true},
+	}, 20, 42)
+
+	assert.Equal(t, 20, annotations[0].StartIndex)
+	assert.Equal(t, 42, annotations[0].EndIndex)
+	assert.Equal(t, 5, annotations[1].StartIndex)
+	assert.Equal(t, 42, annotations[1].EndIndex)
+}
+
+func TestPendingAnnotationPositionsWithoutContentIndex(t *testing.T) {
+	pending := map[int][]pendingAnnotationPosition{}
+	annotations := []llm.Annotation{
+		{Type: llm.AnnotationTypeURLCitation, StartIndex: 0, EndIndex: 0, URL: "https://example.com", Index: 1},
+	}
+
+	pending[missingContentIndex] = append(pending[missingContentIndex], pendingAnnotationPosition{
+		index:        0,
+		missingStart: true,
+		missingEnd:   true,
+	})
+	flushPendingAnnotationPositions(annotations, pending, missingContentIndex, 0, 42)
+
+	assert.Empty(t, pending)
+	assert.Equal(t, 0, annotations[0].StartIndex)
+	assert.Equal(t, 42, annotations[0].EndIndex)
+}
+
 type testStructuredOutput struct {
 	Name  string `json:"name"`
 	Score int    `json:"score"`

--- a/e2e/helpers/api-config.ts
+++ b/e2e/helpers/api-config.ts
@@ -9,7 +9,7 @@
  */
 
 // Default models for each provider. Update these when bumping model versions.
-export const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-20250514';
+export const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
 export const DEFAULT_OPENAI_MODEL = 'gpt-5.2';
 
 /**

--- a/e2e/helpers/llmbot-post.ts
+++ b/e2e/helpers/llmbot-post.ts
@@ -135,12 +135,13 @@ export class LLMBotPostHelper {
     }
 
     /**
-     * Get the post text content
+     * Get the final answer's post text. Multi-round responses render one
+     * [data-testid="posttext"] per round; .last() returns the final round.
      * @param postId - Optional post ID to scope the search
      */
     getPostText(postId?: string): Locator {
         const baseLocator = postId ? this.getLLMBotPost(postId) : this.getLLMBotPost();
-        return baseLocator.locator('[data-testid="posttext"]').first();
+        return baseLocator.locator('[data-testid="posttext"]').last();
     }
 
     /**

--- a/server/embedded_mcp_server.go
+++ b/server/embedded_mcp_server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-agents/mcpserver"
 	"github.com/mattermost/mattermost-plugin-agents/mcpserver/tools"
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -36,7 +37,7 @@ func NewEmbeddedMCPServer(pluginAPI *pluginapi.Client, logger pluginapi.LogServi
 	}
 
 	// Determine the internal server URL for API communication
-	internalServerURL := deriveInternalServerURL(pluginAPI)
+	internalServerURL := deriveInternalServerURL(pluginAPI, siteURL)
 
 	logger.Debug("Embedded MCP server configuration",
 		"siteURL", siteURL,
@@ -103,26 +104,46 @@ func (e *EmbeddedMCPServer) CreateClientTransport(userID, sessionID string, plug
 	return clientTransport, nil
 }
 
-// deriveInternalServerURL determines the internal server URL for API communication.
-// When running inside the Mattermost process, the external SiteURL might be mapped
-// to a different port (e.g., in Docker environments), so we use the internal
-// listen address instead.
-func deriveInternalServerURL(pluginAPI *pluginapi.Client) string {
-	internalServerURL := "http://localhost:8065"
-	if config := pluginAPI.Configuration.GetConfig(); config != nil {
-		if config.ServiceSettings.ListenAddress != nil && *config.ServiceSettings.ListenAddress != "" {
-			listenAddr := *config.ServiceSettings.ListenAddress
-			switch {
-			case len(listenAddr) > 0 && listenAddr[0] == ':':
-				internalServerURL = "http://localhost" + listenAddr
-			case len(listenAddr) > 7 && listenAddr[:7] == "0.0.0.0":
-				internalServerURL = "http://localhost" + listenAddr[7:]
-			case strings.HasPrefix(listenAddr, "[::]:"):
-				internalServerURL = "http://localhost:" + listenAddr[5:]
-			default:
-				internalServerURL = "http://" + listenAddr
-			}
-		}
+// deriveInternalServerURL determines the internal server URL for API
+// communication. We prefer the listen address (localhost) so the call stays
+// in-process and survives external port remapping (e.g. Docker), but when
+// Mattermost terminates TLS itself we fall back to SiteURL — hitting localhost
+// on the HTTPS listener fails cert verification because the cert is issued for
+// the public hostname (MM-69180).
+func deriveInternalServerURL(pluginAPI *pluginapi.Client, siteURL string) string {
+	return deriveInternalServerURLFromConfig(pluginAPI.Configuration.GetConfig(), siteURL)
+}
+
+func deriveInternalServerURLFromConfig(config *model.Config, siteURL string) string {
+	const defaultURL = "http://localhost:8065"
+	if config == nil {
+		return defaultURL
 	}
-	return internalServerURL
+
+	tlsTerminated := config.ServiceSettings.ConnectionSecurity != nil &&
+		*config.ServiceSettings.ConnectionSecurity == model.ConnSecurityTLS
+
+	if tlsTerminated && siteURL != "" {
+		return siteURL
+	}
+
+	scheme := "http://"
+	if tlsTerminated {
+		scheme = "https://"
+	}
+
+	if config.ServiceSettings.ListenAddress == nil || *config.ServiceSettings.ListenAddress == "" {
+		return defaultURL
+	}
+	listenAddr := *config.ServiceSettings.ListenAddress
+	switch {
+	case listenAddr[0] == ':':
+		return scheme + "localhost" + listenAddr
+	case strings.HasPrefix(listenAddr, "0.0.0.0"):
+		return scheme + "localhost" + listenAddr[len("0.0.0.0"):]
+	case strings.HasPrefix(listenAddr, "[::]:"):
+		return scheme + "localhost:" + listenAddr[len("[::]:"):]
+	default:
+		return scheme + listenAddr
+	}
 }

--- a/server/embedded_mcp_server_test.go
+++ b/server/embedded_mcp_server_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveInternalServerURL(t *testing.T) {
+	cfgWith := func(listen, connSec *string) *model.Config {
+		return &model.Config{
+			ServiceSettings: model.ServiceSettings{
+				ListenAddress:      listen,
+				ConnectionSecurity: connSec,
+			},
+		}
+	}
+	none := model.NewPointer(model.ConnSecurityNone)
+	tls := model.NewPointer(model.ConnSecurityTLS)
+
+	tests := []struct {
+		name    string
+		cfg     *model.Config
+		siteURL string
+		want    string
+	}{
+		{
+			name:    "nil config falls back to default localhost",
+			cfg:     nil,
+			siteURL: "https://example.com",
+			want:    "http://localhost:8065",
+		},
+		{
+			name:    "nil ListenAddress falls back to default localhost",
+			cfg:     cfgWith(nil, none),
+			siteURL: "https://example.com",
+			want:    "http://localhost:8065",
+		},
+		{
+			name:    "empty ListenAddress falls back to default localhost",
+			cfg:     cfgWith(model.NewPointer(""), none),
+			siteURL: "https://example.com",
+			want:    "http://localhost:8065",
+		},
+		{
+			name:    "nil ConnectionSecurity is treated as plain HTTP",
+			cfg:     cfgWith(model.NewPointer(":8065"), nil),
+			siteURL: "https://example.com",
+			want:    "http://localhost:8065",
+		},
+		{
+			name:    "wildcard IPv4 listen with no TLS",
+			cfg:     cfgWith(model.NewPointer(":8065"), none),
+			siteURL: "https://example.com",
+			want:    "http://localhost:8065",
+		},
+		{
+			name:    "0.0.0.0 listen with no TLS",
+			cfg:     cfgWith(model.NewPointer("0.0.0.0:8065"), none),
+			siteURL: "https://example.com",
+			want:    "http://localhost:8065",
+		},
+		{
+			name:    "IPv6 wildcard listen with no TLS",
+			cfg:     cfgWith(model.NewPointer("[::]:8065"), none),
+			siteURL: "https://example.com",
+			want:    "http://localhost:8065",
+		},
+		{
+			name:    "specific bind address with no TLS",
+			cfg:     cfgWith(model.NewPointer("127.0.0.1:8065"), none),
+			siteURL: "https://example.com",
+			want:    "http://127.0.0.1:8065",
+		},
+		{
+			name:    "TLS on :443 falls back to SiteURL (MM-69180)",
+			cfg:     cfgWith(model.NewPointer(":443"), tls),
+			siteURL: "https://example.com",
+			want:    "https://example.com",
+		},
+		{
+			name:    "TLS without SiteURL uses https on wildcard IPv4 listen",
+			cfg:     cfgWith(model.NewPointer(":443"), tls),
+			siteURL: "",
+			want:    "https://localhost:443",
+		},
+		{
+			name:    "TLS without SiteURL uses https on 0.0.0.0 listen",
+			cfg:     cfgWith(model.NewPointer("0.0.0.0:8443"), tls),
+			siteURL: "",
+			want:    "https://localhost:8443",
+		},
+		{
+			name:    "TLS without SiteURL uses https on IPv6 wildcard listen",
+			cfg:     cfgWith(model.NewPointer("[::]:8443"), tls),
+			siteURL: "",
+			want:    "https://localhost:8443",
+		},
+		{
+			name:    "TLS without SiteURL uses https on hostname:port listen",
+			cfg:     cfgWith(model.NewPointer("internal.example.com:8443"), tls),
+			siteURL: "",
+			want:    "https://internal.example.com:8443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveInternalServerURLFromConfig(tt.cfg, tt.siteURL)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -467,7 +467,7 @@ func (p *Plugin) OnActivate() error {
 	var mcpHandlers *mcpserver.PluginMCPHandlers
 	// Create logger adapter to route MCP handler logs through plugin logging
 	mcpHandlerLogger := NewPluginAPILoggerAdapter(pluginAPI.Log)
-	internalServerURL := deriveInternalServerURL(pluginAPI)
+	internalServerURL := deriveInternalServerURL(pluginAPI, *siteURL)
 	handlers, err := mcpserver.NewPluginMCPHandlers(*siteURL, internalServerURL, mcpHandlerLogger)
 	if err != nil {
 		pluginAPI.Log.Error("Failed to create MCP handlers", "error", err)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Cherry-pick of #828 (merged to `master`) onto `release-2.0`.

The Agents plugin's embedded MCP server hard-coded `http://` when constructing the internal Mattermost URL it uses for session auth. When Mattermost terminates TLS directly (e.g. `ListenAddress=:443`, `ConnectionSecurity=TLS`), the resulting `http://localhost:443` request hits the HTTPS listener and Mattermost replies with the plaintext error `Client sent an HTTP request to an HTTPS server`, which the MCP client surfaces as `invalid character 'C' looking for beginning of value`. This made embedded MCP unusable in any deployment where Mattermost serves TLS itself.

`deriveInternalServerURL` now consults `ServiceSettings.ConnectionSecurity`. When TLS is terminated by Mattermost it falls back to `SiteURL` rather than `https://localhost:port`, because the cert is issued for the public hostname and `localhost` would fail certificate verification. The localhost optimization (which exists for Docker port-remapping) is preserved for non-TLS deployments. The function was also split into a pure helper (`deriveInternalServerURLFromConfig`) so it can be unit-tested directly.

**Cherry-pick notes:**
- Resolved a merge conflict in `server/main.go` by keeping the `release-2.0` `NewPluginMCPHandlers` signature while adopting the updated `deriveInternalServerURL(pluginAPI, *siteURL)` call.
- Also cherry-picked #831 to fix real-API e2e CI failures on `release-2.0` caused by the retired `claude-sonnet-4-20250514` model (HTTP 404 from Anthropic).
- Backported Bifrost citation annotation handling from `master` so Anthropic `web_search` citations render with `claude-sonnet-4-6` (fixes `e2e-llmbot-real-apis-citations`).

**Original PRs:**
- https://github.com/mattermost/mattermost-plugin-agents/pull/828
- https://github.com/mattermost/mattermost-plugin-agents/pull/831

#### Ticket Link

Jira https://mattermost.atlassian.net/browse/MM-69180

#### Screenshots

Pure backend logic change — no UI surface.

#### Release Note

```release-note
Fixed embedded MCP authentication failing when Mattermost terminates TLS directly (ListenAddress=:443, ConnectionSecurity=TLS). The plugin now uses SiteURL for internal API calls in that topology instead of http://localhost:port.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb26e876-2f5b-4979-bb27-2ee8809cb380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb26e876-2f5b-4979-bb27-2ee8809cb380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

