### PR TITLE
Add bare name to tool list endpoint and ensure hooks work for namespaced tools

### DIFF
--- a/api/api_llm_bridge.go
+++ b/api/api_llm_bridge.go
@@ -325,31 +325,14 @@ func (a *API) prepareAgentBridgeCompletion(
 		return nil, llm.CompletionRequest{}, nil, nil, nil, http.StatusBadRequest, errors.New("tool_hooks requires allowed_tools")
 	}
 
-	// Issue before-hook keys up front so we have a stable per-tool metadata map to
-	// bind into each scoped tool's CallMetadata below. Hook keys are tracked in
-	// beforeHookKeys so the deferred cleanup runs even on later failures.
-	hookMetaByTool := make(map[string]map[string]any, len(req.ToolHooks))
+	// Normalize tool_hooks keys to bare names so they match the embedded MCP
+	// server, which registers and runs before-hooks by bare name. Callers may key
+	// hooks by either the bare or namespaced form; both collapse to the same bare
+	// key. Keys are issued lazily per scoped tool below, tracked in beforeHookKeys
+	// so the deferred cleanup runs even on later failures.
+	hooksByBareName := make(map[string]bridgeclient.ToolHookConfig, len(req.ToolHooks))
 	for name, cfg := range req.ToolHooks {
-		hookEntry := make(map[string]any)
-		if cfg.BeforeCallback != "" {
-			beforeHookKey, hookErr := a.beforeHookStore.Issue(req.UserID, name, normalizedPluginID, cfg.BeforeCallback)
-			if hookErr != nil {
-				statusCode := http.StatusInternalServerError
-				if errors.Is(hookErr, mcp.ErrInvalidBeforeHookConfig) {
-					statusCode = http.StatusBadRequest
-				}
-				return nil, llm.CompletionRequest{}, nil, nil, nil, statusCode, fmt.Errorf("invalid tool_hooks: %w", hookErr)
-			}
-			beforeHookKeys = append(beforeHookKeys, beforeHookKey)
-			hookEntry["before_hook_key"] = beforeHookKey
-		}
-		// Wire format on the MCP server side keys hooks by tool name (see
-		// mcpserver/tools/provider.go decodeToolHooksFromMetadata). Per-tool binding
-		// means each call only carries its own entry, but the structure stays the
-		// same so the server-side decode is unchanged.
-		hookMetaByTool[name] = map[string]any{
-			"tool_hooks": map[string]any{name: hookEntry},
-		}
+		hooksByBareName[llm.BareMCPToolName(name)] = cfg
 	}
 
 	autoRunNames := make(map[string]struct{})
