### PR TITLE
harden: SSRF guards on MCP/OAuth URLs + strip email PII from channel tool

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -234,11 +235,41 @@ func (c *EmbeddedServerClient) CreateClient(ctx context.Context, userID, session
 	return client, nil
 }
 
+// requireSafeMCPURL rejects MCP server URLs that could be used for SSRF.
+// Embedded servers (EmbeddedClientKey) are always allowed.
+// External URLs must use HTTPS unless the host is a loopback address
+// (localhost / 127.x / ::1), which is permitted for local dev.
+func requireSafeMCPURL(baseURL string) error {
+	if baseURL == EmbeddedClientKey {
+		return nil
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Errorf("invalid MCP server URL: %w", err)
+	}
+	host := u.Hostname()
+	ip := net.ParseIP(host)
+	isLoopback := (ip != nil && ip.IsLoopback()) || host == "localhost"
+	if u.Scheme != "https" && !isLoopback {
+		return fmt.Errorf("MCP server URL must use HTTPS for non-local servers (got scheme %q in %q)", u.Scheme, baseURL)
+	}
+	if ip != nil && !isLoopback {
+		if ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+			return fmt.Errorf("MCP server URL must not point to a private or link-local address: %q", baseURL)
+		}
+	}
+	return nil
+}
+
 // NewClient creates a new MCP client for the given server and user and connects to the specified MCP server.
 // forceRefresh bypasses the shared tools cache read. Its sole purpose is to close the race where a concurrent
 // lookup repopulates the cache between a manual refresh's invalidation and this reconnect; a plain
 // post-invalidation rediscovery would otherwise cache-miss on its own.
 func NewClient(ctx context.Context, userID string, serverConfig ServerConfig, log pluginapi.LogService, oauthManager *OAuthManager, httpClient *http.Client, toolsCache *ToolsCache, forceRefresh bool) (*Client, error) {
+	if err := requireSafeMCPURL(serverConfig.BaseURL); err != nil {
+		return nil, fmt.Errorf("MCP server URL validation failed: %w", err)
+	}
+
 	c := &Client{
 		session:      nil,
 		config:       serverConfig,

--- a/mcp/oauth_metadata.go
+++ b/mcp/oauth_metadata.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 )
@@ -40,6 +41,10 @@ func discoverProtectedResourceMetadata(ctx context.Context, httpClient *http.Cli
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct metadata URL: %w", err)
 		}
+	}
+
+	if err := requireSafeOAuthURL(metadataURL); err != nil {
+		return nil, fmt.Errorf("protected resource metadata URL rejected: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
@@ -77,6 +82,12 @@ func discoverProtectedResourceMetadata(ctx context.Context, httpClient *http.Cli
 
 // discoverAuthorizationServerMetadata fetches the OAuth 2.0 Authorization Server Metadata (RFC 8414)
 func discoverAuthorizationServerMetadata(ctx context.Context, httpClient *http.Client, authServerIssuer string) (*AuthorizationServerMetadata, error) {
+	// authServerIssuer comes from a remote server's JSON body — validate it before
+	// building any URLs from it to prevent SSRF via a crafted authorization_servers list.
+	if err := requireSafeOAuthURL(authServerIssuer); err != nil {
+		return nil, fmt.Errorf("authorization server issuer URL rejected: %w", err)
+	}
+
 	// Construct the well-known metadata URL according to RFC 8414 Section 3.1
 	// The well-known URI must be inserted between the host and path components
 	metadataURL, err := constructWellKnownURL(authServerIssuer, "oauth-authorization-server")
@@ -121,6 +132,21 @@ func discoverAuthorizationServerMetadata(ctx context.Context, httpClient *http.C
 		return nil, fmt.Errorf("missing required 'token_endpoint' field in authorization server metadata from %s", metadataURL)
 	}
 
+	// Reject SSRF bait: endpoints in the metadata body could be attacker-controlled
+	// (a compromised or malicious OAuth server could return internal IPs).
+	for field, rawEndpoint := range map[string]string{
+		"authorization_endpoint": metadata.AuthorizationEndpoint,
+		"token_endpoint":         metadata.TokenEndpoint,
+		"registration_endpoint":  metadata.RegistrationEndpoint,
+	} {
+		if rawEndpoint == "" {
+			continue
+		}
+		if safeErr := requireSafeOAuthURL(rawEndpoint); safeErr != nil {
+			return nil, fmt.Errorf("authorization server metadata field %q rejected: %w", field, safeErr)
+		}
+	}
+
 	// Validate that the issuer matches the expected value
 	// 2025-03-26 of mcp spec allows mismatches here.
 	/*if metadata.Issuer != authServerIssuer {
@@ -128,6 +154,44 @@ func discoverAuthorizationServerMetadata(ctx context.Context, httpClient *http.C
 	}*/
 
 	return &metadata, nil
+}
+
+// requireSafeOAuthURL rejects URLs that could be used for SSRF via OAuth metadata.
+// Any URL that comes from a remote server's JSON response (authorization_servers,
+// authorization_endpoint, token_endpoint, registration_endpoint) must pass this
+// check before we make a follow-up request to it.
+//
+// Rules:
+//   - loopback / localhost is allowed (local MCP and OAuth servers are a supported
+//     deployment; SSRF to loopback in production is already blocked by Mattermost's
+//     untrusted HTTP client). This mirrors requireSafeMCPURL in client.go.
+//   - any non-local host must use https (rejects plaintext downgrade, file, ftp, etc.)
+//   - any non-local host must not be a private, link-local, or unspecified IP
+func requireSafeOAuthURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid OAuth URL: %w", err)
+	}
+	host := u.Hostname()
+	ip := net.ParseIP(host)
+	isLoopback := (ip != nil && ip.IsLoopback()) || host == "localhost"
+	if isLoopback {
+		return nil
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("OAuth metadata URL must use HTTPS for non-local hosts, got scheme %q in %q", u.Scheme, rawURL)
+	}
+	if ip != nil {
+		switch {
+		case ip.IsPrivate():
+			return fmt.Errorf("OAuth metadata URL must not point to a private address: %q", rawURL)
+		case ip.IsLinkLocalUnicast(), ip.IsLinkLocalMulticast():
+			return fmt.Errorf("OAuth metadata URL must not point to a link-local address: %q", rawURL)
+		case ip.IsUnspecified():
+			return fmt.Errorf("OAuth metadata URL must not point to an unspecified address: %q", rawURL)
+		}
+	}
+	return nil
 }
 
 // constructWellKnownURL constructs a well-known URL according to RFC 8414 Section 3.1

--- a/mcp/oauth_metadata_test.go
+++ b/mcp/oauth_metadata_test.go
@@ -124,3 +124,41 @@ func TestConstructWellKnownURL(t *testing.T) {
 		})
 	}
 }
+
+func TestRequireSafeOAuthURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawURL    string
+		expectErr bool
+	}{
+		// Allowed: legitimate public OAuth servers over HTTPS.
+		{name: "https public host", rawURL: "https://auth.example.com/authorize", expectErr: false},
+		{name: "https public host with port", rawURL: "https://auth.example.com:8443/token", expectErr: false},
+		// Allowed: loopback / localhost (supported local deployment; SSRF to
+		// loopback in production is blocked by the untrusted HTTP client).
+		{name: "loopback ipv4 http", rawURL: "http://127.0.0.1:53257/authorize", expectErr: false},
+		{name: "loopback ipv6 http", rawURL: "http://[::1]:9000/token", expectErr: false},
+		{name: "localhost http", rawURL: "http://localhost:8080/register", expectErr: false},
+		// Rejected: plaintext downgrade to a non-local host.
+		{name: "http public host", rawURL: "http://auth.example.com/authorize", expectErr: true},
+		{name: "non-http scheme", rawURL: "file:///etc/passwd", expectErr: true},
+		// Rejected: SSRF into internal ranges via a crafted metadata body.
+		{name: "private 10/8", rawURL: "https://10.0.0.5/token", expectErr: true},
+		{name: "private 192.168/16", rawURL: "https://192.168.1.1/authorize", expectErr: true},
+		{name: "private 172.16/12", rawURL: "https://172.16.0.1/token", expectErr: true},
+		{name: "link-local 169.254", rawURL: "https://169.254.169.254/latest/meta-data", expectErr: true},
+		{name: "unspecified", rawURL: "https://0.0.0.0/token", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireSafeOAuthURL(tt.rawURL)
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error for %q, got nil", tt.rawURL)
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("expected no error for %q, got %v", tt.rawURL, err)
+			}
+		})
+	}
+}

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -582,6 +582,9 @@ func (p *MattermostToolProvider) toolGetChannelMembers(mcpContext *MCPToolContex
 			continue
 		}
 
+		// Strip email before passing to formatter — tool output is readable by all
+		// AI context consumers in the channel; email is PII not needed for agent tasks.
+		user.Email = ""
 		format.WriteUser(&result, format.UserEntry{
 			User: user,
 			Role: format.MemberRole(member.SchemeAdmin, member.SchemeGuest, member.SchemeUser),


### PR DESCRIPTION
#### Summary

Defense-in-depth hardening against the SSRF class addressed by CVE-2025-47700, plus a PII leak fix. Three changes:

- **`mcp/oauth_metadata.go`** — add `requireSafeOAuthURL`, applied to every URL that originates from a remote server's JSON body (`authorization_servers` issuer, `authorization_endpoint`, `token_endpoint`, `registration_endpoint`) before a follow-up request is made. Allows loopback/localhost (a supported local deployment; production SSRF-to-loopback is already blocked by the untrusted HTTP client), requires HTTPS for non-local hosts, and rejects private, link-local, and unspecified IP ranges. Covered by `TestRequireSafeOAuthURL`.
- **`mcp/client.go`** — add a `requireSafeMCPURL` guard at `NewClient`, mirroring the OAuth rule, so an externally-configured MCP server URL is validated before any network connection is opened.
- **`mcpserver/tools/channels.go`** — strip `user.Email` before `format.WriteUser` in `toolGetChannelMembers`. Tool output is readable by every AI context consumer in a channel; email is PII not needed for agent tasks.

These are belt-and-suspenders guards layered above the existing transport-level protection (`MakeClient(false)` untrusted client) — they add scheme enforcement and explicit rejection of internal ranges at the point each remote-supplied URL is consumed.

**Test steps:** `go build ./mcp/... ./mcpserver/...`, `go vet ./mcp/... ./mcpserver/tools/...`, and `go test ./mcp/... ./mcpserver/tools/...` all pass. `TestRequireSafeOAuthURL` covers the allow/reject matrix (public HTTPS, loopback, localhost, private 10/192.168/172.16, link-local 169.254, unspecified, plaintext downgrade, non-http scheme).

#### Ticket Link

N/A — hardening contribution.

#### Release Note

```release-note
Hardened MCP and OAuth metadata URL handling against SSRF: remote-supplied OAuth discovery endpoints and configured MCP server URLs are now validated to require HTTPS for non-local hosts and to reject private, link-local, and unspecified IP ranges. Stripped email addresses from the get-channel-members tool output to avoid exposing PII to AI context consumers.
```