@@ -364,6 +347,9 @@ func (a *API) prepareAgentBridgeCompletion(
 
 		scopedTools := llm.NewToolStore()
 		for _, name := range allowedToolNames {
+			// GetTool resolves exact namespaced names and unique bare names. A bare
+			// name that collides across servers returns nil here; the caller must
+			// pass the namespaced name to disambiguate.
 			tool := llmRequest.Context.Tools.GetTool(name)
 			if tool == nil {
 				return nil, llm.CompletionRequest{}, nil, nil, nil, http.StatusBadRequest, fmt.Errorf("tool %q is not eligible or not available for this agent", name)
@@ -374,10 +360,32 @@ func (a *API) prepareAgentBridgeCompletion(
 					name,
 				)
 			}
+
 			scopedTool := *tool
-			if meta, ok := hookMetaByTool[name]; ok {
-				scopedTool = scopedTool.WithCallMetadata(meta)
+			// Bind a before-hook (if the caller registered one for this tool) keyed
+			// by the resolved tool's bare name, so it matches the embedded server's
+			// bare lookup at execution time regardless of the name form the caller
+			// passed.
+			bare := llm.BareMCPToolName(scopedTool.Name)
+			if cfg, ok := hooksByBareName[bare]; ok && cfg.BeforeCallback != "" {
+				beforeHookKey, hookErr := a.beforeHookStore.Issue(req.UserID, bare, normalizedPluginID, cfg.BeforeCallback)
+				if hookErr != nil {
+					statusCode := http.StatusInternalServerError
+					if errors.Is(hookErr, mcp.ErrInvalidBeforeHookConfig) {
+						statusCode = http.StatusBadRequest
+					}
+					return nil, llm.CompletionRequest{}, nil, nil, nil, statusCode, fmt.Errorf("invalid tool_hooks: %w", hookErr)
+				}
+				beforeHookKeys = append(beforeHookKeys, beforeHookKey)
+				// Wire format on the MCP server side keys hooks by tool name (see
+				// mcpserver/tools/provider.go decodeToolHooksFromMetadata).
+				scopedTool = scopedTool.WithCallMetadata(map[string]any{
+					"tool_hooks": map[string]any{
+						bare: map[string]any{"before_hook_key": beforeHookKey},
+					},
+				})
 			}
+
 			scopedTools.AddTools([]llm.Tool{scopedTool})
 			autoRunNames[scopedTool.Name] = struct{}{}
 		}
@@ -708,6 +716,7 @@ func (a *API) handleGetAgentTools(c *gin.Context) {
 			}
 			tools = append(tools, bridgeclient.BridgeToolInfo{
 				Name:         info.Name,
+				BareName:     llm.BareMCPToolName(info.Name),
 				Description:  info.Description,
 				ServerOrigin: info.ServerOrigin,
 			})

--- a/api/api_llm_bridge.go
+++ b/api/api_llm_bridge.go
@@ -330,9 +330,19 @@ func (a *API) prepareAgentBridgeCompletion(
 	// hooks by either the bare or namespaced form; both collapse to the same bare
 	// key. Keys are issued lazily per scoped tool below, tracked in beforeHookKeys
 	// so the deferred cleanup runs even on later failures.
+	//
+	// Reject two distinct keys (e.g. "search_posts" and "mattermost__search_posts")
+	// that collapse to the same bare name: silently keeping one would be
+	// non-deterministic. Each tool may be hooked once.
 	hooksByBareName := make(map[string]bridgeclient.ToolHookConfig, len(req.ToolHooks))
+	hookKeyByBareName := make(map[string]string, len(req.ToolHooks))
 	for name, cfg := range req.ToolHooks {
-		hooksByBareName[llm.BareMCPToolName(name)] = cfg
+		bare := llm.BareMCPToolName(name)
+		if existing, ok := hookKeyByBareName[bare]; ok {
+			return nil, llm.CompletionRequest{}, nil, nil, nil, http.StatusBadRequest, fmt.Errorf("tool_hooks has conflicting entries %q and %q for the same tool; specify it once", existing, name)
+		}
+		hookKeyByBareName[bare] = name
+		hooksByBareName[bare] = cfg
 	}
 
 	autoRunNames := make(map[string]struct{})

--- a/api/api_llm_bridge_test.go
+++ b/api/api_llm_bridge_test.go
@@ -2193,6 +2193,51 @@ func TestPrepareAgentBridgeCompletionToolHooksNormalizeToBare(t *testing.T) {
 	}
 }
 
+// TestPrepareAgentBridgeCompletionToolHooksRejectsConflictingKeys verifies that
+// two tool_hooks keys for the same tool (one bare, one namespaced) that normalize
+// to the same bare name are rejected deterministically rather than silently
+// keeping one.
+func TestPrepareAgentBridgeCompletionToolHooksRejectsConflictingKeys(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	e.setupBridgeMCPProvider([]llm.Tool{
+		bridgeMCPTool("mattermost", "search_posts", embeddedOrigin),
+	})
+	e.setupTestBot(llm.BotConfig{
+		Name:                  "testbot",
+		DisplayName:           "Test Bot",
+		UserAccessLevel:       llm.UserAccessLevelAll,
+		MCPDynamicToolLoading: true,
+		EnabledMCPTools: []llm.EnabledMCPTool{
+			{ServerOrigin: embeddedOrigin, ToolName: "search_posts"},
+		},
+	})
+
+	_, _, _, _, _, statusCode, err := e.api.prepareAgentBridgeCompletion(
+		context.Background(),
+		testBotUserID,
+		bridgeclient.CompletionRequest{
+			Posts:        []bridgeclient.Post{{Role: "user", Message: "Hi"}},
+			AllowedTools: []string{"search_posts"},
+			UserID:       testUserID,
+			ToolHooks: map[string]bridgeclient.ToolHookConfig{
+				"search_posts":             {BeforeCallback: "/hooks/before-a"},
+				"mattermost__search_posts": {BeforeCallback: "/hooks/before-b"},
+			},
+		},
+		"com.example.caller",
+		llm.OperationBridgeAgent,
+		llm.SubTypeNoStream,
+	)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, statusCode)
+	require.Contains(t, err.Error(), "conflicting entries")
+}
+
 func TestCleanupBeforeHookKeysDeletesIssuedKeys(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DefaultWriter = io.Discard

--- a/api/api_llm_bridge_test.go
+++ b/api/api_llm_bridge_test.go
@@ -1708,6 +1708,223 @@ func TestBridgeClientAgentCompletionAllowedToolsEnablesAutoRun(t *testing.T) {
 	require.Len(t, fakeLLM.LastConversation.Context.Tools.GetTools(), 1)
 }
 
+// fakeBridgeMCPToolProvider is a minimal llmcontext.MCPToolProvider that returns
+// a fixed set of (namespaced) MCP tools regardless of user. Unlike
+// testLLMContextToolProvider (which feeds the built-in tool path), this exercises
+// the real MCP path: per-agent allowlist filtering and namespacing.
+type fakeBridgeMCPToolProvider struct {
+	tools []llm.Tool
+}
+
+func (p *fakeBridgeMCPToolProvider) GetToolsForUser(_ context.Context, _ string) ([]llm.Tool, *mcp.Errors) {
+	return p.tools, nil
+}
+
+// setupBridgeMCPProvider wires the context builder with a real MCP tool provider
+// returning the given namespaced tools, so bridge discovery and completion run
+// through getToolsStoreForUser (namespacing + EnabledMCPTools filtering).
+func (e *TestEnvironment) setupBridgeMCPProvider(tools []llm.Tool) {
+	e.api.contextBuilder = llmcontext.NewLLMContextBuilder(
+		e.client,
+		&testLLMContextToolProvider{},
+		&fakeBridgeMCPToolProvider{tools: tools},
+		&testLLMContextConfigProvider{},
+	)
+}
+
+// bridgeMCPTool builds a namespaced MCP tool (slug__bare) with the given origin.
+func bridgeMCPTool(serverSlug, bareName, serverOrigin string) llm.Tool {
+	return llm.Tool{
+		Name:         llm.NamespaceMCPToolName(serverSlug, bareName),
+		ServerOrigin: serverOrigin,
+		Description:  bareName,
+		Schema:       llm.NewJSONSchemaFromStruct[struct{}](),
+		Resolver: func(_ context.Context, _ *llm.Context, _ llm.ToolArgumentGetter) (string, error) {
+			return "ok", nil
+		},
+	}
+}
+
+const embeddedOrigin = "embedded://mattermost"
+
+// TestBridgeGetAgentToolsReturnsBareAndNamespacedNames verifies discovery
+// advertises the namespaced runtime name plus the additive bare_name field, so
+// callers that work in bare names can still validate against the list.
+func TestBridgeGetAgentToolsReturnsBareAndNamespacedNames(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	e.setupBridgeMCPProvider([]llm.Tool{
+		bridgeMCPTool("mattermost", "search_posts", embeddedOrigin),
+	})
+
+	e.setupTestBot(llm.BotConfig{
+		Name:                  "testbot",
+		DisplayName:           "Test Bot",
+		UserAccessLevel:       llm.UserAccessLevelAll,
+		MCPDynamicToolLoading: true,
+		EnabledMCPTools: []llm.EnabledMCPTool{
+			{ServerOrigin: embeddedOrigin, ToolName: "search_posts"},
+		},
+	})
+
+	client := e.CreateBridgeClient()
+	tools, err := client.GetAgentTools(testBotUserID, testUserID)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	require.Equal(t, "mattermost__search_posts", tools[0].Name)
+	require.Equal(t, "search_posts", tools[0].BareName)
+	require.Equal(t, embeddedOrigin, tools[0].ServerOrigin)
+}
+
+// TestBridgeClientAgentCompletionAllowedToolsAcceptsBareName verifies a bridge
+// caller can pass the bare tool name and have it resolve to the namespaced
+// runtime tool (the pre-#772 contract that namespacing regressed).
+func TestBridgeClientAgentCompletionAllowedToolsAcceptsBareName(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	e.setupBridgeMCPProvider([]llm.Tool{
+		bridgeMCPTool("mattermost", "search_posts", embeddedOrigin),
+	})
+
+	e.setupTestBot(llm.BotConfig{
+		Name:                  "testbot",
+		DisplayName:           "Test Bot",
+		UserAccessLevel:       llm.UserAccessLevelAll,
+		MCPDynamicToolLoading: true,
+		EnabledMCPTools: []llm.EnabledMCPTool{
+			{ServerOrigin: embeddedOrigin, ToolName: "search_posts"},
+		},
+	})
+
+	fakeLLM := NewFakeLLM("done")
+	fakeLLM.StreamEventSequence = fakeLLMAutoRunSequence("tc1", "mattermost__search_posts", "done")
+	for _, bot := range e.bots.GetAllBots() {
+		bot.SetLLMForTest(fakeLLM)
+	}
+
+	client := e.CreateBridgeClient()
+	result, err := client.AgentCompletion(testBotUserID, bridgeclient.CompletionRequest{
+		Posts:        []bridgeclient.Post{{Role: "user", Message: "search"}},
+		AllowedTools: []string{"search_posts"},
+		UserID:       testUserID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "done", result)
+	require.Len(t, fakeLLM.AllRequests, 2)
+	require.Equal(t, 1, findAutoApprovedToolUse(fakeLLM.AllRequests[1], "mattermost__search_posts"))
+}
+
+// TestBridgeClientAgentCompletionAllowedToolsAcceptsNamespacedName verifies the
+// namespaced runtime name is still accepted in allowed_tools.
+func TestBridgeClientAgentCompletionAllowedToolsAcceptsNamespacedName(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+
+	e.setupBridgeMCPProvider([]llm.Tool{
+		bridgeMCPTool("mattermost", "search_posts", embeddedOrigin),
+	})
+
+	e.setupTestBot(llm.BotConfig{
+		Name:                  "testbot",
+		DisplayName:           "Test Bot",
+		UserAccessLevel:       llm.UserAccessLevelAll,
+		MCPDynamicToolLoading: true,
+		EnabledMCPTools: []llm.EnabledMCPTool{
+			{ServerOrigin: embeddedOrigin, ToolName: "search_posts"},
+		},
+	})
+
+	fakeLLM := NewFakeLLM("done")
+	fakeLLM.StreamEventSequence = fakeLLMAutoRunSequence("tc1", "mattermost__search_posts", "done")
+	for _, bot := range e.bots.GetAllBots() {
+		bot.SetLLMForTest(fakeLLM)
+	}
+
+	client := e.CreateBridgeClient()
+	result, err := client.AgentCompletion(testBotUserID, bridgeclient.CompletionRequest{
+		Posts:        []bridgeclient.Post{{Role: "user", Message: "search"}},
+		AllowedTools: []string{"mattermost__search_posts"},
+		UserID:       testUserID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "done", result)
+	require.Len(t, fakeLLM.AllRequests, 2)
+	require.Equal(t, 1, findAutoApprovedToolUse(fakeLLM.AllRequests[1], "mattermost__search_posts"))
+}
+
+// TestBridgeClientAgentCompletionAllowedToolsRejectsBareCollision verifies that a
+// bare name colliding across servers is rejected (GetTool returns nil on an
+// ambiguous bare name), and that passing the namespaced name disambiguates.
+func TestBridgeClientAgentCompletionAllowedToolsRejectsBareCollision(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	setup := func(t *testing.T) (*TestEnvironment, *FakeLLM) {
+		t.Helper()
+		e := SetupTestEnvironment(t)
+		e.setupBridgeMCPProvider([]llm.Tool{
+			bridgeMCPTool("mattermost", "create_post", embeddedOrigin),
+			bridgeMCPTool("remote", "create_post", "https://remote.example.com"),
+		})
+		// AutoEnable keeps both tools in the store (no upstream allowlist
+		// filtering), so the bare name "create_post" collides.
+		e.setupTestBot(llm.BotConfig{
+			Name:                  "testbot",
+			DisplayName:           "Test Bot",
+			UserAccessLevel:       llm.UserAccessLevelAll,
+			MCPDynamicToolLoading: true,
+			AutoEnableNewMCPTools: true,
+		})
+		fakeLLM := NewFakeLLM("done")
+		fakeLLM.StreamEventSequence = fakeLLMAutoRunSequence("tc1", "mattermost__create_post", "done")
+		for _, bot := range e.bots.GetAllBots() {
+			bot.SetLLMForTest(fakeLLM)
+		}
+		return e, fakeLLM
+	}
+
+	t.Run("bare name is rejected", func(t *testing.T) {
+		e, _ := setup(t)
+		defer e.Cleanup(t)
+
+		client := e.CreateBridgeClient()
+		_, err := client.AgentCompletion(testBotUserID, bridgeclient.CompletionRequest{
+			Posts:        []bridgeclient.Post{{Role: "user", Message: "post"}},
+			AllowedTools: []string{"create_post"},
+			UserID:       testUserID,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not eligible or not available")
+	})
+
+	t.Run("namespaced name disambiguates", func(t *testing.T) {
+		e, fakeLLM := setup(t)
+		defer e.Cleanup(t)
+
+		client := e.CreateBridgeClient()
+		result, err := client.AgentCompletion(testBotUserID, bridgeclient.CompletionRequest{
+			Posts:        []bridgeclient.Post{{Role: "user", Message: "post"}},
+			AllowedTools: []string{"mattermost__create_post"},
+			UserID:       testUserID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "done", result)
+		require.Len(t, fakeLLM.AllRequests, 2)
+		require.Equal(t, 1, findAutoApprovedToolUse(fakeLLM.AllRequests[1], "mattermost__create_post"))
+	})
+}
+
 func TestBridgeClientAgentCompletionAllowedToolsWorksWithDynamicMCPAgent(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DefaultWriter = io.Discard
@@ -1881,6 +2098,99 @@ func TestPrepareAgentBridgeCompletionStoresToolHookKeysInMCPMetadata(t *testing.
 	require.NotContains(t, eligible, "before_callback")
 	require.Equal(t, testUserID, storedEntry.UserID)
 	require.Equal(t, "eligible_tool", storedEntry.ToolName)
+}
+
+// TestPrepareAgentBridgeCompletionToolHooksNormalizeToBare verifies before-hooks
+// fire whether the caller keys allowed_tools / tool_hooks by the bare or
+// namespaced name: the issued key and the MCP metadata key are always the bare
+// name, matching the embedded server's bare lookup at execution time.
+func TestPrepareAgentBridgeCompletionToolHooksNormalizeToBare(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	const (
+		bare       = "search_posts"
+		namespaced = "mattermost__search_posts"
+	)
+
+	testCases := []struct {
+		name        string
+		allowedTool string
+		hookKey     string
+	}{
+		{name: "bare allowed, bare hook", allowedTool: bare, hookKey: bare},
+		{name: "namespaced allowed, namespaced hook", allowedTool: namespaced, hookKey: namespaced},
+		{name: "namespaced allowed, bare hook", allowedTool: namespaced, hookKey: bare},
+		{name: "bare allowed, namespaced hook", allowedTool: bare, hookKey: namespaced},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := SetupTestEnvironment(t)
+			defer e.Cleanup(t)
+
+			e.setupBridgeMCPProvider([]llm.Tool{
+				bridgeMCPTool("mattermost", bare, embeddedOrigin),
+			})
+			e.setupTestBot(llm.BotConfig{
+				Name:                  "testbot",
+				DisplayName:           "Test Bot",
+				UserAccessLevel:       llm.UserAccessLevelAll,
+				MCPDynamicToolLoading: true,
+				EnabledMCPTools: []llm.EnabledMCPTool{
+					{ServerOrigin: embeddedOrigin, ToolName: bare},
+				},
+			})
+
+			var storedKey string
+			var storedEntry mcp.BeforeHookEntry
+			e.mockAPI.On(
+				"KVSetWithOptions",
+				mock.MatchedBy(func(key string) bool {
+					storedKey = key
+					return strings.HasPrefix(key, "beforeHook:")
+				}),
+				mock.MatchedBy(func(data []byte) bool {
+					if err := json.Unmarshal(data, &storedEntry); err != nil {
+						return false
+					}
+					return storedEntry.ToolName == bare
+				}),
+				mock.MatchedBy(func(opts model.PluginKVSetOptions) bool {
+					return opts.ExpireInSeconds == int64(mcp.BeforeHookKeyTTL.Seconds())
+				}),
+			).Return(true, (*model.AppError)(nil)).Once()
+
+			_, llmRequest, _, _, beforeHookKeys, statusCode, err := e.api.prepareAgentBridgeCompletion(
+				context.Background(),
+				testBotUserID,
+				bridgeclient.CompletionRequest{
+					Posts:        []bridgeclient.Post{{Role: "user", Message: "Hi"}},
+					AllowedTools: []string{tc.allowedTool},
+					UserID:       testUserID,
+					ToolHooks: map[string]bridgeclient.ToolHookConfig{
+						tc.hookKey: {BeforeCallback: "/hooks/before"},
+					},
+				},
+				"com.example.caller",
+				llm.OperationBridgeAgent,
+				llm.SubTypeNoStream,
+			)
+			require.NoError(t, err)
+			require.Equal(t, 0, statusCode)
+			require.Equal(t, []string{storedKey}, beforeHookKeys)
+			require.Equal(t, bare, storedEntry.ToolName)
+
+			require.NotNil(t, llmRequest.Context.Tools)
+			scopedTool := llmRequest.Context.Tools.GetTool(namespaced)
+			require.NotNil(t, scopedTool)
+			hooks, ok := scopedTool.CallMetadata["tool_hooks"].(map[string]any)
+			require.True(t, ok)
+			entry, ok := hooks[bare].(map[string]any)
+			require.True(t, ok, "tool_hooks metadata must be keyed by the bare name")
+			require.Equal(t, storedKey, entry["before_hook_key"])
+		})
+	}
 }
 
 func TestCleanupBeforeHookKeysDeletesIssuedKeys(t *testing.T) {

--- a/public/bridgeclient/README.md
+++ b/public/bridgeclient/README.md
@@ -111,14 +111,17 @@ request := bridgeclient.CompletionRequest{
 
 ### Agent tool allowlist
 
-Use tool names exactly as returned by `GetAgentTools` (each entry in `allowed_tools` is a string tool name).
+Each entry in `allowed_tools` is a string tool name. The bridge accepts **both**
+the namespaced runtime name (`server__tool`, e.g. `mattermost__search_posts`) and
+the bare name (`search_posts`). `GetAgentTools` returns both forms per tool
+(`Name` is namespaced, `BareName` is bare). Bare names remain supported for backward compatibility.
 
 ```go
 request := bridgeclient.CompletionRequest{
     Posts: []bridgeclient.Post{
         {Role: "user", Message: "Use the eligible MCP tool"},
     },
-    AllowedTools: []string{"eligible_tool_name"},
+    AllowedTools: []string{"mattermost__search_posts", "read_channel"},
     UserID:       userID, // Required when using AllowedTools
 }
 
@@ -130,6 +133,9 @@ When `AllowedTools` is provided:
 - tool execution is auto-run (no approval flow)
 - tools must come from enabled MCP servers or embedded MCP servers (built-in agent tools are not exposed for bridge allowlists)
 - empty lists and blank tool names are rejected by the bridge API
+- a bare name that exists on more than one MCP server is ambiguous and is
+  rejected; pass the namespaced name (`server__tool`) to target a specific
+  server's tool
 
 ## Permission Checking
 
@@ -226,13 +232,16 @@ if err != nil {
 }
 
 for _, tool := range tools {
-    fmt.Printf("Tool: %s - %s\n", tool.Name, tool.Description)
+    fmt.Printf("Tool: %s (bare: %s) - %s\n", tool.Name, tool.BareName, tool.Description)
 }
 ```
 
 This endpoint returns only tools that are currently eligible for `AllowedTools`.
 Eligible tools come from enabled MCP servers and embedded MCP servers.
 If no eligible tools are available, this returns an empty list.
+
+Each entry exposes both `Name` (namespaced) and `BareName`. Either may be passed
+in `allowed_tools`; validate stored allowlists against either field.
 
 You can optionally pass `userID` to apply user-level permission filtering:
 

--- a/public/bridgeclient/client.go
+++ b/public/bridgeclient/client.go
@@ -98,7 +98,12 @@ type BridgeServiceInfo struct {
 
 // BridgeToolInfo represents a bridge-eligible tool (MCP or embedded; not built-in).
 type BridgeToolInfo struct {
-	Name        string `json:"name"`
+	// Name is the namespaced runtime tool name (e.g. "mattermost__search_posts").
+	Name string `json:"name"`
+	// BareName is the tool's bare name without the server namespace prefix
+	// (e.g. "search_posts"). Both Name and BareName are accepted in allowed_tools;
+	// prefer Name (namespaced) for new integrations.
+	BareName    string `json:"bare_name,omitempty"`
 	Description string `json:"description"`
 	// ServerOrigin is the MCP server base URL or the embedded client key; never empty.
 	ServerOrigin string `json:"server_origin,omitempty"`


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Changing tool names to be namespaced broke automations because existing automations rely on the bare tool names. The agent tool list endpoint now returns the bare name with the namespaced tool so that the bridge endpoints are backwards compatible. Also, fixed the before hooks so the work with both namespaced and bare tool names.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69459

#### Related
https://github.com/mattermost/mattermost-plugin-channel-automation/pull/75

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents now accept allowed tools specified using either bare names (e.g., `search_posts`) or namespaced names (e.g., `server__search_posts`).
  * Tool information endpoints now return both namespaced (`Name`) and bare (`BareName`) identifiers.

* **Bug Fixes**
  * Improved handling of tool hooks to consistently normalize hook keys to the bare tool name.
  * Bare-name collisions across multiple MCP servers are rejected unless disambiguated with a namespaced name.

* **Documentation**
  * Updated guidance for allowed tools naming and ambiguous bare names.

* **Tests**
  * Expanded coverage for tool name resolution and tool hook normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->