### PR TITLE
Simplify MCP server tool definitions to ease adding tools

### DIFF
--- a/mcpserver/AGENTS.md
+++ b/mcpserver/AGENTS.md
@@ -21,8 +21,23 @@ Scoped instructions for the `mcpserver/` package. Root rules in `/AGENTS.md` sti
 - HTTP serialization DTOs (e.g., `httpSearchRequest`, `httpSearchResult` in `search_http.go`) are intentionally separate from domain types and stay in their respective files.
 - If you only need a subset of fields, accept the full type and ignore the unused fields rather than introducing a parallel struct.
 
+## Adding a tool
+
+Tools live in `tools/<area>.go` and are registered through `getXTools()` aggregated by `mcpTools()` in `provider.go`. To add one:
+
+1. **Args struct** — define `XArgs` with `json` + `jsonschema` tags. For ID fields use `minLength=26,maxLength=26` when required, `maxLength=26` (with `,omitempty`) when optional. Tag fields that only make sense for local servers with `access:"local"`.
+2. **Resolver** — write `func (p *MattermostToolProvider) toolX(mcpContext *MCPToolContext, args XArgs) (string, error)`. The framework decodes args before the resolver runs, so start at the real logic — do not re-decode and do not nil-check `mcpContext.Client` (it is always set). Conventions:
+   - Validate IDs with `requireID` / `optionalID`.
+   - On failure return `"", fmt.Errorf(...)` — the error text is what the model sees, so put any guidance there (the first return value is only used on success). On a non-error "nothing found"/disambiguation outcome, return the guidance as `(text, nil)`.
+   - For posts, set AI attribution via `p.stampAIGenerated`; for member listings reuse `p.renderMembers`.
+   - Format Mattermost entities through the `format/` package, never `fmt.Sprintf` on model types.
+3. **Register** — add a literal to the relevant `getXTools()`:
+   `{Name: "x", Description: xDescription, Schema: NewJSONSchemaForAccessMode[XArgs](string(p.accessMode)), Resolver: typed("x", p.toolX)}`.
+   Put a long description in a package-level `const`. Set `Available: someFunc` to hide the tool from `tools/list` when a dependency is absent (see the automation tools).
+4. **Test** — table-driven, calling the resolver directly with an `XArgs` value (helpers in `helpers_test.go`).
+
 ## Adding a new optional capability
 
 1. Define the interface in `tools/`, reusing types from their source package.
 2. For embedded servers: add the parameter to `NewInMemoryServer`.
-3. For external servers: add a plugin HTTP endpoint plus an HTTP client implementation that calls it.
+3. For external servers: add a plugin HTTP endpoint plus an HTTP client implementation that calls it (reuse `postPluginJSON` for the request plumbing).

--- a/mcpserver/tools/agents.go
+++ b/mcpserver/tools/agents.go
@@ -49,10 +49,6 @@ func (p *MattermostToolProvider) toolListAgents(mcpContext *MCPToolContext, args
 		return "", fmt.Errorf("failed to get arguments for tool list_agents: %w", err)
 	}
 
-	if mcpContext == nil || mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
-
 	bots, err := p.fetchAIBots(mcpContext.Client)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch agents: %w", err)

--- a/mcpserver/tools/agents.go
+++ b/mcpserver/tools/agents.go
@@ -46,16 +46,16 @@ func (p *MattermostToolProvider) getAgentTools() []MCPTool {
 func (p *MattermostToolProvider) toolListAgents(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
 	var args ListAgentsArgs
 	if err := argsGetter(&args); err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool list_agents: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool list_agents: %w", err)
 	}
 
 	if mcpContext == nil || mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 
 	bots, err := p.fetchAIBots(mcpContext.Client)
 	if err != nil {
-		return "Failed to retrieve agents. The AI plugin is not reachable.", fmt.Errorf("failed to fetch agents: %w", err)
+		return "", fmt.Errorf("failed to fetch agents: %w", err)
 	}
 
 	if len(bots) == 0 {

--- a/mcpserver/tools/agents.go
+++ b/mcpserver/tools/agents.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/mattermost/mattermost-plugin-agents/format"
-	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -37,18 +36,13 @@ func (p *MattermostToolProvider) getAgentTools() []MCPTool {
 			Name:        "list_agents",
 			Description: `List all available AI agents (bots). Returns each agent's ID, display name, and username.`,
 			Schema:      NewJSONSchemaForAccessMode[ListAgentsArgs](string(p.accessMode)),
-			Resolver:    p.toolListAgents,
+			Resolver:    typed("list_agents", p.toolListAgents),
 		},
 	}
 }
 
 // toolListAgents fetches available agents via the plugin's /ai_bots endpoint.
-func (p *MattermostToolProvider) toolListAgents(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args ListAgentsArgs
-	if err := argsGetter(&args); err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool list_agents: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolListAgents(mcpContext *MCPToolContext, _ ListAgentsArgs) (string, error) {
 	bots, err := p.fetchAIBots(mcpContext.Client)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch agents: %w", err)

--- a/mcpserver/tools/agents.go
+++ b/mcpserver/tools/agents.go
@@ -36,7 +36,7 @@ func (p *MattermostToolProvider) getAgentTools() []MCPTool {
 		{
 			Name:        "list_agents",
 			Description: `List all available AI agents (bots). Returns each agent's ID, display name, and username.`,
-			Schema:      llm.NewJSONSchemaFromStruct[ListAgentsArgs](),
+			Schema:      NewJSONSchemaForAccessMode[ListAgentsArgs](string(p.accessMode)),
 			Resolver:    p.toolListAgents,
 		},
 	}

--- a/mcpserver/tools/agents_test.go
+++ b/mcpserver/tools/agents_test.go
@@ -64,8 +64,8 @@ func TestListAgents(t *testing.T) {
 			return json.Unmarshal([]byte(`{}`), target)
 		}
 
-		result, err := provider.toolListAgents(mcpCtx, argsGetter)
+		_, err := provider.toolListAgents(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, result, "not reachable")
+		assert.Contains(t, err.Error(), "failed to fetch agents")
 	})
 }

--- a/mcpserver/tools/agents_test.go
+++ b/mcpserver/tools/agents_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,12 +29,6 @@ func newTestAIBotsServer(t *testing.T, bots []AIBotInfo) *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-func newTestClient4(serverURL string) *model.Client4 {
-	client := model.NewAPIv4Client(serverURL)
-	client.AuthToken = "test-token"
-	return client
-}
-
 func TestListAgents(t *testing.T) {
 	sampleBots := []AIBotInfo{
 		{ID: "bot1id12345678901234567", DisplayName: "Otto", Username: "otto"},
@@ -47,7 +40,7 @@ func TestListAgents(t *testing.T) {
 
 	t.Run("marks self agent", func(t *testing.T) {
 		provider := newTestProvider(t, ts.URL)
-		mcpCtx := &MCPToolContext{BotUserID: "bot1id12345678901234567", Client: newTestClient4(ts.URL)}
+		mcpCtx := &MCPToolContext{BotUserID: "bot1id12345678901234567", Client: newTestClient(ts.URL)}
 		argsGetter := func(target any) error {
 			return json.Unmarshal([]byte(`{}`), target)
 		}
@@ -59,7 +52,7 @@ func TestListAgents(t *testing.T) {
 
 	t.Run("unreachable server", func(t *testing.T) {
 		provider := newTestProvider(t, "http://127.0.0.1:1")
-		mcpCtx := &MCPToolContext{Client: newTestClient4("http://127.0.0.1:1")}
+		mcpCtx := &MCPToolContext{Client: newTestClient("http://127.0.0.1:1")}
 		argsGetter := func(target any) error {
 			return json.Unmarshal([]byte(`{}`), target)
 		}

--- a/mcpserver/tools/agents_test.go
+++ b/mcpserver/tools/agents_test.go
@@ -41,11 +41,8 @@ func TestListAgents(t *testing.T) {
 	t.Run("marks self agent", func(t *testing.T) {
 		provider := newTestProvider(t, ts.URL)
 		mcpCtx := &MCPToolContext{BotUserID: "bot1id12345678901234567", Client: newTestClient(ts.URL)}
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{}`), target)
-		}
 
-		result, err := provider.toolListAgents(mcpCtx, argsGetter)
+		result, err := provider.toolListAgents(mcpCtx, ListAgentsArgs{})
 		require.NoError(t, err)
 		assert.Contains(t, result, "This is YOU")
 	})
@@ -53,11 +50,8 @@ func TestListAgents(t *testing.T) {
 	t.Run("unreachable server", func(t *testing.T) {
 		provider := newTestProvider(t, "http://127.0.0.1:1")
 		mcpCtx := &MCPToolContext{Client: newTestClient("http://127.0.0.1:1")}
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{}`), target)
-		}
 
-		_, err := provider.toolListAgents(mcpCtx, argsGetter)
+		_, err := provider.toolListAgents(mcpCtx, ListAgentsArgs{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to fetch agents")
 	})

--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -256,19 +255,19 @@ func (p *MattermostToolProvider) getAutomationTools() []MCPTool {
 Provide automation_id to get a specific automation, or use optional channel_id to filter by trigger channel.
 Returns the full JSON for each automation including trigger configuration and action pipeline.`,
 			Schema:   NewJSONSchemaForAccessMode[ListAutomationsArgs](string(p.accessMode)),
-			Resolver: p.toolListAutomations,
+			Resolver: typed("list_automations", p.toolListAutomations),
 		},
 		{
 			Name:        "get_automation_instructions",
 			Description: "Returns detailed documentation for creating and updating channel automations: triggers, actions, template syntax, allowed_tools, and required user-confirmation workflow. Call this before create_automation or update_automation.",
 			Schema:      nil,
-			Resolver:    p.toolGetAutomationInstructions,
+			Resolver:    typed("get_automation_instructions", p.toolGetAutomationInstructions),
 		},
 		{
 			Name:        "create_automation",
 			Description: createAutomationToolDescription,
 			Schema:      NewJSONSchemaForAccessMode[CreateAutomationArgs](string(p.accessMode)),
-			Resolver:    p.toolCreateAutomation,
+			Resolver:    typed("create_automation", p.toolCreateAutomation),
 		},
 		{
 			Name: "update_automation",
@@ -278,24 +277,20 @@ only what needs to change and pass the full updated automation back. Call get_au
 for trigger/action format details.
 IMPORTANT: Show the user what will change and get their confirmation first.`,
 			Schema:   NewJSONSchemaForAccessMode[UpdateAutomationArgs](string(p.accessMode)),
-			Resolver: p.toolUpdateAutomation,
+			Resolver: typed("update_automation", p.toolUpdateAutomation),
 		},
 		{
 			Name:        "delete_automation",
 			Description: "Delete a channel automation by ID. This is permanent and cannot be undone.",
 			Schema:      NewJSONSchemaForAccessMode[DeleteAutomationArgs](string(p.accessMode)),
-			Resolver:    p.toolDeleteAutomation,
+			Resolver:    typed("delete_automation", p.toolDeleteAutomation),
 		},
 	}
 }
 
 // --- Resolvers ---
 
-func (p *MattermostToolProvider) toolGetAutomationInstructions(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var noArgs struct{}
-	if err := argsGetter(&noArgs); err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool get_automation_instructions: %w", err)
-	}
+func (p *MattermostToolProvider) toolGetAutomationInstructions(mcpContext *MCPToolContext, _ struct{}) (string, error) {
 	payload, err := p.fetchAutomationInstructions(mcpContext.Ctx, mcpContext.Client)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch automation instructions from Channel Automation plugin (upgrade plugin or check connectivity): %w", err)
@@ -303,12 +298,7 @@ func (p *MattermostToolProvider) toolGetAutomationInstructions(mcpContext *MCPTo
 	return payload.Instructions, nil
 }
 
-func (p *MattermostToolProvider) toolListAutomations(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args ListAutomationsArgs
-	if err := argsGetter(&args); err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool list_automations: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolListAutomations(mcpContext *MCPToolContext, args ListAutomationsArgs) (string, error) {
 	ctx := context.Background()
 
 	// If a specific automation ID was requested, fetch just that one.
@@ -358,12 +348,7 @@ func (p *MattermostToolProvider) getAutomationByID(ctx context.Context, mcpConte
 	return formatAutomationJSON(automation)
 }
 
-func (p *MattermostToolProvider) toolCreateAutomation(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args CreateAutomationArgs
-	if err := argsGetter(&args); err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool create_automation: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolCreateAutomation(mcpContext *MCPToolContext, args CreateAutomationArgs) (string, error) {
 	if args.Name == "" {
 		return "", fmt.Errorf("name cannot be empty")
 	}
@@ -408,12 +393,7 @@ func (p *MattermostToolProvider) toolCreateAutomation(mcpContext *MCPToolContext
 	return fmt.Sprintf("Successfully created automation '%s' (ID: %s).\n\n%s", created.Name, created.ID, jsonStr), nil
 }
 
-func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args UpdateAutomationArgs
-	if err := argsGetter(&args); err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool update_automation: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext, args UpdateAutomationArgs) (string, error) {
 	if err := requireID("automation_id", args.AutomationID); err != nil {
 		return "", err
 	}
@@ -459,12 +439,7 @@ func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext
 	return fmt.Sprintf("Successfully updated automation '%s' (ID: %s).\n\n%s", updated.Name, updated.ID, jsonStr), nil
 }
 
-func (p *MattermostToolProvider) toolDeleteAutomation(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args DeleteAutomationArgs
-	if err := argsGetter(&args); err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool delete_automation: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolDeleteAutomation(mcpContext *MCPToolContext, args DeleteAutomationArgs) (string, error) {
 	if err := requireID("automation_id", args.AutomationID); err != nil {
 		return "", err
 	}

--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -290,7 +290,7 @@ func (p *MattermostToolProvider) toolGetAutomationInstructions(mcpContext *MCPTo
 }
 
 func (p *MattermostToolProvider) toolListAutomations(mcpContext *MCPToolContext, args ListAutomationsArgs) (string, error) {
-	ctx := context.Background()
+	ctx := mcpContext.Ctx
 
 	// If a specific automation ID was requested, fetch just that one.
 	if args.AutomationID != "" {
@@ -344,7 +344,7 @@ func (p *MattermostToolProvider) toolCreateAutomation(mcpContext *MCPToolContext
 		return "", fmt.Errorf("name cannot be empty")
 	}
 
-	ctx := context.Background()
+	ctx := mcpContext.Ctx
 
 	automation := Automation{
 		Name:    args.Name,
@@ -389,7 +389,7 @@ func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext
 		return "", err
 	}
 
-	ctx := context.Background()
+	ctx := mcpContext.Ctx
 
 	automation := Automation{
 		ID:      args.AutomationID,
@@ -435,7 +435,7 @@ func (p *MattermostToolProvider) toolDeleteAutomation(mcpContext *MCPToolContext
 		return "", err
 	}
 
-	ctx := context.Background()
+	ctx := mcpContext.Ctx
 
 	resp, err := doAutomationRequest(ctx, mcpContext.Client, http.MethodDelete, p.automationAPIURL("/automations/"+args.AutomationID), "")
 	if err != nil {

--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -178,8 +178,8 @@ func doAutomationRequest(ctx context.Context, client *model.Client4, method, req
 
 // ListAutomationsArgs represents arguments for the list_automations tool.
 type ListAutomationsArgs struct {
-	AutomationID string `json:"automation_id,omitempty" jsonschema:"The ID of a specific automation to retrieve"`
-	ChannelID    string `json:"channel_id,omitempty" jsonschema:"Filter automations by trigger channel ID"`
+	AutomationID string `json:"automation_id,omitempty" jsonschema:"The ID of a specific automation to retrieve,maxLength=26"`
+	ChannelID    string `json:"channel_id,omitempty" jsonschema:"Filter automations by trigger channel ID,maxLength=26"`
 }
 
 // CreateAutomationArgs represents arguments for the create_automation tool.
@@ -192,7 +192,7 @@ type CreateAutomationArgs struct {
 
 // UpdateAutomationArgs represents arguments for the update_automation tool.
 type UpdateAutomationArgs struct {
-	AutomationID string             `json:"automation_id" jsonschema:"The ID of the automation to update,minLength=1"`
+	AutomationID string             `json:"automation_id" jsonschema:"The ID of the automation to update,minLength=26,maxLength=26"`
 	Name         string             `json:"name" jsonschema:"The name of the automation,minLength=1"`
 	Enabled      bool               `json:"enabled" jsonschema:"Whether the automation is enabled"`
 	Trigger      AutomationTrigger  `json:"trigger" jsonschema:"Set exactly one trigger type"`
@@ -201,7 +201,7 @@ type UpdateAutomationArgs struct {
 
 // DeleteAutomationArgs represents arguments for the delete_automation tool.
 type DeleteAutomationArgs struct {
-	AutomationID string `json:"automation_id" jsonschema:"The ID of the automation to delete,minLength=1"`
+	AutomationID string `json:"automation_id" jsonschema:"The ID of the automation to delete,minLength=26,maxLength=26"`
 }
 
 // automationInstructionsAPIResponse matches GET .../automation-instructions on the channel-automation plugin.

--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -255,7 +255,7 @@ func (p *MattermostToolProvider) getAutomationTools() []MCPTool {
 			Description: `List or get channel automations (trigger-action workflows).
 Provide automation_id to get a specific automation, or use optional channel_id to filter by trigger channel.
 Returns the full JSON for each automation including trigger configuration and action pipeline.`,
-			Schema:   llm.NewJSONSchemaFromStruct[ListAutomationsArgs](),
+			Schema:   NewJSONSchemaForAccessMode[ListAutomationsArgs](string(p.accessMode)),
 			Resolver: p.toolListAutomations,
 		},
 		{
@@ -267,7 +267,7 @@ Returns the full JSON for each automation including trigger configuration and ac
 		{
 			Name:        "create_automation",
 			Description: createAutomationToolDescription,
-			Schema:      llm.NewJSONSchemaFromStruct[CreateAutomationArgs](),
+			Schema:      NewJSONSchemaForAccessMode[CreateAutomationArgs](string(p.accessMode)),
 			Resolver:    p.toolCreateAutomation,
 		},
 		{
@@ -277,13 +277,13 @@ omit will be cleared. Always call list_automations first to fetch the current JS
 only what needs to change and pass the full updated automation back. Call get_automation_instructions
 for trigger/action format details.
 IMPORTANT: Show the user what will change and get their confirmation first.`,
-			Schema:   llm.NewJSONSchemaFromStruct[UpdateAutomationArgs](),
+			Schema:   NewJSONSchemaForAccessMode[UpdateAutomationArgs](string(p.accessMode)),
 			Resolver: p.toolUpdateAutomation,
 		},
 		{
 			Name:        "delete_automation",
 			Description: "Delete a channel automation by ID. This is permanent and cannot be undone.",
-			Schema:      llm.NewJSONSchemaFromStruct[DeleteAutomationArgs](),
+			Schema:      NewJSONSchemaForAccessMode[DeleteAutomationArgs](string(p.accessMode)),
 			Resolver:    p.toolDeleteAutomation,
 		},
 	}

--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -309,18 +309,18 @@ func (p *MattermostToolProvider) toolGetAutomationInstructions(mcpContext *MCPTo
 func (p *MattermostToolProvider) toolListAutomations(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
 	var args ListAutomationsArgs
 	if err := argsGetter(&args); err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool list_automations: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool list_automations: %w", err)
 	}
 
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	ctx := context.Background()
 
 	// If a specific automation ID was requested, fetch just that one.
 	if args.AutomationID != "" {
 		if !model.IsValidId(args.AutomationID) {
-			return "invalid automation_id", fmt.Errorf("invalid automation_id")
+			return "", fmt.Errorf("invalid automation_id")
 		}
 		return p.getAutomationByID(ctx, mcpContext, args.AutomationID)
 	}
@@ -333,13 +333,13 @@ func (p *MattermostToolProvider) toolListAutomations(mcpContext *MCPToolContext,
 
 	resp, err := doAutomationRequest(ctx, mcpContext.Client, http.MethodGet, listURL, "")
 	if err != nil {
-		return handleAutomationHTTPError(resp, err, "")
+		return "", handleAutomationHTTPError(resp, err, "")
 	}
 	defer resp.Body.Close()
 
 	var automations []Automation
 	if err := json.NewDecoder(resp.Body).Decode(&automations); err != nil {
-		return "failed to parse automation list", fmt.Errorf("failed to decode automations response: %w", err)
+		return "", fmt.Errorf("failed to decode automations response: %w", err)
 	}
 
 	if len(automations) == 0 {
@@ -352,13 +352,13 @@ func (p *MattermostToolProvider) toolListAutomations(mcpContext *MCPToolContext,
 func (p *MattermostToolProvider) getAutomationByID(ctx context.Context, mcpContext *MCPToolContext, id string) (string, error) {
 	resp, err := doAutomationRequest(ctx, mcpContext.Client, http.MethodGet, p.automationAPIURL("/automations/"+id), "")
 	if err != nil {
-		return handleAutomationHTTPError(resp, err, id)
+		return "", handleAutomationHTTPError(resp, err, id)
 	}
 	defer resp.Body.Close()
 
 	var automation Automation
 	if err := json.NewDecoder(resp.Body).Decode(&automation); err != nil {
-		return "failed to parse automation", fmt.Errorf("failed to decode automation response: %w", err)
+		return "", fmt.Errorf("failed to decode automation response: %w", err)
 	}
 
 	return formatAutomationJSON(automation)
@@ -367,15 +367,15 @@ func (p *MattermostToolProvider) getAutomationByID(ctx context.Context, mcpConte
 func (p *MattermostToolProvider) toolCreateAutomation(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
 	var args CreateAutomationArgs
 	if err := argsGetter(&args); err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool create_automation: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool create_automation: %w", err)
 	}
 
 	if args.Name == "" {
-		return "name is required", fmt.Errorf("name cannot be empty")
+		return "", fmt.Errorf("name cannot be empty")
 	}
 
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	ctx := context.Background()
 
@@ -388,7 +388,7 @@ func (p *MattermostToolProvider) toolCreateAutomation(mcpContext *MCPToolContext
 
 	body, err := json.Marshal(automation)
 	if err != nil {
-		return "failed to encode automation", fmt.Errorf("failed to marshal automation: %w", err)
+		return "", fmt.Errorf("failed to marshal automation: %w", err)
 	}
 
 	resp, err := doAutomationRequest(ctx, mcpContext.Client, http.MethodPost, p.automationAPIURL("/automations"), string(body))
@@ -401,18 +401,18 @@ func (p *MattermostToolProvider) toolCreateAutomation(mcpContext *MCPToolContext
 			"status", statusCode,
 			"error", err.Error(),
 		)
-		return handleAutomationHTTPError(resp, err, "")
+		return "", handleAutomationHTTPError(resp, err, "")
 	}
 	defer resp.Body.Close()
 
 	var created Automation
 	if decodeErr := json.NewDecoder(resp.Body).Decode(&created); decodeErr != nil {
-		return "failed to parse created automation", fmt.Errorf("failed to decode create response: %w", decodeErr)
+		return "", fmt.Errorf("failed to decode create response: %w", decodeErr)
 	}
 
 	jsonStr, err := marshalAutomationJSON(created)
 	if err != nil {
-		return "failed to encode created automation", err
+		return "", err
 	}
 	return fmt.Sprintf("Successfully created automation '%s' (ID: %s).\n\n%s", created.Name, created.ID, jsonStr), nil
 }
@@ -420,15 +420,15 @@ func (p *MattermostToolProvider) toolCreateAutomation(mcpContext *MCPToolContext
 func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
 	var args UpdateAutomationArgs
 	if err := argsGetter(&args); err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool update_automation: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool update_automation: %w", err)
 	}
 
 	if !model.IsValidId(args.AutomationID) {
-		return "invalid automation_id", fmt.Errorf("invalid automation_id")
+		return "", fmt.Errorf("invalid automation_id")
 	}
 
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	ctx := context.Background()
 
@@ -442,7 +442,7 @@ func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext
 
 	body, err := json.Marshal(automation)
 	if err != nil {
-		return "failed to encode automation", fmt.Errorf("failed to marshal automation: %w", err)
+		return "", fmt.Errorf("failed to marshal automation: %w", err)
 	}
 
 	resp, err := doAutomationRequest(ctx, mcpContext.Client, http.MethodPut, p.automationAPIURL("/automations/"+args.AutomationID), string(body))
@@ -455,18 +455,18 @@ func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext
 			"status", statusCode,
 			"error", err.Error(),
 		)
-		return handleAutomationHTTPError(resp, err, args.AutomationID)
+		return "", handleAutomationHTTPError(resp, err, args.AutomationID)
 	}
 	defer resp.Body.Close()
 
 	var updated Automation
 	if decodeErr := json.NewDecoder(resp.Body).Decode(&updated); decodeErr != nil {
-		return "failed to parse updated automation", fmt.Errorf("failed to decode update response: %w", decodeErr)
+		return "", fmt.Errorf("failed to decode update response: %w", decodeErr)
 	}
 
 	jsonStr, err := marshalAutomationJSON(updated)
 	if err != nil {
-		return "failed to encode updated automation", err
+		return "", err
 	}
 	return fmt.Sprintf("Successfully updated automation '%s' (ID: %s).\n\n%s", updated.Name, updated.ID, jsonStr), nil
 }
@@ -474,21 +474,21 @@ func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext
 func (p *MattermostToolProvider) toolDeleteAutomation(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
 	var args DeleteAutomationArgs
 	if err := argsGetter(&args); err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool delete_automation: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool delete_automation: %w", err)
 	}
 
 	if !model.IsValidId(args.AutomationID) {
-		return "invalid automation_id", fmt.Errorf("invalid automation_id")
+		return "", fmt.Errorf("invalid automation_id")
 	}
 
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	ctx := context.Background()
 
 	resp, err := doAutomationRequest(ctx, mcpContext.Client, http.MethodDelete, p.automationAPIURL("/automations/"+args.AutomationID), "")
 	if err != nil {
-		return handleAutomationHTTPError(resp, err, args.AutomationID)
+		return "", handleAutomationHTTPError(resp, err, args.AutomationID)
 	}
 	defer resp.Body.Close()
 
@@ -515,9 +515,9 @@ func triggerChannelID(t AutomationTrigger) string {
 // The Mattermost client's DoAPIRequestWithHeaders consumes the response body for non-2xx
 // status codes, so resp.Body is typically empty. The original body content is available
 // in the err parameter via AppErrorFromJSON.
-func handleAutomationHTTPError(resp *http.Response, err error, automationID string) (string, error) {
+func handleAutomationHTTPError(resp *http.Response, err error, automationID string) error {
 	if resp == nil {
-		return "Channel Automation plugin is not installed or not reachable.", fmt.Errorf("automation plugin request failed: %w", err)
+		return fmt.Errorf("the Channel Automation plugin is not installed or not reachable: %w", err)
 	}
 
 	// Try reading the body, but it's usually empty because the Mattermost client
@@ -537,16 +537,16 @@ func handleAutomationHTTPError(resp *http.Response, err error, automationID stri
 		if detail == "" {
 			detail = "invalid request"
 		}
-		return fmt.Sprintf("Bad request: %s", detail), fmt.Errorf("automation API returned 400: %s", detail)
+		return fmt.Errorf("bad request: %s", detail)
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return "You don't have permission to manage automations for this channel.", fmt.Errorf("automation API returned %d: %s", resp.StatusCode, detail)
+		return fmt.Errorf("you don't have permission to manage automations for this channel")
 	case http.StatusNotFound:
 		if automationID != "" {
-			return fmt.Sprintf("Automation not found with ID '%s'.", automationID), fmt.Errorf("automation API returned 404 for ID %s", automationID)
+			return fmt.Errorf("automation not found with ID %q", automationID)
 		}
-		return "Channel Automation plugin is not installed or not reachable.", fmt.Errorf("automation API returned 404: %s", detail)
+		return fmt.Errorf("the Channel Automation plugin is not installed or not reachable")
 	default:
-		return "Channel Automation plugin is not installed or not reachable.", fmt.Errorf("automation API returned %d: %s", resp.StatusCode, detail)
+		return fmt.Errorf("automation API returned status %d: %s", resp.StatusCode, detail)
 	}
 }
 
@@ -581,7 +581,7 @@ func marshalAutomationJSON(a Automation) (string, error) {
 func formatAutomationJSON(a Automation) (string, error) {
 	jsonStr, err := marshalAutomationJSON(a)
 	if err != nil {
-		return "failed to encode automation", err
+		return "", err
 	}
 	return fmt.Sprintf("Automation '%s' (ID: %s):\n\n%s", a.Name, a.ID, jsonStr), nil
 }
@@ -594,7 +594,7 @@ func formatAutomationsJSON(automations []Automation) (string, error) {
 	for i, a := range automations {
 		jsonStr, err := marshalAutomationJSON(a)
 		if err != nil {
-			return "failed to encode automation", err
+			return "", err
 		}
 		result.WriteString(fmt.Sprintf("%d. %s (ID: %s)\n%s\n\n", i+1, a.Name, a.ID, jsonStr))
 	}

--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -296,9 +296,6 @@ func (p *MattermostToolProvider) toolGetAutomationInstructions(mcpContext *MCPTo
 	if err := argsGetter(&noArgs); err != nil {
 		return "", fmt.Errorf("failed to get arguments for tool get_automation_instructions: %w", err)
 	}
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	payload, err := p.fetchAutomationInstructions(mcpContext.Ctx, mcpContext.Client)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch automation instructions from Channel Automation plugin (upgrade plugin or check connectivity): %w", err)
@@ -312,9 +309,6 @@ func (p *MattermostToolProvider) toolListAutomations(mcpContext *MCPToolContext,
 		return "", fmt.Errorf("failed to get arguments for tool list_automations: %w", err)
 	}
 
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	ctx := context.Background()
 
 	// If a specific automation ID was requested, fetch just that one.
@@ -374,9 +368,6 @@ func (p *MattermostToolProvider) toolCreateAutomation(mcpContext *MCPToolContext
 		return "", fmt.Errorf("name cannot be empty")
 	}
 
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	ctx := context.Background()
 
 	automation := Automation{
@@ -427,9 +418,6 @@ func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext
 		return "", err
 	}
 
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	ctx := context.Background()
 
 	automation := Automation{
@@ -481,9 +469,6 @@ func (p *MattermostToolProvider) toolDeleteAutomation(mcpContext *MCPToolContext
 		return "", err
 	}
 
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	ctx := context.Background()
 
 	resp, err := doAutomationRequest(ctx, mcpContext.Client, http.MethodDelete, p.automationAPIURL("/automations/"+args.AutomationID), "")

--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -232,20 +232,6 @@ func (p *MattermostToolProvider) fetchAutomationInstructions(ctx context.Context
 	return out, nil
 }
 
-// automationToolNames lists all automation tool names for filtering.
-var automationToolNames = map[string]bool{
-	"list_automations":            true,
-	"get_automation_instructions": true,
-	"create_automation":           true,
-	"update_automation":           true,
-	"delete_automation":           true,
-}
-
-// IsAutomationTool returns true if the given tool name is an automation tool.
-func IsAutomationTool(name string) bool {
-	return automationToolNames[name]
-}
-
 // getAutomationTools returns all automation-related tools.
 func (p *MattermostToolProvider) getAutomationTools() []MCPTool {
 	return []MCPTool{
@@ -254,20 +240,23 @@ func (p *MattermostToolProvider) getAutomationTools() []MCPTool {
 			Description: `List or get channel automations (trigger-action workflows).
 Provide automation_id to get a specific automation, or use optional channel_id to filter by trigger channel.
 Returns the full JSON for each automation including trigger configuration and action pipeline.`,
-			Schema:   NewJSONSchemaForAccessMode[ListAutomationsArgs](string(p.accessMode)),
-			Resolver: typed("list_automations", p.toolListAutomations),
+			Schema:    NewJSONSchemaForAccessMode[ListAutomationsArgs](string(p.accessMode)),
+			Resolver:  typed("list_automations", p.toolListAutomations),
+			Available: p.isAutomationPluginInstalled,
 		},
 		{
 			Name:        "get_automation_instructions",
 			Description: "Returns detailed documentation for creating and updating channel automations: triggers, actions, template syntax, allowed_tools, and required user-confirmation workflow. Call this before create_automation or update_automation.",
 			Schema:      nil,
 			Resolver:    typed("get_automation_instructions", p.toolGetAutomationInstructions),
+			Available:   p.isAutomationPluginInstalled,
 		},
 		{
 			Name:        "create_automation",
 			Description: createAutomationToolDescription,
 			Schema:      NewJSONSchemaForAccessMode[CreateAutomationArgs](string(p.accessMode)),
 			Resolver:    typed("create_automation", p.toolCreateAutomation),
+			Available:   p.isAutomationPluginInstalled,
 		},
 		{
 			Name: "update_automation",
@@ -276,14 +265,16 @@ omit will be cleared. Always call list_automations first to fetch the current JS
 only what needs to change and pass the full updated automation back. Call get_automation_instructions
 for trigger/action format details.
 IMPORTANT: Show the user what will change and get their confirmation first.`,
-			Schema:   NewJSONSchemaForAccessMode[UpdateAutomationArgs](string(p.accessMode)),
-			Resolver: typed("update_automation", p.toolUpdateAutomation),
+			Schema:    NewJSONSchemaForAccessMode[UpdateAutomationArgs](string(p.accessMode)),
+			Resolver:  typed("update_automation", p.toolUpdateAutomation),
+			Available: p.isAutomationPluginInstalled,
 		},
 		{
 			Name:        "delete_automation",
 			Description: "Delete a channel automation by ID. This is permanent and cannot be undone.",
 			Schema:      NewJSONSchemaForAccessMode[DeleteAutomationArgs](string(p.accessMode)),
 			Resolver:    typed("delete_automation", p.toolDeleteAutomation),
+			Available:   p.isAutomationPluginInstalled,
 		},
 	}
 }

--- a/mcpserver/tools/automations.go
+++ b/mcpserver/tools/automations.go
@@ -319,8 +319,8 @@ func (p *MattermostToolProvider) toolListAutomations(mcpContext *MCPToolContext,
 
 	// If a specific automation ID was requested, fetch just that one.
 	if args.AutomationID != "" {
-		if !model.IsValidId(args.AutomationID) {
-			return "", fmt.Errorf("invalid automation_id")
+		if err := requireID("automation_id", args.AutomationID); err != nil {
+			return "", err
 		}
 		return p.getAutomationByID(ctx, mcpContext, args.AutomationID)
 	}
@@ -423,8 +423,8 @@ func (p *MattermostToolProvider) toolUpdateAutomation(mcpContext *MCPToolContext
 		return "", fmt.Errorf("failed to get arguments for tool update_automation: %w", err)
 	}
 
-	if !model.IsValidId(args.AutomationID) {
-		return "", fmt.Errorf("invalid automation_id")
+	if err := requireID("automation_id", args.AutomationID); err != nil {
+		return "", err
 	}
 
 	if mcpContext.Client == nil {
@@ -477,8 +477,8 @@ func (p *MattermostToolProvider) toolDeleteAutomation(mcpContext *MCPToolContext
 		return "", fmt.Errorf("failed to get arguments for tool delete_automation: %w", err)
 	}
 
-	if !model.IsValidId(args.AutomationID) {
-		return "", fmt.Errorf("invalid automation_id")
+	if err := requireID("automation_id", args.AutomationID); err != nil {
+		return "", err
 	}
 
 	if mcpContext.Client == nil {

--- a/mcpserver/tools/automations_test.go
+++ b/mcpserver/tools/automations_test.go
@@ -263,7 +263,7 @@ func TestAutomationListAutomations(t *testing.T) {
 
 		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid automation_id")
+		assert.Contains(t, err.Error(), "automation_id must be a valid ID")
 	})
 }
 
@@ -411,7 +411,7 @@ func TestAutomationUpdate(t *testing.T) {
 
 		_, err := provider.toolUpdateAutomation(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid automation_id")
+		assert.Contains(t, err.Error(), "automation_id must be a valid ID")
 	})
 }
 
@@ -457,7 +457,7 @@ func TestAutomationDelete(t *testing.T) {
 
 		_, err := provider.toolDeleteAutomation(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid automation_id")
+		assert.Contains(t, err.Error(), "automation_id must be a valid ID")
 	})
 }
 

--- a/mcpserver/tools/automations_test.go
+++ b/mcpserver/tools/automations_test.go
@@ -189,7 +189,7 @@ func TestAutomationListAutomations(t *testing.T) {
 
 	provider := newTestProvider(t, ts.URL)
 	client := newTestClient(ts.URL)
-	mcpCtx := &MCPToolContext{Client: client}
+	mcpCtx := &MCPToolContext{Ctx: context.Background(), Client: client}
 
 	t.Run("list all", func(t *testing.T) {
 		result, err := provider.toolListAutomations(mcpCtx, ListAutomationsArgs{})
@@ -255,7 +255,7 @@ func TestAutomationCreate(t *testing.T) {
 
 	provider := newTestProvider(t, ts.URL)
 	client := newTestClient(ts.URL)
-	mcpCtx := &MCPToolContext{Client: client}
+	mcpCtx := &MCPToolContext{Ctx: context.Background(), Client: client}
 
 	t.Run("create with message_posted trigger", func(t *testing.T) {
 		args := CreateAutomationArgs{
@@ -330,7 +330,7 @@ func TestAutomationUpdate(t *testing.T) {
 
 	provider := newTestProvider(t, ts.URL)
 	client := newTestClient(ts.URL)
-	mcpCtx := &MCPToolContext{Client: client}
+	mcpCtx := &MCPToolContext{Ctx: context.Background(), Client: client}
 
 	t.Run("update success", func(t *testing.T) {
 		args := UpdateAutomationArgs{
@@ -387,7 +387,7 @@ func TestAutomationDelete(t *testing.T) {
 
 	provider := newTestProvider(t, ts.URL)
 	client := newTestClient(ts.URL)
-	mcpCtx := &MCPToolContext{Client: client}
+	mcpCtx := &MCPToolContext{Ctx: context.Background(), Client: client}
 
 	t.Run("delete success", func(t *testing.T) {
 		result, err := provider.toolDeleteAutomation(mcpCtx, DeleteAutomationArgs{AutomationID: id})
@@ -424,7 +424,7 @@ func TestAutomationErrorHandling(t *testing.T) {
 
 		provider := newTestProvider(t, ts.URL)
 		client := newTestClient(ts.URL)
-		mcpCtx := &MCPToolContext{Client: client}
+		mcpCtx := &MCPToolContext{Ctx: context.Background(), Client: client}
 
 		_, err := provider.toolListAutomations(mcpCtx, ListAutomationsArgs{})
 		require.Error(t, err)
@@ -435,7 +435,7 @@ func TestAutomationErrorHandling(t *testing.T) {
 		// Use an unreachable URL
 		provider := newTestProvider(t, "http://127.0.0.1:1")
 		client := newTestClient("http://127.0.0.1:1")
-		mcpCtx := &MCPToolContext{Client: client}
+		mcpCtx := &MCPToolContext{Ctx: context.Background(), Client: client}
 
 		_, err := provider.toolListAutomations(mcpCtx, ListAutomationsArgs{})
 		require.Error(t, err)

--- a/mcpserver/tools/automations_test.go
+++ b/mcpserver/tools/automations_test.go
@@ -486,19 +486,6 @@ func TestAutomationErrorHandling(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not installed or not reachable")
 	})
-
-	t.Run("nil client", func(t *testing.T) {
-		provider := newTestProvider(t, "http://localhost:8065")
-		mcpCtx := &MCPToolContext{Client: nil}
-
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{}`), target)
-		}
-
-		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "client not available")
-	})
 }
 
 func TestAutomationPluginInstalled(t *testing.T) {

--- a/mcpserver/tools/automations_test.go
+++ b/mcpserver/tools/automations_test.go
@@ -251,9 +251,9 @@ func TestAutomationListAutomations(t *testing.T) {
 			return json.Unmarshal([]byte(fmt.Sprintf(`{"automation_id":%q}`, missingID)), target)
 		}
 
-		result, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, result, "Automation not found")
+		assert.Contains(t, err.Error(), "automation not found")
 	})
 
 	t.Run("get by invalid id", func(t *testing.T) {
@@ -261,9 +261,9 @@ func TestAutomationListAutomations(t *testing.T) {
 			return json.Unmarshal([]byte(`{"automation_id":"bad-id"}`), target)
 		}
 
-		result, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Equal(t, "invalid automation_id", result)
+		assert.Contains(t, err.Error(), "invalid automation_id")
 	})
 }
 
@@ -323,9 +323,9 @@ func TestAutomationCreate(t *testing.T) {
 			}`), target)
 		}
 
-		result, err := provider.toolCreateAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolCreateAutomation(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Equal(t, "name is required", result)
+		assert.Contains(t, err.Error(), "name cannot be empty")
 	})
 
 	t.Run("create missing trigger", func(t *testing.T) {
@@ -336,9 +336,9 @@ func TestAutomationCreate(t *testing.T) {
 			}`), target)
 		}
 
-		result, err := provider.toolCreateAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolCreateAutomation(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, result, "trigger is required")
+		assert.Contains(t, err.Error(), "trigger is required")
 	})
 
 	t.Run("create multiple triggers", func(t *testing.T) {
@@ -349,9 +349,9 @@ func TestAutomationCreate(t *testing.T) {
 			}`), target)
 		}
 
-		result, err := provider.toolCreateAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolCreateAutomation(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, result, "exactly one type set")
+		assert.Contains(t, err.Error(), "exactly one type set")
 	})
 }
 
@@ -399,9 +399,9 @@ func TestAutomationUpdate(t *testing.T) {
 			}`, missingID)), target)
 		}
 
-		result, err := provider.toolUpdateAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolUpdateAutomation(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, result, "Automation not found")
+		assert.Contains(t, err.Error(), "automation not found")
 	})
 
 	t.Run("update invalid automation_id", func(t *testing.T) {
@@ -409,9 +409,9 @@ func TestAutomationUpdate(t *testing.T) {
 			return json.Unmarshal([]byte(`{"name": "X"}`), target)
 		}
 
-		result, err := provider.toolUpdateAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolUpdateAutomation(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Equal(t, "invalid automation_id", result)
+		assert.Contains(t, err.Error(), "invalid automation_id")
 	})
 }
 
@@ -445,9 +445,9 @@ func TestAutomationDelete(t *testing.T) {
 			return json.Unmarshal([]byte(fmt.Sprintf(`{"automation_id": %q}`, missingID)), target)
 		}
 
-		result, err := provider.toolDeleteAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolDeleteAutomation(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, result, "Automation not found")
+		assert.Contains(t, err.Error(), "automation not found")
 	})
 
 	t.Run("delete invalid automation_id", func(t *testing.T) {
@@ -455,9 +455,9 @@ func TestAutomationDelete(t *testing.T) {
 			return json.Unmarshal([]byte(`{}`), target)
 		}
 
-		result, err := provider.toolDeleteAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolDeleteAutomation(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Equal(t, "invalid automation_id", result)
+		assert.Contains(t, err.Error(), "invalid automation_id")
 	})
 }
 
@@ -481,9 +481,9 @@ func TestAutomationErrorHandling(t *testing.T) {
 			return json.Unmarshal([]byte(`{}`), target)
 		}
 
-		result, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, result, "permission")
+		assert.Contains(t, err.Error(), "permission")
 	})
 
 	t.Run("connection error", func(t *testing.T) {
@@ -496,9 +496,9 @@ func TestAutomationErrorHandling(t *testing.T) {
 			return json.Unmarshal([]byte(`{}`), target)
 		}
 
-		result, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Contains(t, result, "not installed or not reachable")
+		assert.Contains(t, err.Error(), "not installed or not reachable")
 	})
 
 	t.Run("nil client", func(t *testing.T) {
@@ -509,9 +509,9 @@ func TestAutomationErrorHandling(t *testing.T) {
 			return json.Unmarshal([]byte(`{}`), target)
 		}
 
-		result, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
 		require.Error(t, err)
-		assert.Equal(t, "client not available", result)
+		assert.Contains(t, err.Error(), "client not available")
 	})
 }
 
@@ -563,31 +563,31 @@ func TestHandleAutomationHTTPError(t *testing.T) {
 			name:           "400 bad request with body",
 			statusCode:     http.StatusBadRequest,
 			body:           "invalid trigger configuration",
-			expectedResult: "Bad request: invalid trigger configuration",
+			expectedResult: "bad request: invalid trigger configuration",
 		},
 		{
 			name:           "400 bad request empty body falls back to error",
 			statusCode:     http.StatusBadRequest,
 			body:           "",
-			expectedResult: "Bad request: test error",
+			expectedResult: "bad request: test error",
 		},
 		{
 			name:           "401 unauthorized",
 			statusCode:     http.StatusUnauthorized,
 			automationID:   "",
-			expectedResult: "You don't have permission to manage automations for this channel",
+			expectedResult: "you don't have permission to manage automations for this channel",
 		},
 		{
 			name:           "403 forbidden",
 			statusCode:     http.StatusForbidden,
 			automationID:   "",
-			expectedResult: "You don't have permission to manage automations for this channel",
+			expectedResult: "you don't have permission to manage automations for this channel",
 		},
 		{
 			name:           "404 with automation id",
 			statusCode:     http.StatusNotFound,
 			automationID:   "abc123",
-			expectedResult: "Automation not found with ID 'abc123'",
+			expectedResult: `automation not found with ID "abc123"`,
 		},
 		{
 			name:           "404 without automation id",
@@ -599,7 +599,7 @@ func TestHandleAutomationHTTPError(t *testing.T) {
 			name:           "500 server error",
 			statusCode:     http.StatusInternalServerError,
 			automationID:   "",
-			expectedResult: "not installed or not reachable",
+			expectedResult: "automation API returned status 500",
 		},
 	}
 
@@ -616,16 +616,16 @@ func TestHandleAutomationHTTPError(t *testing.T) {
 				Body:       respBody,
 			}
 
-			result, err := handleAutomationHTTPError(resp, fmt.Errorf("test error"), tt.automationID)
+			err := handleAutomationHTTPError(resp, fmt.Errorf("test error"), tt.automationID)
 			require.Error(t, err)
-			assert.Contains(t, result, tt.expectedResult)
+			assert.Contains(t, err.Error(), tt.expectedResult)
 		})
 	}
 
 	t.Run("nil response (connection error)", func(t *testing.T) {
-		result, err := handleAutomationHTTPError(nil, fmt.Errorf("connection refused"), "")
+		err := handleAutomationHTTPError(nil, fmt.Errorf("connection refused"), "")
 		require.Error(t, err)
-		assert.Contains(t, result, "not installed or not reachable")
+		assert.Contains(t, err.Error(), "not installed or not reachable")
 	})
 
 	t.Run("400 with nil error and empty body", func(t *testing.T) {
@@ -633,9 +633,9 @@ func TestHandleAutomationHTTPError(t *testing.T) {
 			StatusCode: http.StatusBadRequest,
 			Body:       http.NoBody,
 		}
-		result, err := handleAutomationHTTPError(resp, nil, "")
+		err := handleAutomationHTTPError(resp, nil, "")
 		require.Error(t, err)
-		assert.Contains(t, result, "Bad request: invalid request")
+		assert.Contains(t, err.Error(), "bad request: invalid request")
 	})
 }
 

--- a/mcpserver/tools/automations_test.go
+++ b/mcpserver/tools/automations_test.go
@@ -192,11 +192,7 @@ func TestAutomationListAutomations(t *testing.T) {
 	mcpCtx := &MCPToolContext{Client: client}
 
 	t.Run("list all", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{}`), target)
-		}
-
-		result, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		result, err := provider.toolListAutomations(mcpCtx, ListAutomationsArgs{})
 		require.NoError(t, err)
 		assert.Contains(t, result, "Welcome Bot")
 		assert.Contains(t, result, "Bug Triage")
@@ -207,11 +203,7 @@ func TestAutomationListAutomations(t *testing.T) {
 	})
 
 	t.Run("get by id", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(fmt.Sprintf(`{"automation_id":%q}`, id1)), target)
-		}
-
-		result, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		result, err := provider.toolListAutomations(mcpCtx, ListAutomationsArgs{AutomationID: id1})
 		require.NoError(t, err)
 		assert.Contains(t, result, "Welcome Bot")
 		assert.NotContains(t, result, "Bug Triage")
@@ -221,11 +213,7 @@ func TestAutomationListAutomations(t *testing.T) {
 	})
 
 	t.Run("filter by channel_id", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(fmt.Sprintf(`{"channel_id":%q}`, chID2)), target)
-		}
-
-		result, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		result, err := provider.toolListAutomations(mcpCtx, ListAutomationsArgs{ChannelID: chID2})
 		require.NoError(t, err)
 		assert.Contains(t, result, "Bug Triage")
 		assert.NotContains(t, result, "Welcome Bot")
@@ -233,21 +221,13 @@ func TestAutomationListAutomations(t *testing.T) {
 
 	t.Run("get by id not found", func(t *testing.T) {
 		missingID := model.NewId()
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(fmt.Sprintf(`{"automation_id":%q}`, missingID)), target)
-		}
-
-		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		_, err := provider.toolListAutomations(mcpCtx, ListAutomationsArgs{AutomationID: missingID})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "automation not found")
 	})
 
 	t.Run("get by invalid id", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{"automation_id":"bad-id"}`), target)
-		}
-
-		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		_, err := provider.toolListAutomations(mcpCtx, ListAutomationsArgs{AutomationID: "bad-id"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "automation_id must be a valid ID")
 	})
@@ -263,11 +243,7 @@ func TestGetAutomationInstructions(t *testing.T) {
 		Ctx:    context.Background(),
 		Client: client,
 	}
-	argsGetter := func(target any) error {
-		return json.Unmarshal([]byte(`{}`), target)
-	}
-
-	result, err := provider.toolGetAutomationInstructions(mcpCtx, argsGetter)
+	result, err := provider.toolGetAutomationInstructions(mcpCtx, struct{}{})
 	require.NoError(t, err)
 	assert.Contains(t, result, "TRIGGERS:")
 	assert.Contains(t, result, "ACTION SELECTION:")
@@ -282,16 +258,20 @@ func TestAutomationCreate(t *testing.T) {
 	mcpCtx := &MCPToolContext{Client: client}
 
 	t.Run("create with message_posted trigger", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{
-				"name": "Test Automation",
-				"enabled": true,
-				"trigger": {"message_posted": {"channel_id": "abcdefghijklmnopqrstuvwxyz", "include_thread_replies": true}},
-				"actions": [{"id": "prompt", "ai_prompt": {"prompt": "Hello!", "provider_type": "agent", "provider_id": "bot1", "allowed_tools": ["search_posts"], "guardrails": {"channel_ids": ["abcdefghijklmnopqrstuvwxyz"]}}}]
-			}`), target)
+		args := CreateAutomationArgs{
+			Name:    "Test Automation",
+			Enabled: true,
+			Trigger: AutomationTrigger{MessagePosted: &MessagePostedConfig{ChannelID: "abcdefghijklmnopqrstuvwxyz", IncludeThreadReplies: true}},
+			Actions: []AutomationAction{{ID: "prompt", AIPrompt: &AIPromptActionConfig{
+				Prompt:       "Hello!",
+				ProviderType: "agent",
+				ProviderID:   "bot1",
+				AllowedTools: []string{"search_posts"},
+				Guardrails:   &AutomationGuardrails{ChannelIDs: []string{"abcdefghijklmnopqrstuvwxyz"}},
+			}}},
 		}
 
-		result, err := provider.toolCreateAutomation(mcpCtx, argsGetter)
+		result, err := provider.toolCreateAutomation(mcpCtx, args)
 		require.NoError(t, err)
 		assert.Contains(t, result, "Successfully created automation")
 		assert.Contains(t, result, "Test Automation")
@@ -302,40 +282,37 @@ func TestAutomationCreate(t *testing.T) {
 	})
 
 	t.Run("create missing name", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{
-				"name": "",
-				"trigger": {"message_posted": {"channel_id": "abcdefghijklmnopqrstuvwxyz"}}
-			}`), target)
+		args := CreateAutomationArgs{
+			Name:    "",
+			Trigger: AutomationTrigger{MessagePosted: &MessagePostedConfig{ChannelID: "abcdefghijklmnopqrstuvwxyz"}},
 		}
 
-		_, err := provider.toolCreateAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolCreateAutomation(mcpCtx, args)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "name cannot be empty")
 	})
 
 	t.Run("create missing trigger", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{
-				"name": "Test",
-				"trigger": {}
-			}`), target)
+		args := CreateAutomationArgs{
+			Name:    "Test",
+			Trigger: AutomationTrigger{},
 		}
 
-		_, err := provider.toolCreateAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolCreateAutomation(mcpCtx, args)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "trigger is required")
 	})
 
 	t.Run("create multiple triggers", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{
-				"name": "Test",
-				"trigger": {"message_posted": {"channel_id": "ch1"}, "schedule": {"channel_id": "ch1", "interval": "daily"}}
-			}`), target)
+		args := CreateAutomationArgs{
+			Name: "Test",
+			Trigger: AutomationTrigger{
+				MessagePosted: &MessagePostedConfig{ChannelID: "ch1"},
+				Schedule:      &ScheduleConfig{ChannelID: "ch1", Interval: "daily"},
+			},
 		}
 
-		_, err := provider.toolCreateAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolCreateAutomation(mcpCtx, args)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "exactly one type set")
 	})
@@ -356,17 +333,21 @@ func TestAutomationUpdate(t *testing.T) {
 	mcpCtx := &MCPToolContext{Client: client}
 
 	t.Run("update success", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(fmt.Sprintf(`{
-				"automation_id": %q,
-				"name": "Updated Name",
-				"enabled": false,
-				"trigger": {"message_posted": {"channel_id": "abcdefghijklmnopqrstuvwxyz", "include_thread_replies": true}},
-				"actions": [{"id": "prompt", "ai_prompt": {"prompt": "Hello!", "provider_type": "agent", "provider_id": "bot1", "allowed_tools": ["search_posts"], "guardrails": {"channel_ids": [%q]}}}]
-			}`, id, chID)), target)
+		args := UpdateAutomationArgs{
+			AutomationID: id,
+			Name:         "Updated Name",
+			Enabled:      false,
+			Trigger:      AutomationTrigger{MessagePosted: &MessagePostedConfig{ChannelID: "abcdefghijklmnopqrstuvwxyz", IncludeThreadReplies: true}},
+			Actions: []AutomationAction{{ID: "prompt", AIPrompt: &AIPromptActionConfig{
+				Prompt:       "Hello!",
+				ProviderType: "agent",
+				ProviderID:   "bot1",
+				AllowedTools: []string{"search_posts"},
+				Guardrails:   &AutomationGuardrails{ChannelIDs: []string{chID}},
+			}}},
 		}
 
-		result, err := provider.toolUpdateAutomation(mcpCtx, argsGetter)
+		result, err := provider.toolUpdateAutomation(mcpCtx, args)
 		require.NoError(t, err)
 		assert.Contains(t, result, "Successfully updated automation")
 		assert.Contains(t, result, "Updated Name")
@@ -377,25 +358,19 @@ func TestAutomationUpdate(t *testing.T) {
 
 	t.Run("update not found", func(t *testing.T) {
 		missingID := model.NewId()
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(fmt.Sprintf(`{
-				"automation_id": %q,
-				"name": "X",
-				"trigger": {"message_posted": {"channel_id": "abcdefghijklmnopqrstuvwxyz"}}
-			}`, missingID)), target)
+		args := UpdateAutomationArgs{
+			AutomationID: missingID,
+			Name:         "X",
+			Trigger:      AutomationTrigger{MessagePosted: &MessagePostedConfig{ChannelID: "abcdefghijklmnopqrstuvwxyz"}},
 		}
 
-		_, err := provider.toolUpdateAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolUpdateAutomation(mcpCtx, args)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "automation not found")
 	})
 
 	t.Run("update invalid automation_id", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{"name": "X"}`), target)
-		}
-
-		_, err := provider.toolUpdateAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolUpdateAutomation(mcpCtx, UpdateAutomationArgs{Name: "X"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "automation_id must be a valid ID")
 	})
@@ -415,11 +390,7 @@ func TestAutomationDelete(t *testing.T) {
 	mcpCtx := &MCPToolContext{Client: client}
 
 	t.Run("delete success", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(fmt.Sprintf(`{"automation_id": %q}`, id)), target)
-		}
-
-		result, err := provider.toolDeleteAutomation(mcpCtx, argsGetter)
+		result, err := provider.toolDeleteAutomation(mcpCtx, DeleteAutomationArgs{AutomationID: id})
 		require.NoError(t, err)
 		assert.Contains(t, result, "Successfully deleted automation")
 		assert.Contains(t, result, id)
@@ -427,21 +398,13 @@ func TestAutomationDelete(t *testing.T) {
 
 	t.Run("delete not found", func(t *testing.T) {
 		missingID := model.NewId()
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(fmt.Sprintf(`{"automation_id": %q}`, missingID)), target)
-		}
-
-		_, err := provider.toolDeleteAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolDeleteAutomation(mcpCtx, DeleteAutomationArgs{AutomationID: missingID})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "automation not found")
 	})
 
 	t.Run("delete invalid automation_id", func(t *testing.T) {
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{}`), target)
-		}
-
-		_, err := provider.toolDeleteAutomation(mcpCtx, argsGetter)
+		_, err := provider.toolDeleteAutomation(mcpCtx, DeleteAutomationArgs{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "automation_id must be a valid ID")
 	})
@@ -463,11 +426,7 @@ func TestAutomationErrorHandling(t *testing.T) {
 		client := newTestClient(ts.URL)
 		mcpCtx := &MCPToolContext{Client: client}
 
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{}`), target)
-		}
-
-		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		_, err := provider.toolListAutomations(mcpCtx, ListAutomationsArgs{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "permission")
 	})
@@ -478,11 +437,7 @@ func TestAutomationErrorHandling(t *testing.T) {
 		client := newTestClient("http://127.0.0.1:1")
 		mcpCtx := &MCPToolContext{Client: client}
 
-		argsGetter := func(target any) error {
-			return json.Unmarshal([]byte(`{}`), target)
-		}
-
-		_, err := provider.toolListAutomations(mcpCtx, argsGetter)
+		_, err := provider.toolListAutomations(mcpCtx, ListAutomationsArgs{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not installed or not reachable")
 	})

--- a/mcpserver/tools/automations_test.go
+++ b/mcpserver/tools/automations_test.go
@@ -156,20 +156,6 @@ func newTestAutomationServer(t *testing.T, automations []Automation) *httptest.S
 	return httptest.NewServer(mux)
 }
 
-func newTestProvider(t *testing.T, serverURL string) *MattermostToolProvider {
-	t.Helper()
-	return &MattermostToolProvider{
-		logger:      &testLogger{t: t},
-		mmServerURL: serverURL,
-	}
-}
-
-func newTestClient(serverURL string) *model.Client4 {
-	client := model.NewAPIv4Client(serverURL)
-	client.SetToken("test-token")
-	return client
-}
-
 func TestAutomationListAutomations(t *testing.T) {
 	id1 := model.NewId()
 	id2 := model.NewId()

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -67,37 +67,37 @@ func (p *MattermostToolProvider) getChannelTools() []MCPTool {
 		{
 			Name:        "read_channel",
 			Description: "Read recent posts from a Mattermost channel. Parameters: channel_id (required), limit (1-100, default 20), since (ISO 8601 timestamp, optional). Returns post details including author, content, and timestamps. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"limit\": 10, \"since\": \"2024-01-01T00:00:00Z\"}",
-			Schema:      llm.NewJSONSchemaFromStruct[ReadChannelArgs](),
+			Schema:      NewJSONSchemaForAccessMode[ReadChannelArgs](string(p.accessMode)),
 			Resolver:    p.toolReadChannel,
 		},
 		{
 			Name:        "create_channel",
 			Description: "Create a new channel in Mattermost. Parameters: name (URL-friendly), display_name (user-visible), type ('O' for public, 'P' for private), team_id (required), purpose (optional), header (optional). Returns created channel details. Example: {\"name\": \"dev-chat\", \"display_name\": \"Development Chat\", \"type\": \"O\", \"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\"}",
-			Schema:      llm.NewJSONSchemaFromStruct[CreateChannelArgs](),
+			Schema:      NewJSONSchemaForAccessMode[CreateChannelArgs](string(p.accessMode)),
 			Resolver:    p.toolCreateChannel,
 		},
 		{
 			Name:        "get_channel_info",
 			Description: "Get information about channel(s). Provide channel_id (fastest) or channel_name (matches against both display name and URL name, case-insensitive, supports partial matches). Optional: team_id to limit search scope. If multiple channels match (e.g., 'General' exists in multiple teams), returns ALL matches with team context for disambiguation. Returns channel metadata including ID, names, type, team, purpose, member count, and the requesting user's role in the channel (admin, member, guest, or not_member). Example: {\"channel_name\": \"General\"} or {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\"}",
-			Schema:      llm.NewJSONSchemaFromStruct[GetChannelInfoArgs](),
+			Schema:      NewJSONSchemaForAccessMode[GetChannelInfoArgs](string(p.accessMode)),
 			Resolver:    p.toolGetChannelInfo,
 		},
 		{
 			Name:        "get_channel_members",
 			Description: "Get members of a channel with pagination support. Parameters: channel_id (required), limit (1-200, default 50), page (0+, default 0). Returns user details for each member including username, email, display name, and join date. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"limit\": 25, \"page\": 0}",
-			Schema:      llm.NewJSONSchemaFromStruct[GetChannelMembersArgs](),
+			Schema:      NewJSONSchemaForAccessMode[GetChannelMembersArgs](string(p.accessMode)),
 			Resolver:    p.toolGetChannelMembers,
 		},
 		{
 			Name:        "add_user_to_channel",
 			Description: "Add a user to a channel. Parameters: user_id (required), channel_id (required). Returns confirmation message.",
-			Schema:      llm.NewJSONSchemaFromStruct[AddUserToChannelArgs](),
+			Schema:      NewJSONSchemaForAccessMode[AddUserToChannelArgs](string(p.accessMode)),
 			Resolver:    p.toolAddUserToChannel,
 		},
 		{
 			Name:        "get_user_channels",
 			Description: "Get channels the current user is a member of, including DMs and GMs. Parameters: team_id (optional, filter by team), page (default 0), per_page (1-200, default 60). Returns channel details with team info and pagination. Example: {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\", \"per_page\": 60}",
-			Schema:      llm.NewJSONSchemaFromStruct[GetUserChannelsArgs](),
+			Schema:      NewJSONSchemaForAccessMode[GetUserChannelsArgs](string(p.accessMode)),
 			Resolver:    p.toolGetUserChannels,
 		},
 	}

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -111,12 +111,12 @@ func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, arg
 	var args ReadChannelArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool read_channel: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool read_channel: %w", err)
 	}
 
 	// Validate channel ID
 	if !model.IsValidId(args.ChannelID) {
-		return "invalid channel_id format", fmt.Errorf("channel_id must be a valid ID")
+		return "", fmt.Errorf("channel_id must be a valid ID")
 	}
 
 	// Set defaults and validate
@@ -129,7 +129,7 @@ func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, arg
 
 	// Get client and context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -139,7 +139,7 @@ func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, arg
 	if args.Since != "" {
 		parsedTime, parseErr := time.Parse(time.RFC3339, args.Since)
 		if parseErr != nil {
-			return "invalid since timestamp format", fmt.Errorf("invalid timestamp format: %w", parseErr)
+			return "", fmt.Errorf("invalid timestamp format: %w", parseErr)
 		}
 		since = parsedTime.Unix() * 1000 // Convert to milliseconds
 	}
@@ -147,7 +147,7 @@ func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, arg
 	// Get channel info for context
 	channel, _, err := client.GetChannel(ctx, args.ChannelID)
 	if err != nil {
-		return "failed to fetch channel info", fmt.Errorf("error fetching channel: %w", err)
+		return "", fmt.Errorf("error fetching channel: %w", err)
 	}
 
 	// Determine team display name; DMs/Groups have no team
@@ -176,7 +176,7 @@ func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, arg
 	} else {
 		team, _, teamErr := client.GetTeam(ctx, channel.TeamId, "")
 		if teamErr != nil {
-			return "failed to fetch team info", fmt.Errorf("error fetching team: %w", teamErr)
+			return "", fmt.Errorf("error fetching team: %w", teamErr)
 		}
 		teamDisplayName = team.DisplayName
 	}
@@ -184,7 +184,7 @@ func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, arg
 	// Get posts from the channel
 	posts, _, err := client.GetPostsForChannel(ctx, args.ChannelID, 0, args.Limit, "", false, false)
 	if err != nil {
-		return "failed to fetch channel posts", fmt.Errorf("error fetching posts: %w", err)
+		return "", fmt.Errorf("error fetching posts: %w", err)
 	}
 
 	// Filter by since timestamp if provided
@@ -263,31 +263,31 @@ func (p *MattermostToolProvider) toolCreateChannel(mcpContext *MCPToolContext, a
 	var args CreateChannelArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool create_channel: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool create_channel: %w", err)
 	}
 
 	// Validate required fields
 	if args.Name == "" {
-		return "name is required", fmt.Errorf("name cannot be empty")
+		return "", fmt.Errorf("name cannot be empty")
 	}
 	if args.DisplayName == "" {
-		return "display_name is required", fmt.Errorf("display_name cannot be empty")
+		return "", fmt.Errorf("display_name cannot be empty")
 	}
 	if args.Type == "" {
-		return "type is required", fmt.Errorf("type cannot be empty")
+		return "", fmt.Errorf("type cannot be empty")
 	}
 	if !model.IsValidId(args.TeamID) {
-		return "invalid team_id format", fmt.Errorf("team_id must be a valid ID")
+		return "", fmt.Errorf("team_id must be a valid ID")
 	}
 
 	// Validate channel type
 	if args.Type != "O" && args.Type != "P" {
-		return "type must be 'O' for public or 'P' for private", fmt.Errorf("invalid channel type: %s", args.Type)
+		return "", fmt.Errorf("invalid channel type: %s", args.Type)
 	}
 
 	// Get client and context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -304,7 +304,7 @@ func (p *MattermostToolProvider) toolCreateChannel(mcpContext *MCPToolContext, a
 
 	createdChannel, _, err := client.CreateChannel(ctx, channel)
 	if err != nil {
-		return "failed to create channel", fmt.Errorf("error creating channel: %w", err)
+		return "", fmt.Errorf("error creating channel: %w", err)
 	}
 
 	return fmt.Sprintf("Successfully created channel '%s' with ID: %s", createdChannel.DisplayName, createdChannel.Id), nil
@@ -315,19 +315,19 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 	var args GetChannelInfoArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool get_channel_info: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool get_channel_info: %w", err)
 	}
 
 	// Get client and context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
 	// Validate team ID if provided
 	if args.TeamID != "" && !model.IsValidId(args.TeamID) {
-		return "invalid team_id format", fmt.Errorf("team_id must be a valid ID")
+		return "", fmt.Errorf("team_id must be a valid ID")
 	}
 
 	var channels []*model.Channel
@@ -339,7 +339,7 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 	case args.ChannelID != "":
 		// Validate channel ID format
 		if !model.IsValidId(args.ChannelID) {
-			return "invalid channel_id format", fmt.Errorf("channel_id must be a valid ID")
+			return "", fmt.Errorf("channel_id must be a valid ID")
 		}
 		// Direct ID lookup - fastest method, always returns single result
 		var channel *model.Channel
@@ -351,7 +351,7 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 				return fmt.Sprintf("No channel found with ID '%s'. The channel may have been deleted or you may not have access to it.", args.ChannelID), nil
 			}
 			// Real error (network, auth, etc.)
-			return "failed to fetch channel", fmt.Errorf("error fetching channel by ID: %w", err)
+			return "", fmt.Errorf("error fetching channel by ID: %w", err)
 		}
 		channels = []*model.Channel{channel}
 	case args.ChannelName != "":
@@ -365,7 +365,7 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 		if len(channels) == 0 {
 			channels, err = p.tryFindChannelByName(ctx, client, args.ChannelName, args.TeamID)
 			if err != nil {
-				return "failed to search for channels", err
+				return "", err
 			}
 		}
 
@@ -373,7 +373,7 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 		if len(channels) == 0 && args.TeamID != "" {
 			channels, err = p.tryFindChannelBySubstring(ctx, client, args.ChannelName, args.TeamID)
 			if err != nil {
-				return "failed to search for channels", err
+				return "", err
 			}
 		}
 
@@ -404,7 +404,7 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 			return notFoundMsg.String(), nil
 		}
 	default:
-		return "either channel_id or channel_name must be provided", fmt.Errorf("insufficient parameters for channel lookup")
+		return "", fmt.Errorf("insufficient parameters for channel lookup")
 	}
 
 	// If multiple channels found, return all with disambiguation guidance
@@ -524,12 +524,12 @@ func (p *MattermostToolProvider) toolGetChannelMembers(mcpContext *MCPToolContex
 	var args GetChannelMembersArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool get_channel_members: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool get_channel_members: %w", err)
 	}
 
 	// Validate required fields
 	if !model.IsValidId(args.ChannelID) {
-		return "invalid channel_id format", fmt.Errorf("channel_id must be a valid ID")
+		return "", fmt.Errorf("channel_id must be a valid ID")
 	}
 
 	// Set defaults and validate
@@ -545,7 +545,7 @@ func (p *MattermostToolProvider) toolGetChannelMembers(mcpContext *MCPToolContex
 
 	// Get client and context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -556,7 +556,7 @@ func (p *MattermostToolProvider) toolGetChannelMembers(mcpContext *MCPToolContex
 	// Get channel members
 	members, _, err := client.GetChannelMembers(ctx, args.ChannelID, args.Page, args.Limit, "")
 	if err != nil {
-		return "failed to fetch channel members", fmt.Errorf("error fetching channel members: %w", err)
+		return "", fmt.Errorf("error fetching channel members: %w", err)
 	}
 
 	if len(members) == 0 {
@@ -606,20 +606,20 @@ func (p *MattermostToolProvider) toolAddUserToChannel(mcpContext *MCPToolContext
 	var args AddUserToChannelArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool add_user_to_channel: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool add_user_to_channel: %w", err)
 	}
 
 	// Validate required fields
 	if !model.IsValidId(args.UserID) {
-		return "invalid user_id format", fmt.Errorf("user_id must be a valid ID")
+		return "", fmt.Errorf("user_id must be a valid ID")
 	}
 	if !model.IsValidId(args.ChannelID) {
-		return "invalid channel_id format", fmt.Errorf("channel_id must be a valid ID")
+		return "", fmt.Errorf("channel_id must be a valid ID")
 	}
 
 	// Get client and context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -627,7 +627,7 @@ func (p *MattermostToolProvider) toolAddUserToChannel(mcpContext *MCPToolContext
 	// Add user to channel
 	_, _, err = client.AddChannelMember(ctx, args.ChannelID, args.UserID)
 	if err != nil {
-		return "failed to add user to channel", fmt.Errorf("error adding user to channel: %w", err)
+		return "", fmt.Errorf("error adding user to channel: %w", err)
 	}
 
 	// Get user and channel info for confirmation
@@ -789,12 +789,12 @@ func (p *MattermostToolProvider) toolGetUserChannels(mcpContext *MCPToolContext,
 	var args GetUserChannelsArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool get_user_channels: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool get_user_channels: %w", err)
 	}
 
 	// Validate team ID if provided
 	if args.TeamID != "" && !model.IsValidId(args.TeamID) {
-		return "invalid team_id format", fmt.Errorf("team_id must be a valid ID")
+		return "", fmt.Errorf("team_id must be a valid ID")
 	}
 
 	// Set defaults and cap to match schema (consistent with get_channel_members and get_team_members).
@@ -811,12 +811,12 @@ func (p *MattermostToolProvider) toolGetUserChannels(mcpContext *MCPToolContext,
 
 	maxInt := int(^uint(0) >> 1)
 	if args.Page > maxInt/args.PerPage {
-		return "page value too large", fmt.Errorf("page * per_page overflows int")
+		return "", fmt.Errorf("page * per_page overflows int")
 	}
 
 	// Get client and context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -824,7 +824,7 @@ func (p *MattermostToolProvider) toolGetUserChannels(mcpContext *MCPToolContext,
 	// Get current user
 	user, _, err := client.GetMe(ctx, "")
 	if err != nil {
-		return "failed to get current user", fmt.Errorf("failed to get current user: %w", err)
+		return "", fmt.Errorf("failed to get current user: %w", err)
 	}
 	// Fetch all channels for the user (including DMs, GMs, and team channels).
 	// NOTE: GetChannelsForUserWithLastDeleteAt does not support server-side pagination,
@@ -832,7 +832,7 @@ func (p *MattermostToolProvider) toolGetUserChannels(mcpContext *MCPToolContext,
 	// Pass 0 for lastDeleteAt to get all channels without filtering.
 	allChannels, _, err := client.GetChannelsForUserWithLastDeleteAt(ctx, user.Id, 0)
 	if err != nil {
-		return "failed to get channels for user", fmt.Errorf("failed to get channels for user: %w", err)
+		return "", fmt.Errorf("failed to get channels for user: %w", err)
 	}
 
 	// Filter by team if specified

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -60,30 +60,43 @@ type GetUserChannelsArgs struct {
 	PerPage int    `json:"per_page,omitempty" jsonschema:"Number of channels per page (default: 60, max: 200),minimum=1,maximum=200"`
 }
 
+// Tool description constants for channel-related tools.
+const (
+	readChannelDescription = "Read recent posts from a Mattermost channel. Parameters: channel_id (required), limit (1-100, default 20), since (ISO 8601 timestamp, optional). Returns post details including author, content, and timestamps. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"limit\": 10, \"since\": \"2024-01-01T00:00:00Z\"}"
+
+	createChannelDescription = "Create a new channel in Mattermost. Parameters: name (URL-friendly), display_name (user-visible), type ('O' for public, 'P' for private), team_id (required), purpose (optional), header (optional). Returns created channel details. Example: {\"name\": \"dev-chat\", \"display_name\": \"Development Chat\", \"type\": \"O\", \"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\"}"
+
+	getChannelInfoDescription = "Get information about channel(s). Provide channel_id (fastest) or channel_name (matches against both display name and URL name, case-insensitive, supports partial matches). Optional: team_id to limit search scope. If multiple channels match (e.g., 'General' exists in multiple teams), returns ALL matches with team context for disambiguation. Returns channel metadata including ID, names, type, team, purpose, member count, and the requesting user's role in the channel (admin, member, guest, or not_member). Example: {\"channel_name\": \"General\"} or {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\"}"
+
+	getChannelMembersDescription = "Get members of a channel with pagination support. Parameters: channel_id (required), limit (1-200, default 50), page (0+, default 0). Returns user details for each member including username, email, display name, and join date. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"limit\": 25, \"page\": 0}"
+
+	getUserChannelsDescription = "Get channels the current user is a member of, including DMs and GMs. Parameters: team_id (optional, filter by team), page (default 0), per_page (1-200, default 60). Returns channel details with team info and pagination. Example: {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\", \"per_page\": 60}"
+)
+
 // getChannelTools returns all channel-related tools
 func (p *MattermostToolProvider) getChannelTools() []MCPTool {
 	return []MCPTool{
 		{
 			Name:        "read_channel",
-			Description: "Read recent posts from a Mattermost channel. Parameters: channel_id (required), limit (1-100, default 20), since (ISO 8601 timestamp, optional). Returns post details including author, content, and timestamps. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"limit\": 10, \"since\": \"2024-01-01T00:00:00Z\"}",
+			Description: readChannelDescription,
 			Schema:      NewJSONSchemaForAccessMode[ReadChannelArgs](string(p.accessMode)),
 			Resolver:    typed("read_channel", p.toolReadChannel),
 		},
 		{
 			Name:        "create_channel",
-			Description: "Create a new channel in Mattermost. Parameters: name (URL-friendly), display_name (user-visible), type ('O' for public, 'P' for private), team_id (required), purpose (optional), header (optional). Returns created channel details. Example: {\"name\": \"dev-chat\", \"display_name\": \"Development Chat\", \"type\": \"O\", \"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\"}",
+			Description: createChannelDescription,
 			Schema:      NewJSONSchemaForAccessMode[CreateChannelArgs](string(p.accessMode)),
 			Resolver:    typed("create_channel", p.toolCreateChannel),
 		},
 		{
 			Name:        "get_channel_info",
-			Description: "Get information about channel(s). Provide channel_id (fastest) or channel_name (matches against both display name and URL name, case-insensitive, supports partial matches). Optional: team_id to limit search scope. If multiple channels match (e.g., 'General' exists in multiple teams), returns ALL matches with team context for disambiguation. Returns channel metadata including ID, names, type, team, purpose, member count, and the requesting user's role in the channel (admin, member, guest, or not_member). Example: {\"channel_name\": \"General\"} or {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\"}",
+			Description: getChannelInfoDescription,
 			Schema:      NewJSONSchemaForAccessMode[GetChannelInfoArgs](string(p.accessMode)),
 			Resolver:    typed("get_channel_info", p.toolGetChannelInfo),
 		},
 		{
 			Name:        "get_channel_members",
-			Description: "Get members of a channel with pagination support. Parameters: channel_id (required), limit (1-200, default 50), page (0+, default 0). Returns user details for each member including username, email, display name, and join date. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"limit\": 25, \"page\": 0}",
+			Description: getChannelMembersDescription,
 			Schema:      NewJSONSchemaForAccessMode[GetChannelMembersArgs](string(p.accessMode)),
 			Resolver:    typed("get_channel_members", p.toolGetChannelMembers),
 		},
@@ -95,7 +108,7 @@ func (p *MattermostToolProvider) getChannelTools() []MCPTool {
 		},
 		{
 			Name:        "get_user_channels",
-			Description: "Get channels the current user is a member of, including DMs and GMs. Parameters: team_id (optional, filter by team), page (default 0), per_page (1-200, default 60). Returns channel details with team info and pagination. Example: {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\", \"per_page\": 60}",
+			Description: getUserChannelsDescription,
 			Schema:      NewJSONSchemaForAccessMode[GetUserChannelsArgs](string(p.accessMode)),
 			Resolver:    typed("get_user_channels", p.toolGetUserChannels),
 		},

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -68,7 +68,7 @@ const (
 
 	getChannelInfoDescription = "Get information about channel(s). Provide channel_id (fastest) or channel_name (matches against both display name and URL name, case-insensitive, supports partial matches). Optional: team_id to limit search scope. If multiple channels match (e.g., 'General' exists in multiple teams), returns ALL matches with team context for disambiguation. Returns channel metadata including ID, names, type, team, purpose, member count, and the requesting user's role in the channel (admin, member, guest, or not_member). Example: {\"channel_name\": \"General\"} or {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\"}"
 
-	getChannelMembersDescription = "Get members of a channel with pagination support. Parameters: channel_id (required), limit (1-200, default 50), page (0+, default 0). Returns user details for each member including username, email, display name, and join date. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"limit\": 25, \"page\": 0}"
+	getChannelMembersDescription = "Get members of a channel with pagination support. Parameters: channel_id (required), limit (1-200, default 50), page (0+, default 0), exclude_bots (optional, default true). Returns user details for each member including username, email, display name, and role. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"limit\": 25, \"page\": 0}"
 
 	getUserChannelsDescription = "Get channels the current user is a member of, including DMs and GMs. Parameters: team_id (optional, filter by team), page (default 0), per_page (1-200, default 60). Returns channel details with team info and pagination. Example: {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\", \"per_page\": 60}"
 )
@@ -313,8 +313,8 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 	ctx := mcpContext.Ctx
 
 	// Validate team ID if provided
-	if err := optionalID("team_id", args.TeamID); err != nil {
-		return "", err
+	if validationErr := optionalID("team_id", args.TeamID); validationErr != nil {
+		return "", validationErr
 	}
 
 	var channels []*model.Channel
@@ -325,8 +325,8 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 	switch {
 	case args.ChannelID != "":
 		// Validate channel ID format
-		if err := requireID("channel_id", args.ChannelID); err != nil {
-			return "", err
+		if validationErr := requireID("channel_id", args.ChannelID); validationErr != nil {
+			return "", validationErr
 		}
 		// Direct ID lookup - fastest method, always returns single result
 		var channel *model.Channel

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -115,8 +115,8 @@ func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, arg
 	}
 
 	// Validate channel ID
-	if !model.IsValidId(args.ChannelID) {
-		return "", fmt.Errorf("channel_id must be a valid ID")
+	if err := requireID("channel_id", args.ChannelID); err != nil {
+		return "", err
 	}
 
 	// Set defaults and validate
@@ -276,8 +276,8 @@ func (p *MattermostToolProvider) toolCreateChannel(mcpContext *MCPToolContext, a
 	if args.Type == "" {
 		return "", fmt.Errorf("type cannot be empty")
 	}
-	if !model.IsValidId(args.TeamID) {
-		return "", fmt.Errorf("team_id must be a valid ID")
+	if err := requireID("team_id", args.TeamID); err != nil {
+		return "", err
 	}
 
 	// Validate channel type
@@ -326,8 +326,8 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 	ctx := mcpContext.Ctx
 
 	// Validate team ID if provided
-	if args.TeamID != "" && !model.IsValidId(args.TeamID) {
-		return "", fmt.Errorf("team_id must be a valid ID")
+	if err := optionalID("team_id", args.TeamID); err != nil {
+		return "", err
 	}
 
 	var channels []*model.Channel
@@ -338,8 +338,8 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 	switch {
 	case args.ChannelID != "":
 		// Validate channel ID format
-		if !model.IsValidId(args.ChannelID) {
-			return "", fmt.Errorf("channel_id must be a valid ID")
+		if err := requireID("channel_id", args.ChannelID); err != nil {
+			return "", err
 		}
 		// Direct ID lookup - fastest method, always returns single result
 		var channel *model.Channel
@@ -528,8 +528,8 @@ func (p *MattermostToolProvider) toolGetChannelMembers(mcpContext *MCPToolContex
 	}
 
 	// Validate required fields
-	if !model.IsValidId(args.ChannelID) {
-		return "", fmt.Errorf("channel_id must be a valid ID")
+	if err := requireID("channel_id", args.ChannelID); err != nil {
+		return "", err
 	}
 
 	// Set defaults and validate
@@ -610,11 +610,11 @@ func (p *MattermostToolProvider) toolAddUserToChannel(mcpContext *MCPToolContext
 	}
 
 	// Validate required fields
-	if !model.IsValidId(args.UserID) {
-		return "", fmt.Errorf("user_id must be a valid ID")
+	if err := requireID("user_id", args.UserID); err != nil {
+		return "", err
 	}
-	if !model.IsValidId(args.ChannelID) {
-		return "", fmt.Errorf("channel_id must be a valid ID")
+	if err := requireID("channel_id", args.ChannelID); err != nil {
+		return "", err
 	}
 
 	// Get client and context
@@ -793,8 +793,8 @@ func (p *MattermostToolProvider) toolGetUserChannels(mcpContext *MCPToolContext,
 	}
 
 	// Validate team ID if provided
-	if args.TeamID != "" && !model.IsValidId(args.TeamID) {
-		return "", fmt.Errorf("team_id must be a valid ID")
+	if err := optionalID("team_id", args.TeamID); err != nil {
+		return "", err
 	}
 
 	// Set defaults and cap to match schema (consistent with get_channel_members and get_team_members).

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -49,8 +49,8 @@ type GetChannelMembersArgs struct {
 
 // AddUserToChannelArgs represents arguments for the add_user_to_channel tool
 type AddUserToChannelArgs struct {
-	UserID    string `json:"user_id" jsonschema:"ID of the user to add"`
-	ChannelID string `json:"channel_id" jsonschema:"ID of the channel to add user to"`
+	UserID    string `json:"user_id" jsonschema:"ID of the user to add,minLength=26,maxLength=26"`
+	ChannelID string `json:"channel_id" jsonschema:"ID of the channel to add user to,minLength=26,maxLength=26"`
 }
 
 // GetUserChannelsArgs represents arguments for the get_user_channels tool

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-plugin-agents/format"
-	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -68,37 +67,37 @@ func (p *MattermostToolProvider) getChannelTools() []MCPTool {
 			Name:        "read_channel",
 			Description: "Read recent posts from a Mattermost channel. Parameters: channel_id (required), limit (1-100, default 20), since (ISO 8601 timestamp, optional). Returns post details including author, content, and timestamps. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"limit\": 10, \"since\": \"2024-01-01T00:00:00Z\"}",
 			Schema:      NewJSONSchemaForAccessMode[ReadChannelArgs](string(p.accessMode)),
-			Resolver:    p.toolReadChannel,
+			Resolver:    typed("read_channel", p.toolReadChannel),
 		},
 		{
 			Name:        "create_channel",
 			Description: "Create a new channel in Mattermost. Parameters: name (URL-friendly), display_name (user-visible), type ('O' for public, 'P' for private), team_id (required), purpose (optional), header (optional). Returns created channel details. Example: {\"name\": \"dev-chat\", \"display_name\": \"Development Chat\", \"type\": \"O\", \"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\"}",
 			Schema:      NewJSONSchemaForAccessMode[CreateChannelArgs](string(p.accessMode)),
-			Resolver:    p.toolCreateChannel,
+			Resolver:    typed("create_channel", p.toolCreateChannel),
 		},
 		{
 			Name:        "get_channel_info",
 			Description: "Get information about channel(s). Provide channel_id (fastest) or channel_name (matches against both display name and URL name, case-insensitive, supports partial matches). Optional: team_id to limit search scope. If multiple channels match (e.g., 'General' exists in multiple teams), returns ALL matches with team context for disambiguation. Returns channel metadata including ID, names, type, team, purpose, member count, and the requesting user's role in the channel (admin, member, guest, or not_member). Example: {\"channel_name\": \"General\"} or {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\"}",
 			Schema:      NewJSONSchemaForAccessMode[GetChannelInfoArgs](string(p.accessMode)),
-			Resolver:    p.toolGetChannelInfo,
+			Resolver:    typed("get_channel_info", p.toolGetChannelInfo),
 		},
 		{
 			Name:        "get_channel_members",
 			Description: "Get members of a channel with pagination support. Parameters: channel_id (required), limit (1-200, default 50), page (0+, default 0). Returns user details for each member including username, email, display name, and join date. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"limit\": 25, \"page\": 0}",
 			Schema:      NewJSONSchemaForAccessMode[GetChannelMembersArgs](string(p.accessMode)),
-			Resolver:    p.toolGetChannelMembers,
+			Resolver:    typed("get_channel_members", p.toolGetChannelMembers),
 		},
 		{
 			Name:        "add_user_to_channel",
 			Description: "Add a user to a channel. Parameters: user_id (required), channel_id (required). Returns confirmation message.",
 			Schema:      NewJSONSchemaForAccessMode[AddUserToChannelArgs](string(p.accessMode)),
-			Resolver:    p.toolAddUserToChannel,
+			Resolver:    typed("add_user_to_channel", p.toolAddUserToChannel),
 		},
 		{
 			Name:        "get_user_channels",
 			Description: "Get channels the current user is a member of, including DMs and GMs. Parameters: team_id (optional, filter by team), page (default 0), per_page (1-200, default 60). Returns channel details with team info and pagination. Example: {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\", \"per_page\": 60}",
 			Schema:      NewJSONSchemaForAccessMode[GetUserChannelsArgs](string(p.accessMode)),
-			Resolver:    p.toolGetUserChannels,
+			Resolver:    typed("get_user_channels", p.toolGetUserChannels),
 		},
 	}
 }
@@ -107,13 +106,7 @@ func (p *MattermostToolProvider) getChannelTools() []MCPTool {
 // It reads recent posts from a channel and formats them with author usernames.
 // Uses GetUsersByIds to fetch all authors in a single API call.
 // Makes a single GetTeam call for the channel's team context (acceptable for one channel).
-func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args ReadChannelArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool read_channel: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, args ReadChannelArgs) (string, error) {
 	// Validate channel ID
 	if err := requireID("channel_id", args.ChannelID); err != nil {
 		return "", err
@@ -256,13 +249,7 @@ func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, arg
 
 // toolCreateChannel implements the create_channel tool.
 // Creates a new public or private channel in a specified team.
-func (p *MattermostToolProvider) toolCreateChannel(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args CreateChannelArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool create_channel: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolCreateChannel(mcpContext *MCPToolContext, args CreateChannelArgs) (string, error) {
 	// Validate required fields
 	if args.Name == "" {
 		return "", fmt.Errorf("name cannot be empty")
@@ -305,12 +292,8 @@ func (p *MattermostToolProvider) toolCreateChannel(mcpContext *MCPToolContext, a
 }
 
 // toolGetChannelInfo implements the get_channel_info tool.
-func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args GetChannelInfoArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool get_channel_info: %w", err)
-	}
+func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, args GetChannelInfoArgs) (string, error) {
+	var err error
 
 	// Get client and context
 	client := mcpContext.Client
@@ -511,13 +494,7 @@ func (p *MattermostToolProvider) formatMultipleChannels(ctx context.Context, cli
 
 // toolGetChannelMembers implements the get_channel_members tool.
 // Returns paginated member details for a channel, including username, email, and roles.
-func (p *MattermostToolProvider) toolGetChannelMembers(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args GetChannelMembersArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool get_channel_members: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolGetChannelMembers(mcpContext *MCPToolContext, args GetChannelMembersArgs) (string, error) {
 	// Validate required fields
 	if err := requireID("channel_id", args.ChannelID); err != nil {
 		return "", err
@@ -590,13 +567,7 @@ func (p *MattermostToolProvider) toolGetChannelMembers(mcpContext *MCPToolContex
 }
 
 // toolAddUserToChannel implements the add_user_to_channel tool using the context client
-func (p *MattermostToolProvider) toolAddUserToChannel(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args AddUserToChannelArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool add_user_to_channel: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolAddUserToChannel(mcpContext *MCPToolContext, args AddUserToChannelArgs) (string, error) {
 	// Validate required fields
 	if err := requireID("user_id", args.UserID); err != nil {
 		return "", err
@@ -610,7 +581,7 @@ func (p *MattermostToolProvider) toolAddUserToChannel(mcpContext *MCPToolContext
 	ctx := mcpContext.Ctx
 
 	// Add user to channel
-	_, _, err = client.AddChannelMember(ctx, args.ChannelID, args.UserID)
+	_, _, err := client.AddChannelMember(ctx, args.ChannelID, args.UserID)
 	if err != nil {
 		return "", fmt.Errorf("error adding user to channel: %w", err)
 	}
@@ -770,13 +741,7 @@ func (p *MattermostToolProvider) tryFindChannelBySubstring(ctx context.Context, 
 // It returns all channels the current user is a member of, including DMs, GMs, and team channels.
 // Team information is resolved in a single batch call via GetTeamsForUser to avoid N+1 queries.
 // The response is paginated and returned as plain text with team metadata for each channel.
-func (p *MattermostToolProvider) toolGetUserChannels(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args GetUserChannelsArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool get_user_channels: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolGetUserChannels(mcpContext *MCPToolContext, args GetUserChannelsArgs) (string, error) {
 	// Validate team ID if provided
 	if err := optionalID("team_id", args.TeamID); err != nil {
 		return "", err

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -128,9 +128,6 @@ func (p *MattermostToolProvider) toolReadChannel(mcpContext *MCPToolContext, arg
 	}
 
 	// Get client and context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -286,9 +283,6 @@ func (p *MattermostToolProvider) toolCreateChannel(mcpContext *MCPToolContext, a
 	}
 
 	// Get client and context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -319,9 +313,6 @@ func (p *MattermostToolProvider) toolGetChannelInfo(mcpContext *MCPToolContext, 
 	}
 
 	// Get client and context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -544,9 +535,6 @@ func (p *MattermostToolProvider) toolGetChannelMembers(mcpContext *MCPToolContex
 	}
 
 	// Get client and context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -618,9 +606,6 @@ func (p *MattermostToolProvider) toolAddUserToChannel(mcpContext *MCPToolContext
 	}
 
 	// Get client and context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -815,9 +800,6 @@ func (p *MattermostToolProvider) toolGetUserChannels(mcpContext *MCPToolContext,
 	}
 
 	// Get client and context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 

--- a/mcpserver/tools/channels.go
+++ b/mcpserver/tools/channels.go
@@ -528,42 +528,15 @@ func (p *MattermostToolProvider) toolGetChannelMembers(mcpContext *MCPToolContex
 		return "no members found in this channel", nil
 	}
 
-	// Get user details for each member, optionally filtering bots
-	var result strings.Builder
-	botsExcluded := 0
-	var written int
-
-	for _, member := range members {
-		user, _, err := client.GetUser(ctx, member.UserId, "")
-		if err != nil {
-			p.logger.Warn("failed to get user details for member", "user_id", member.UserId, "error", err)
-			format.WriteUser(&result, format.UserEntry{User: &model.User{Id: member.UserId, Username: "details unavailable"}})
-			written++
-			continue
+	rendered := make([]renderMember, len(members))
+	for i, member := range members {
+		rendered[i] = renderMember{
+			userID: member.UserId,
+			role:   format.MemberRole(member.SchemeAdmin, member.SchemeGuest, member.SchemeUser),
 		}
-
-		if excludeBots && user.IsBot {
-			botsExcluded++
-			continue
-		}
-
-		format.WriteUser(&result, format.UserEntry{
-			User: user,
-			Role: format.MemberRole(member.SchemeAdmin, member.SchemeGuest, member.SchemeUser),
-		})
-		written++
 	}
 
-	// Build header and footer
-	var header strings.Builder
-	header.WriteString(fmt.Sprintf("Channel Members (page %d, showing %d members):\n", args.Page, written))
-
-	var footer string
-	if botsExcluded > 0 {
-		footer = fmt.Sprintf("\n(%d bot account(s) excluded — set exclude_bots=false to include them)\n", botsExcluded)
-	}
-
-	return header.String() + result.String() + footer, nil
+	return p.renderMembers(ctx, client, "Channel Members", args.Page, rendered, excludeBots), nil
 }
 
 // toolAddUserToChannel implements the add_user_to_channel tool using the context client

--- a/mcpserver/tools/channels_test.go
+++ b/mcpserver/tools/channels_test.go
@@ -78,11 +78,7 @@ func TestToolGetChannelInfoChannelRole(t *testing.T) {
 			client := newTestClient(ts.URL)
 			mcpCtx := &MCPToolContext{Client: client, Ctx: t.Context(), UserID: userID}
 
-			argsGetter := func(target any) error {
-				return json.Unmarshal([]byte(fmt.Sprintf(`{"channel_id":%q}`, channelID)), target)
-			}
-
-			out, err := provider.toolGetChannelInfo(mcpCtx, argsGetter)
+			out, err := provider.toolGetChannelInfo(mcpCtx, GetChannelInfoArgs{ChannelID: channelID})
 			require.NoError(t, err)
 			assert.Contains(t, out, channelID, "expected channel ID in formatted output")
 

--- a/mcpserver/tools/files.go
+++ b/mcpserver/tools/files.go
@@ -45,11 +45,11 @@ func (p *MattermostToolProvider) getFileTools() []MCPTool {
 func (p *MattermostToolProvider) toolReadFile(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
 	var args ReadFileArgs
 	if err := argsGetter(&args); err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool read_file: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool read_file: %w", err)
 	}
 
 	if !model.IsValidId(args.FileID) {
-		return "invalid file_id format", fmt.Errorf("file_id must be a valid ID")
+		return "", fmt.Errorf("file_id must be a valid ID")
 	}
 
 	if p.fileContentService == nil {
@@ -61,7 +61,7 @@ func (p *MattermostToolProvider) toolReadFile(mcpContext *MCPToolContext, argsGe
 		if errors.Is(err, files.ErrForbidden) {
 			return "you do not have permission to read this file", nil
 		}
-		return "failed to read file", fmt.Errorf("error reading file %s: %w", args.FileID, err)
+		return "", fmt.Errorf("error reading file %s: %w", args.FileID, err)
 	}
 
 	return formatFileContent(content), nil

--- a/mcpserver/tools/files.go
+++ b/mcpserver/tools/files.go
@@ -27,12 +27,15 @@ type ReadFileArgs struct {
 	Limit  int    `json:"limit,omitempty" jsonschema:"Maximum number of characters to return (default 6000, capped at 20000)."`
 }
 
+// readFileDescription is the MCP tool metadata description for read_file.
+const readFileDescription = "Read the text contents of a Mattermost file attachment by its File ID. Large attachments in a conversation are shown to you as metadata (name, type, size, File ID) instead of inline content — call this tool with that File ID to read them. Returns extracted text for documents (PDF, Office) and the raw text for plain-text files. Supports ranged reads via offset and limit to page through large files. Parameters: file_id (required), offset (optional), limit (optional). Example: {\"file_id\": \"8xqzn3pfmtbyfkr9hqbw4hheoa\", \"offset\": 0, \"limit\": 6000}"
+
 // getFileTools returns the file-related tools.
 func (p *MattermostToolProvider) getFileTools() []MCPTool {
 	return []MCPTool{
 		{
 			Name:        "read_file",
-			Description: "Read the text contents of a Mattermost file attachment by its File ID. Large attachments in a conversation are shown to you as metadata (name, type, size, File ID) instead of inline content — call this tool with that File ID to read them. Returns extracted text for documents (PDF, Office) and the raw text for plain-text files. Supports ranged reads via offset and limit to page through large files. Parameters: file_id (required), offset (optional), limit (optional). Example: {\"file_id\": \"8xqzn3pfmtbyfkr9hqbw4hheoa\", \"offset\": 0, \"limit\": 6000}",
+			Description: readFileDescription,
 			Schema:      NewJSONSchemaForAccessMode[ReadFileArgs](string(p.accessMode)),
 			Resolver:    typed("read_file", p.toolReadFile),
 		},

--- a/mcpserver/tools/files.go
+++ b/mcpserver/tools/files.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-plugin-agents/files"
-	"github.com/mattermost/mattermost-plugin-agents/llm"
 )
 
 // FileContentService reads the text contents of Mattermost file attachments on
@@ -35,18 +34,13 @@ func (p *MattermostToolProvider) getFileTools() []MCPTool {
 			Name:        "read_file",
 			Description: "Read the text contents of a Mattermost file attachment by its File ID. Large attachments in a conversation are shown to you as metadata (name, type, size, File ID) instead of inline content — call this tool with that File ID to read them. Returns extracted text for documents (PDF, Office) and the raw text for plain-text files. Supports ranged reads via offset and limit to page through large files. Parameters: file_id (required), offset (optional), limit (optional). Example: {\"file_id\": \"8xqzn3pfmtbyfkr9hqbw4hheoa\", \"offset\": 0, \"limit\": 6000}",
 			Schema:      NewJSONSchemaForAccessMode[ReadFileArgs](string(p.accessMode)),
-			Resolver:    p.toolReadFile,
+			Resolver:    typed("read_file", p.toolReadFile),
 		},
 	}
 }
 
 // toolReadFile implements the read_file tool.
-func (p *MattermostToolProvider) toolReadFile(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args ReadFileArgs
-	if err := argsGetter(&args); err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool read_file: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolReadFile(mcpContext *MCPToolContext, args ReadFileArgs) (string, error) {
 	if err := requireID("file_id", args.FileID); err != nil {
 		return "", err
 	}

--- a/mcpserver/tools/files.go
+++ b/mcpserver/tools/files.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-agents/files"
 	"github.com/mattermost/mattermost-plugin-agents/llm"
-	"github.com/mattermost/mattermost/server/public/model"
 )
 
 // FileContentService reads the text contents of Mattermost file attachments on
@@ -48,8 +47,8 @@ func (p *MattermostToolProvider) toolReadFile(mcpContext *MCPToolContext, argsGe
 		return "", fmt.Errorf("failed to get arguments for tool read_file: %w", err)
 	}
 
-	if !model.IsValidId(args.FileID) {
-		return "", fmt.Errorf("file_id must be a valid ID")
+	if err := requireID("file_id", args.FileID); err != nil {
+		return "", err
 	}
 
 	if p.fileContentService == nil {

--- a/mcpserver/tools/files_http.go
+++ b/mcpserver/tools/files_http.go
@@ -4,16 +4,13 @@
 package tools
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
 	"github.com/mattermost/mattermost-plugin-agents/files"
-	"github.com/mattermost/mattermost-plugin-agents/mcpserver/auth"
 )
 
 // HTTPFileContentService reads file contents by calling back to the plugin API.
@@ -55,47 +52,21 @@ type httpFileContentResponse struct {
 
 // GetContent reads a ranged slice of a file's text via the plugin's endpoint.
 func (s *HTTPFileContentService) GetContent(ctx context.Context, userID, fileID string, offset, limit int) (files.Content, error) {
-	bodyBytes, err := json.Marshal(httpFileContentRequest{FileID: fileID, Offset: offset, Limit: limit})
+	reqBody := httpFileContentRequest{FileID: fileID, Offset: offset, Limit: limit}
+	status, respBody, err := postPluginJSON(ctx, s.client, s.pluginURL+"/api/v1/files/content", reqBody, userID)
 	if err != nil {
-		return files.Content{}, fmt.Errorf("failed to marshal request: %w", err)
+		return files.Content{}, err
 	}
 
-	url := s.pluginURL + "/api/v1/files/content"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return files.Content{}, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	if token, ok := ctx.Value(auth.AuthTokenContextKey).(string); ok && token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-	if ctxUserID, ok := ctx.Value(auth.UserIDContextKey).(string); ok && ctxUserID != "" {
-		req.Header.Set("Mattermost-User-Id", ctxUserID)
-	} else if userID != "" {
-		req.Header.Set("Mattermost-User-Id", userID)
-	}
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return files.Content{}, fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return files.Content{}, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode == http.StatusForbidden {
+	if status == http.StatusForbidden {
 		return files.Content{}, files.ErrForbidden
 	}
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		var errResp httpFileContentResponse
 		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
 			return files.Content{}, fmt.Errorf("read file failed: %s", errResp.Error)
 		}
-		return files.Content{}, fmt.Errorf("read file failed with status %d: %s", resp.StatusCode, string(respBody))
+		return files.Content{}, fmt.Errorf("read file failed with status %d: %s", status, string(respBody))
 	}
 
 	var out httpFileContentResponse

--- a/mcpserver/tools/files_test.go
+++ b/mcpserver/tools/files_test.go
@@ -108,7 +108,7 @@ func TestToolReadFile(t *testing.T) {
 			p := &MattermostToolProvider{fileContentService: tt.service}
 			ctx := &MCPToolContext{Ctx: context.Background(), UserID: model.NewId()}
 
-			result, err := p.toolReadFile(ctx, argsGetterFor(t, ReadFileArgs{FileID: tt.fileID}))
+			result, err := p.toolReadFile(ctx, ReadFileArgs{FileID: tt.fileID})
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -139,7 +139,7 @@ func TestToolReadFilePassesRequestingUser(t *testing.T) {
 	fileID := model.NewId()
 	ctx := &MCPToolContext{Ctx: context.Background(), UserID: userID}
 
-	_, err := p.toolReadFile(ctx, argsGetterFor(t, ReadFileArgs{FileID: fileID, Offset: 12, Limit: 34}))
+	_, err := p.toolReadFile(ctx, ReadFileArgs{FileID: fileID, Offset: 12, Limit: 34})
 	require.NoError(t, err)
 
 	assert.Equal(t, userID, fake.gotUserID)

--- a/mcpserver/tools/files_test.go
+++ b/mcpserver/tools/files_test.go
@@ -45,19 +45,20 @@ func TestToolReadFile(t *testing.T) {
 	validID := model.NewId()
 
 	tests := []struct {
-		name         string
-		fileID       string
-		service      FileContentService
-		wantErr      bool
-		wantResult   string   // exact match when set
-		wantContains []string // substring matches
+		name            string
+		fileID          string
+		service         FileContentService
+		wantErr         bool
+		wantResult      string   // exact match when set
+		wantContains    []string // substring matches
+		wantErrContains string   // substring match against err on error paths
 	}{
 		{
-			name:       "invalid file id",
-			fileID:     "too-short",
-			service:    &fakeFileContentService{},
-			wantErr:    true,
-			wantResult: "invalid file_id format",
+			name:            "invalid file id",
+			fileID:          "too-short",
+			service:         &fakeFileContentService{},
+			wantErr:         true,
+			wantErrContains: "file_id must be a valid ID",
 		},
 		{
 			name:       "service unavailable",
@@ -122,6 +123,9 @@ func TestToolReadFile(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
+			}
+			if tt.wantErrContains != "" {
+				assert.Contains(t, err.Error(), tt.wantErrContains)
 			}
 			if tt.wantResult != "" {
 				assert.Equal(t, tt.wantResult, result)

--- a/mcpserver/tools/files_test.go
+++ b/mcpserver/tools/files_test.go
@@ -5,14 +5,12 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-plugin-agents/files"
-	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -32,13 +30,6 @@ func (f *fakeFileContentService) GetContent(_ context.Context, userID, fileID st
 	f.gotOffset = offset
 	f.gotLimit = limit
 	return f.content, f.err
-}
-
-func argsGetterFor(t *testing.T, v any) llm.ToolArgumentGetter {
-	t.Helper()
-	b, err := json.Marshal(v)
-	require.NoError(t, err)
-	return func(target any) error { return json.Unmarshal(b, target) }
 }
 
 func TestToolReadFile(t *testing.T) {

--- a/mcpserver/tools/helpers_test.go
+++ b/mcpserver/tools/helpers_test.go
@@ -4,12 +4,9 @@
 package tools
 
 import (
-	"encoding/json"
 	"testing"
 
-	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost/server/public/model"
-	"github.com/stretchr/testify/require"
 )
 
 // testLogger is a no-op logger for tests. Errors are surfaced via t.Logf.
@@ -39,13 +36,4 @@ func newTestClient(serverURL string) *model.Client4 {
 	client := model.NewAPIv4Client(serverURL)
 	client.SetToken("test-token")
 	return client
-}
-
-// argsGetterFor returns a ToolArgumentGetter that decodes v (marshaled to JSON)
-// into a resolver's argument struct.
-func argsGetterFor(t *testing.T, v any) llm.ToolArgumentGetter {
-	t.Helper()
-	b, err := json.Marshal(v)
-	require.NoError(t, err)
-	return func(target any) error { return json.Unmarshal(b, target) }
 }

--- a/mcpserver/tools/helpers_test.go
+++ b/mcpserver/tools/helpers_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/llm"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+// testLogger is a no-op logger for tests. Errors are surfaced via t.Logf.
+type testLogger struct {
+	t *testing.T
+}
+
+func (l *testLogger) Debug(msg string, keyValuePairs ...any) {}
+func (l *testLogger) Info(msg string, keyValuePairs ...any)  {}
+func (l *testLogger) Warn(msg string, keyValuePairs ...any)  {}
+func (l *testLogger) Error(msg string, keyValuePairs ...any) {
+	l.t.Logf("ERROR: %s %v", msg, keyValuePairs)
+}
+func (l *testLogger) Flush() error { return nil }
+
+// newTestProvider builds a provider wired to a test logger and the given server URL.
+func newTestProvider(t *testing.T, serverURL string) *MattermostToolProvider {
+	t.Helper()
+	return &MattermostToolProvider{
+		logger:      &testLogger{t: t},
+		mmServerURL: serverURL,
+	}
+}
+
+// newTestClient returns a Client4 pointed at serverURL with a dummy token set.
+func newTestClient(serverURL string) *model.Client4 {
+	client := model.NewAPIv4Client(serverURL)
+	client.SetToken("test-token")
+	return client
+}
+
+// argsGetterFor returns a ToolArgumentGetter that decodes v (marshaled to JSON)
+// into a resolver's argument struct.
+func argsGetterFor(t *testing.T, v any) llm.ToolArgumentGetter {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return func(target any) error { return json.Unmarshal(b, target) }
+}

--- a/mcpserver/tools/members.go
+++ b/mcpserver/tools/members.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-agents/format"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// renderMember is the subset of a channel/team membership needed to render a
+// member listing: the user id and the member's formatted role.
+type renderMember struct {
+	userID string
+	role   string
+}
+
+// renderMembers resolves each member's user details and formats them as a paged
+// listing. noun labels the listing (e.g. "Channel Members"). Bot accounts are
+// dropped when excludeBots is set, and the count is reported in the footer.
+func (p *MattermostToolProvider) renderMembers(ctx context.Context, client *model.Client4, noun string, page int, members []renderMember, excludeBots bool) string {
+	var result strings.Builder
+	botsExcluded := 0
+	written := 0
+
+	for _, m := range members {
+		user, _, err := client.GetUser(ctx, m.userID, "")
+		if err != nil {
+			p.logger.Warn("failed to get user details for member", "user_id", m.userID, "error", err)
+			format.WriteUser(&result, format.UserEntry{User: &model.User{Id: m.userID, Username: "details unavailable"}})
+			written++
+			continue
+		}
+
+		if excludeBots && user.IsBot {
+			botsExcluded++
+			continue
+		}
+
+		format.WriteUser(&result, format.UserEntry{User: user, Role: m.role})
+		written++
+	}
+
+	header := fmt.Sprintf("%s (page %d, showing %d members):\n", noun, page, written)
+	footer := ""
+	if botsExcluded > 0 {
+		footer = fmt.Sprintf("\n(%d bot account(s) excluded — set exclude_bots=false to include them)\n", botsExcluded)
+	}
+	return header + result.String() + footer
+}

--- a/mcpserver/tools/plugin_http.go
+++ b/mcpserver/tools/plugin_http.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/mattermost/mattermost-plugin-agents/mcpserver/auth"
+)
+
+// postPluginJSON marshals reqBody to JSON and POSTs it to a plugin callback
+// endpoint, forwarding the auth token and user id from ctx (falling back to
+// fallbackUserID when ctx carries no user id). It returns the response status
+// code and raw body; callers decode the body and map status codes themselves.
+// This centralizes the request plumbing shared by the HTTP-backed capability
+// services (semantic search, file content) so a new one is a thin wrapper.
+func postPluginJSON(ctx context.Context, client *http.Client, url string, reqBody any, fallbackUserID string) (int, []byte, error) {
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if token, ok := ctx.Value(auth.AuthTokenContextKey).(string); ok && token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if ctxUserID, ok := ctx.Value(auth.UserIDContextKey).(string); ok && ctxUserID != "" {
+		req.Header.Set("Mattermost-User-Id", ctxUserID)
+	} else if fallbackUserID != "" {
+		req.Header.Set("Mattermost-User-Id", fallbackUserID)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	return resp.StatusCode, respBody, nil
+}

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -31,9 +31,9 @@ type CreatePostArgs struct {
 type CreatePostAsUserArgs struct {
 	Username    string   `json:"username" jsonschema:"Username to login as"`
 	Password    string   `json:"password" jsonschema:"Password to login with"`
-	ChannelID   string   `json:"channel_id" jsonschema:"The ID of the channel to post in"`
+	ChannelID   string   `json:"channel_id" jsonschema:"The ID of the channel to post in,minLength=26,maxLength=26"`
 	Message     string   `json:"message" jsonschema:"The message content"`
-	RootID      string   `json:"root_id" jsonschema:"Optional root post ID for replies"`
+	RootID      string   `json:"root_id" jsonschema:"Optional root post ID for replies,maxLength=26"`
 	Props       string   `json:"props" jsonschema:"Optional post properties (JSON string)"`
 	Attachments []string `json:"attachments,omitempty" access:"local" jsonschema:"Optional list of file paths or URLs to attach to the post"`
 }

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -112,12 +112,12 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, argsGe
 	var args ReadPostArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool read_post: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool read_post: %w", err)
 	}
 
 	// Validate post ID
 	if !model.IsValidId(args.PostID) {
-		return "invalid post_id format", fmt.Errorf("post_id must be a valid ID")
+		return "", fmt.Errorf("post_id must be a valid ID")
 	}
 
 	// Set default for include_thread
@@ -129,7 +129,7 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, argsGe
 
 	// Get client from context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -140,7 +140,7 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, argsGe
 		// Get the thread
 		postList, _, err := client.GetPostThread(ctx, args.PostID, "", false)
 		if err != nil {
-			return "failed to fetch post thread", fmt.Errorf("error fetching post thread: %w", err)
+			return "", fmt.Errorf("error fetching post thread: %w", err)
 		}
 
 		// Convert to slice and sort by creation time
@@ -161,7 +161,7 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, argsGe
 		// Get just the single post
 		post, _, err := client.GetPost(ctx, args.PostID, "")
 		if err != nil {
-			return "failed to fetch post", fmt.Errorf("error fetching post: %w", err)
+			return "", fmt.Errorf("error fetching post: %w", err)
 		}
 		posts = []*model.Post{post}
 	}
@@ -235,30 +235,30 @@ func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args
 	var args CreatePostArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool create_post: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool create_post: %w", err)
 	}
 
 	// Validate required fields
 	if !model.IsValidId(args.ChannelID) {
-		return "invalid channel_id format", fmt.Errorf("channel_id must be a valid ID")
+		return "", fmt.Errorf("channel_id must be a valid ID")
 	}
 	if args.Message == "" {
-		return "message is required", fmt.Errorf("message cannot be empty")
+		return "", fmt.Errorf("message cannot be empty")
 	}
 	if args.ChannelDisplayName == "" {
-		return "channel_display_name is required", fmt.Errorf("channel_display_name cannot be empty - you must call get_channel_info first")
+		return "", fmt.Errorf("channel_display_name cannot be empty - you must call get_channel_info first")
 	}
 	if args.TeamDisplayName == "" {
-		return "team_display_name is required", fmt.Errorf("team_display_name cannot be empty - you must call get_channel_info first")
+		return "", fmt.Errorf("team_display_name cannot be empty - you must call get_channel_info first")
 	}
 	// Validate root ID if provided (for replies)
 	if args.RootID != "" && !model.IsValidId(args.RootID) {
-		return "invalid root_id format", fmt.Errorf("root_id must be a valid ID")
+		return "", fmt.Errorf("root_id must be a valid ID")
 	}
 
 	// Get client from context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -266,27 +266,25 @@ func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args
 	// Validate that the provided display names match the actual channel and team
 	channel, _, err := client.GetChannel(ctx, args.ChannelID)
 	if err != nil {
-		return "failed to validate channel", fmt.Errorf("error fetching channel for validation: %w", err)
+		return "", fmt.Errorf("error fetching channel for validation: %w", err)
 	}
 
 	// Check if channel display name matches
 	if channel.DisplayName != args.ChannelDisplayName {
-		return fmt.Sprintf("channel_display_name mismatch: provided '%s' but channel ID '%s' has display name '%s'",
-				args.ChannelDisplayName, args.ChannelID, channel.DisplayName),
-			fmt.Errorf("channel display name validation failed")
+		return "", fmt.Errorf("channel_display_name mismatch: provided '%s' but channel ID '%s' has display name '%s'",
+			args.ChannelDisplayName, args.ChannelID, channel.DisplayName)
 	}
 
 	// Get team info to validate team display name
 	team, _, err := client.GetTeam(ctx, channel.TeamId, "")
 	if err != nil {
-		return "failed to validate team", fmt.Errorf("error fetching team for validation: %w", err)
+		return "", fmt.Errorf("error fetching team for validation: %w", err)
 	}
 
 	// Check if team display name matches
 	if team.DisplayName != args.TeamDisplayName {
-		return fmt.Sprintf("team_display_name mismatch: provided '%s' but team ID '%s' has display name '%s'",
-				args.TeamDisplayName, channel.TeamId, team.DisplayName),
-			fmt.Errorf("team display name validation failed")
+		return "", fmt.Errorf("team_display_name mismatch: provided '%s' but team ID '%s' has display name '%s'",
+			args.TeamDisplayName, channel.TeamId, team.DisplayName)
 	}
 
 	// Upload files if specified
@@ -325,7 +323,7 @@ func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args
 
 	createdPost, _, err := client.CreatePost(ctx, post)
 	if err != nil {
-		return "failed to create post", fmt.Errorf("error creating post: %w", err)
+		return "", fmt.Errorf("error creating post: %w", err)
 	}
 
 	return fmt.Sprintf("Successfully created post in channel '%s' (Team: %s) with ID: %s%s",
@@ -337,25 +335,25 @@ func (p *MattermostToolProvider) toolCreatePostAsUser(mcpContext *MCPToolContext
 	var args CreatePostAsUserArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool create_post_as_user: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool create_post_as_user: %w", err)
 	}
 
 	// Validate required fields
 	if args.Username == "" {
-		return "username is required", fmt.Errorf("username cannot be empty")
+		return "", fmt.Errorf("username cannot be empty")
 	}
 	if args.Password == "" {
-		return "password is required", fmt.Errorf("password cannot be empty")
+		return "", fmt.Errorf("password cannot be empty")
 	}
 	if !model.IsValidId(args.ChannelID) {
-		return "invalid channel_id format", fmt.Errorf("channel_id must be a valid ID")
+		return "", fmt.Errorf("channel_id must be a valid ID")
 	}
 	if args.Message == "" {
-		return "message is required", fmt.Errorf("message cannot be empty")
+		return "", fmt.Errorf("message cannot be empty")
 	}
 	// Validate root ID if provided (for replies)
 	if args.RootID != "" && !model.IsValidId(args.RootID) {
-		return "invalid root_id format", fmt.Errorf("root_id must be a valid ID")
+		return "", fmt.Errorf("root_id must be a valid ID")
 	}
 
 	// Create a new client and login as the specified user
@@ -365,7 +363,7 @@ func (p *MattermostToolProvider) toolCreatePostAsUser(mcpContext *MCPToolContext
 	// Login as the specified user
 	user, _, err := userClient.Login(ctx, args.Username, args.Password)
 	if err != nil {
-		return "failed to login as user", fmt.Errorf("login failed for user %s: %w", args.Username, err)
+		return "", fmt.Errorf("login failed for user %s: %w", args.Username, err)
 	}
 
 	// Upload files if specified
@@ -388,7 +386,7 @@ func (p *MattermostToolProvider) toolCreatePostAsUser(mcpContext *MCPToolContext
 
 	createdPost, _, err := userClient.CreatePost(ctx, post)
 	if err != nil {
-		return "failed to create post", fmt.Errorf("error creating post as user %s: %w", args.Username, err)
+		return "", fmt.Errorf("error creating post as user %s: %w", args.Username, err)
 	}
 
 	return fmt.Sprintf("Successfully created post with ID %s as user %s%s", createdPost.Id, user.Username, attachmentMessage), nil
@@ -399,17 +397,17 @@ func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, argsGetter l
 	var args DMArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool dm: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool dm: %w", err)
 	}
 
 	// Validate required fields
 	if args.Message == "" {
-		return "message is required", fmt.Errorf("message cannot be empty")
+		return "", fmt.Errorf("message cannot be empty")
 	}
 
 	// Get client from context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -417,7 +415,7 @@ func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, argsGetter l
 	// Get current user information
 	currentUser, _, err := client.GetMe(ctx, "")
 	if err != nil {
-		return "failed to get current user", fmt.Errorf("error getting current user: %w", err)
+		return "", fmt.Errorf("error getting current user: %w", err)
 	}
 
 	// Resolve target user
@@ -427,7 +425,7 @@ func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, argsGetter l
 	if username != "" {
 		targetUser, _, err = client.GetUserByUsername(ctx, username, "")
 		if err != nil {
-			return "failed to get target user", fmt.Errorf("error getting user by username %q: %w", username, err)
+			return "", fmt.Errorf("error getting user by username %q: %w", username, err)
 		}
 		dmSelf = targetUser.Id == currentUser.Id
 	} else {
@@ -438,7 +436,7 @@ func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, argsGetter l
 	// Create or get direct channel
 	dmChannel, _, err := client.CreateDirectChannel(ctx, currentUser.Id, targetUser.Id)
 	if err != nil {
-		return "failed to create DM channel", fmt.Errorf("error creating direct channel: %w", err)
+		return "", fmt.Errorf("error creating direct channel: %w", err)
 	}
 
 	// Upload files if specified
@@ -480,7 +478,7 @@ func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, argsGetter l
 
 	createdPost, _, err := client.CreatePost(ctx, post)
 	if err != nil {
-		return "failed to create DM post", fmt.Errorf("error creating DM post: %w", err)
+		return "", fmt.Errorf("error creating DM post: %w", err)
 	}
 
 	if dmSelf {
@@ -494,22 +492,22 @@ func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, ar
 	var args GroupMessageArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool group_message: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool group_message: %w", err)
 	}
 
 	if args.Message == "" {
-		return "message is required", fmt.Errorf("message cannot be empty")
+		return "", fmt.Errorf("message cannot be empty")
 	}
 
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
 	currentUser, _, err := client.GetMe(ctx, "")
 	if err != nil {
-		return "failed to get current user", fmt.Errorf("error getting current user: %w", err)
+		return "", fmt.Errorf("error getting current user: %w", err)
 	}
 
 	// Resolve all targets into a deduplicated map of userID -> username
@@ -519,7 +517,7 @@ func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, ar
 		uname = strings.TrimPrefix(uname, "@")
 		resolvedUser, _, resolveErr := client.GetUserByUsername(ctx, uname, "")
 		if resolveErr != nil {
-			return fmt.Sprintf("failed to resolve username %q", uname), fmt.Errorf("error getting user by username %q: %w", uname, resolveErr)
+			return "", fmt.Errorf("error getting user by username %q: %w", uname, resolveErr)
 		}
 		if resolvedUser.Id != currentUser.Id {
 			targets[resolvedUser.Id] = resolvedUser.Username
@@ -527,7 +525,7 @@ func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, ar
 	}
 
 	if len(targets) < 2 {
-		return "group messages require at least 2 other users — for 1:1 DMs use the dm tool instead", fmt.Errorf("need at least 2 target users, got %d", len(targets))
+		return "", fmt.Errorf("group messages require at least 2 other users — for 1:1 DMs use the dm tool instead (got %d)", len(targets))
 	}
 
 	// Build member list: targets + current user
@@ -539,7 +537,7 @@ func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, ar
 
 	gmChannel, _, err := client.CreateGroupChannel(ctx, memberIDs)
 	if err != nil {
-		return "failed to create group message channel", fmt.Errorf("error creating group channel: %w", err)
+		return "", fmt.Errorf("error creating group channel: %w", err)
 	}
 
 	fileIDs, attachmentMessage := uploadFilesAndUrlsForLocal(ctx, client, gmChannel.Id, args.Attachments, mcpContext.AccessMode)
@@ -567,7 +565,7 @@ func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, ar
 
 	createdPost, _, err := client.CreatePost(ctx, post)
 	if err != nil {
-		return "failed to create group message post", fmt.Errorf("error creating group message post: %w", err)
+		return "", fmt.Errorf("error creating group message post: %w", err)
 	}
 
 	// Build username list for success message

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -14,7 +14,7 @@ import (
 // ReadPostArgs represents arguments for the read_post tool
 type ReadPostArgs struct {
 	PostID        string `json:"post_id" jsonschema:"The ID of the post to read,minLength=26,maxLength=26"`
-	IncludeThread bool   `json:"include_thread,omitempty" jsonschema:"Whether to include the entire thread (default: true)"`
+	IncludeThread *bool  `json:"include_thread,omitempty" jsonschema:"Whether to include the entire thread (default: true). Set false to fetch only the single post."`
 }
 
 // CreatePostArgs represents arguments for the create_post tool
@@ -33,7 +33,7 @@ type CreatePostAsUserArgs struct {
 	Password    string   `json:"password" jsonschema:"Password to login with"`
 	ChannelID   string   `json:"channel_id" jsonschema:"The ID of the channel to post in,minLength=26,maxLength=26"`
 	Message     string   `json:"message" jsonschema:"The message content"`
-	RootID      string   `json:"root_id" jsonschema:"Optional root post ID for replies,maxLength=26"`
+	RootID      string   `json:"root_id,omitempty" jsonschema:"Optional root post ID for replies,maxLength=26"`
 	Props       string   `json:"props" jsonschema:"Optional post properties (JSON string)"`
 	Attachments []string `json:"attachments,omitempty" access:"local" jsonschema:"Optional list of file paths or URLs to attach to the post"`
 }
@@ -126,12 +126,9 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, args R
 		return "", err
 	}
 
-	// Set default for include_thread
-	if !args.IncludeThread {
-		// Since bool defaults to false, we need to check if it was explicitly set
-		// For now, default to true
-		args.IncludeThread = true
-	}
+	// Default include_thread to true when omitted; an explicit false fetches only
+	// the single post.
+	includeThread := args.IncludeThread == nil || *args.IncludeThread
 
 	// Get client from context
 	client := mcpContext.Client
@@ -139,7 +136,7 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, args R
 
 	var posts []*model.Post
 
-	if args.IncludeThread {
+	if includeThread {
 		// Get the thread
 		postList, _, err := client.GetPostThread(ctx, args.PostID, "", false)
 		if err != nil {
@@ -211,7 +208,7 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, args R
 	}
 	result.WriteString("\n")
 
-	if args.IncludeThread && len(posts) > 1 {
+	if includeThread && len(posts) > 1 {
 		result.WriteString(fmt.Sprintf("Thread with %d posts:\n\n", len(posts)))
 	}
 

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -128,9 +128,6 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, argsGe
 	}
 
 	// Get client from context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -257,9 +254,6 @@ func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args
 	}
 
 	// Get client from context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -406,9 +400,6 @@ func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, argsGetter l
 	}
 
 	// Get client from context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -499,9 +490,6 @@ func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, ar
 		return "", fmt.Errorf("message cannot be empty")
 	}
 
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-plugin-agents/format"
-	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -72,25 +71,25 @@ func (p *MattermostToolProvider) getPostTools() []MCPTool {
 			Name:        "read_post",
 			Description: "Read a specific post and its thread from Mattermost. Parameters: post_id (required), include_thread (boolean, default true). Returns post content, author info, and optionally all replies in the thread. Example: {\"post_id\": \"8xqzn3pfmtbyfkr9hqbw4hheoa\", \"include_thread\": true}",
 			Schema:      NewJSONSchemaForAccessMode[ReadPostArgs](string(p.accessMode)),
-			Resolver:    p.toolReadPost,
+			Resolver:    typed("read_post", p.toolReadPost),
 		},
 		{
 			Name:        "create_post",
 			Description: createPostDesc,
 			Schema:      NewJSONSchemaForAccessMode[CreatePostArgs](string(p.accessMode)),
-			Resolver:    p.toolCreatePost,
+			Resolver:    typed("create_post", p.toolCreatePost),
 		},
 		{
 			Name:        "dm",
 			Description: dmDesc,
 			Schema:      NewJSONSchemaForAccessMode[DMArgs](string(p.accessMode)),
-			Resolver:    p.toolDM,
+			Resolver:    typed("dm", p.toolDM),
 		},
 		{
 			Name:        "group_message",
 			Description: groupMessageDesc,
 			Schema:      NewJSONSchemaForAccessMode[GroupMessageArgs](string(p.accessMode)),
-			Resolver:    p.toolGroupMessage,
+			Resolver:    typed("group_message", p.toolGroupMessage),
 		},
 	}
 }
@@ -102,19 +101,13 @@ func (p *MattermostToolProvider) getDevPostTools() []MCPTool {
 			Name:        "create_post_as_user",
 			Description: "Create a post as a specific user using username/password login. Use this tool in dev mode for creating realistic multi-user scenarios. Simply provide the username and password of created users.",
 			Schema:      NewJSONSchemaForAccessMode[CreatePostAsUserArgs](string(p.accessMode)),
-			Resolver:    p.toolCreatePostAsUser,
+			Resolver:    typed("create_post_as_user", p.toolCreatePostAsUser),
 		},
 	}
 }
 
 // toolReadPost implements the read_post tool
-func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args ReadPostArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool read_post: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, args ReadPostArgs) (string, error) {
 	// Validate post ID
 	if err := requireID("post_id", args.PostID); err != nil {
 		return "", err
@@ -228,13 +221,7 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, argsGe
 }
 
 // toolCreatePost implements the create_post tool
-func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args CreatePostArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool create_post: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args CreatePostArgs) (string, error) {
 	// Validate required fields
 	if err := requireID("channel_id", args.ChannelID); err != nil {
 		return "", err
@@ -325,13 +312,7 @@ func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args
 }
 
 // toolCreatePostAsUser implements the create_post_as_user tool with custom authentication
-func (p *MattermostToolProvider) toolCreatePostAsUser(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args CreatePostAsUserArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool create_post_as_user: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolCreatePostAsUser(mcpContext *MCPToolContext, args CreatePostAsUserArgs) (string, error) {
 	// Validate required fields
 	if args.Username == "" {
 		return "", fmt.Errorf("username cannot be empty")
@@ -387,13 +368,7 @@ func (p *MattermostToolProvider) toolCreatePostAsUser(mcpContext *MCPToolContext
 }
 
 // toolDM implements the dm tool
-func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args DMArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool dm: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, args DMArgs) (string, error) {
 	// Validate required fields
 	if args.Message == "" {
 		return "", fmt.Errorf("message cannot be empty")
@@ -479,13 +454,7 @@ func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, argsGetter l
 }
 
 // toolGroupMessage implements the group_message tool
-func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args GroupMessageArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool group_message: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, args GroupMessageArgs) (string, error) {
 	if args.Message == "" {
 		return "", fmt.Errorf("message cannot be empty")
 	}

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -52,6 +52,19 @@ type GroupMessageArgs struct {
 	Attachments []string `json:"attachments,omitempty" access:"local" jsonschema:"Optional list of file paths or URLs to attach"`
 }
 
+// Tool description constants for post-related tools. The create_post/dm/group_message
+// descriptions are format strings: getPostTools fills the %s with an access-mode-dependent
+// attachments clause.
+const (
+	readPostDescription = "Read a specific post and its thread from Mattermost. Parameters: post_id (required), include_thread (boolean, default true). Returns post content, author info, and optionally all replies in the thread. Example: {\"post_id\": \"8xqzn3pfmtbyfkr9hqbw4hheoa\", \"include_thread\": true}"
+
+	createPostDescriptionFmt = "Create a new post in Mattermost. IMPORTANT WORKFLOW: You MUST first call get_channel_info to obtain the channel_id, channel_display_name, and team_display_name. Present this context to the user before posting. Then call this tool with all required parameters. This ensures full transparency about where the message will be posted. Parameters: channel_id (required), message (required), root_id (optional - for replies)%s. Returns created post details including ID and timestamp. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"message\": \"Hello team!\"}"
+
+	dmDescriptionFmt = "Send a direct message to a user. Provide username to specify the recipient. If username is omitted, the message is sent to yourself. This is the DEFAULT way to message people — call it multiple times to message multiple people individually. Only use the group_message tool when the user explicitly asks for a group chat. Parameters: message (required), username (optional)%s. Returns confirmation with message ID. Example: {\"message\": \"Hello!\", \"username\": \"john\"}"
+
+	groupMessageDescriptionFmt = "Send a message to a shared group conversation with 2 or more other users. All participants can see each other's messages. ONLY use this when the user explicitly asks for a group message, group chat, or group conversation. If the user just asks to 'message' or 'send to' multiple people, use the dm tool once per person instead. Parameters: message (required), usernames (at least 2 required)%s. Returns confirmation with message ID. Example: {\"message\": \"Hey team!\", \"usernames\": [\"alice\", \"bob\"]}"
+)
+
 // getPostTools returns all post-related tools
 func (p *MattermostToolProvider) getPostTools() []MCPTool {
 	// Build descriptions conditionally based on access mode
@@ -60,16 +73,16 @@ func (p *MattermostToolProvider) getPostTools() []MCPTool {
 		attachmentsParam = ", attachments (optional file paths/URLs)"
 	}
 
-	createPostDesc := fmt.Sprintf("Create a new post in Mattermost. IMPORTANT WORKFLOW: You MUST first call get_channel_info to obtain the channel_id, channel_display_name, and team_display_name. Present this context to the user before posting. Then call this tool with all required parameters. This ensures full transparency about where the message will be posted. Parameters: channel_id (required), message (required), root_id (optional - for replies)%s. Returns created post details including ID and timestamp. Example: {\"channel_id\": \"h5wqm8kxptbztfgzpaxbsqozah\", \"message\": \"Hello team!\"}", attachmentsParam)
+	createPostDesc := fmt.Sprintf(createPostDescriptionFmt, attachmentsParam)
 
-	dmDesc := fmt.Sprintf("Send a direct message to a user. Provide username to specify the recipient. If username is omitted, the message is sent to yourself. This is the DEFAULT way to message people — call it multiple times to message multiple people individually. Only use the group_message tool when the user explicitly asks for a group chat. Parameters: message (required), username (optional)%s. Returns confirmation with message ID. Example: {\"message\": \"Hello!\", \"username\": \"john\"}", attachmentsParam)
+	dmDesc := fmt.Sprintf(dmDescriptionFmt, attachmentsParam)
 
-	groupMessageDesc := fmt.Sprintf("Send a message to a shared group conversation with 2 or more other users. All participants can see each other's messages. ONLY use this when the user explicitly asks for a group message, group chat, or group conversation. If the user just asks to 'message' or 'send to' multiple people, use the dm tool once per person instead. Parameters: message (required), usernames (at least 2 required)%s. Returns confirmation with message ID. Example: {\"message\": \"Hey team!\", \"usernames\": [\"alice\", \"bob\"]}", attachmentsParam)
+	groupMessageDesc := fmt.Sprintf(groupMessageDescriptionFmt, attachmentsParam)
 
 	return []MCPTool{
 		{
 			Name:        "read_post",
-			Description: "Read a specific post and its thread from Mattermost. Parameters: post_id (required), include_thread (boolean, default true). Returns post content, author info, and optionally all replies in the thread. Example: {\"post_id\": \"8xqzn3pfmtbyfkr9hqbw4hheoa\", \"include_thread\": true}",
+			Description: readPostDescription,
 			Schema:      NewJSONSchemaForAccessMode[ReadPostArgs](string(p.accessMode)),
 			Resolver:    typed("read_post", p.toolReadPost),
 		},

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -116,8 +116,8 @@ func (p *MattermostToolProvider) toolReadPost(mcpContext *MCPToolContext, argsGe
 	}
 
 	// Validate post ID
-	if !model.IsValidId(args.PostID) {
-		return "", fmt.Errorf("post_id must be a valid ID")
+	if err := requireID("post_id", args.PostID); err != nil {
+		return "", err
 	}
 
 	// Set default for include_thread
@@ -239,8 +239,8 @@ func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args
 	}
 
 	// Validate required fields
-	if !model.IsValidId(args.ChannelID) {
-		return "", fmt.Errorf("channel_id must be a valid ID")
+	if err := requireID("channel_id", args.ChannelID); err != nil {
+		return "", err
 	}
 	if args.Message == "" {
 		return "", fmt.Errorf("message cannot be empty")
@@ -252,8 +252,8 @@ func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args
 		return "", fmt.Errorf("team_display_name cannot be empty - you must call get_channel_info first")
 	}
 	// Validate root ID if provided (for replies)
-	if args.RootID != "" && !model.IsValidId(args.RootID) {
-		return "", fmt.Errorf("root_id must be a valid ID")
+	if err := optionalID("root_id", args.RootID); err != nil {
+		return "", err
 	}
 
 	// Get client from context
@@ -345,15 +345,15 @@ func (p *MattermostToolProvider) toolCreatePostAsUser(mcpContext *MCPToolContext
 	if args.Password == "" {
 		return "", fmt.Errorf("password cannot be empty")
 	}
-	if !model.IsValidId(args.ChannelID) {
-		return "", fmt.Errorf("channel_id must be a valid ID")
+	if err := requireID("channel_id", args.ChannelID); err != nil {
+		return "", err
 	}
 	if args.Message == "" {
 		return "", fmt.Errorf("message cannot be empty")
 	}
 	// Validate root ID if provided (for replies)
-	if args.RootID != "" && !model.IsValidId(args.RootID) {
-		return "", fmt.Errorf("root_id must be a valid ID")
+	if err := optionalID("root_id", args.RootID); err != nil {
+		return "", err
 	}
 
 	// Create a new client and login as the specified user

--- a/mcpserver/tools/posts.go
+++ b/mcpserver/tools/posts.go
@@ -279,28 +279,7 @@ func (p *MattermostToolProvider) toolCreatePost(mcpContext *MCPToolContext, args
 		FileIds:   fileIDs,
 	}
 
-	// Add AI-generated prop if tracking is enabled
-	if p.trackAIGenerated {
-		var userID string
-
-		// First check if bot user ID was provided via context metadata (from embedded server)
-		if mcpContext.BotUserID != "" && model.IsValidId(mcpContext.BotUserID) {
-			userID = mcpContext.BotUserID
-		} else {
-			// For external servers, fetch the authenticated user's ID
-			if user, _, getMeErr := client.GetMe(ctx, ""); getMeErr == nil && user != nil {
-				userID = user.Id
-			}
-		}
-
-		// Add the prop if we have a valid user ID
-		if userID != "" {
-			if post.Props == nil {
-				post.Props = make(model.StringInterface)
-			}
-			post.Props["ai_generated_by"] = userID
-		}
-	}
+	p.stampAIGenerated(post, mcpContext, "")
 
 	createdPost, _, err := client.CreatePost(ctx, post)
 	if err != nil {
@@ -415,32 +394,12 @@ func (p *MattermostToolProvider) toolDM(mcpContext *MCPToolContext, args DMArgs)
 		FileIds:   fileIDs,
 	}
 
-	props := make(map[string]interface{})
-
 	// Set from_webhook only when DM'ing yourself (prevents AI auto-response loop)
 	if dmSelf {
-		props["from_webhook"] = "true"
+		post.AddProp("from_webhook", "true")
 	}
 
-	// Add AI-generated prop if tracking is enabled
-	if p.trackAIGenerated {
-		var userID string
-
-		// First check if bot user ID was provided via context metadata (from embedded server)
-		if mcpContext.BotUserID != "" && model.IsValidId(mcpContext.BotUserID) {
-			userID = mcpContext.BotUserID
-		} else {
-			userID = currentUser.Id
-		}
-
-		if userID != "" {
-			props["ai_generated_by"] = userID
-		}
-	}
-
-	if len(props) > 0 {
-		post.SetProps(props)
-	}
+	p.stampAIGenerated(post, mcpContext, currentUser.Id)
 
 	createdPost, _, err := client.CreatePost(ctx, post)
 	if err != nil {
@@ -505,20 +464,7 @@ func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, ar
 		FileIds:   fileIDs,
 	}
 
-	if p.trackAIGenerated {
-		var userID string
-		if mcpContext.BotUserID != "" && model.IsValidId(mcpContext.BotUserID) {
-			userID = mcpContext.BotUserID
-		} else {
-			userID = currentUser.Id
-		}
-		if userID != "" {
-			if post.Props == nil {
-				post.Props = make(model.StringInterface)
-			}
-			post.Props["ai_generated_by"] = userID
-		}
-	}
+	p.stampAIGenerated(post, mcpContext, currentUser.Id)
 
 	createdPost, _, err := client.CreatePost(ctx, post)
 	if err != nil {
@@ -533,4 +479,31 @@ func (p *MattermostToolProvider) toolGroupMessage(mcpContext *MCPToolContext, ar
 
 	return fmt.Sprintf("Successfully sent group message to %s with ID: %s%s",
 		strings.Join(usernames, ", "), createdPost.Id, attachmentMessage), nil
+}
+
+// stampAIGenerated marks a post as AI-generated (the ai_generated_by prop) when
+// AI-content tracking is enabled. It prefers the bot user id supplied via request
+// metadata (embedded servers); otherwise it uses fallbackUserID (the authenticated
+// user the caller already resolved), and as a last resort fetches the current user.
+// It is a no-op when tracking is disabled or no user id can be determined.
+func (p *MattermostToolProvider) stampAIGenerated(post *model.Post, mcpContext *MCPToolContext, fallbackUserID string) {
+	if !p.trackAIGenerated {
+		return
+	}
+
+	var userID string
+	switch {
+	case mcpContext.BotUserID != "" && model.IsValidId(mcpContext.BotUserID):
+		userID = mcpContext.BotUserID
+	case fallbackUserID != "":
+		userID = fallbackUserID
+	case mcpContext.Client != nil:
+		if user, _, err := mcpContext.Client.GetMe(mcpContext.Ctx, ""); err == nil && user != nil {
+			userID = user.Id
+		}
+	}
+
+	if userID != "" {
+		post.AddProp("ai_generated_by", userID)
+	}
 }

--- a/mcpserver/tools/posts_test.go
+++ b/mcpserver/tools/posts_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// boolPtr returns a pointer to b for use in optional *bool args.
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func TestStampAIGenerated(t *testing.T) {
+	botID := model.NewId()
+	fallbackID := model.NewId()
+	getMeID := model.NewId()
+
+	// Server that stubs /api/v4/users/me for the GetMe fallback case.
+	meServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v4/users/me" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": getMeID})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer meServer.Close()
+
+	tests := []struct {
+		name             string
+		trackAIGenerated bool
+		mcpContext       *MCPToolContext
+		fallbackUserID   string
+		wantProp         any // nil means the prop must be absent
+	}{
+		{
+			name:             "tracking disabled is a no-op",
+			trackAIGenerated: false,
+			mcpContext:       &MCPToolContext{BotUserID: botID},
+			fallbackUserID:   fallbackID,
+			wantProp:         nil,
+		},
+		{
+			name:             "valid bot user id wins",
+			trackAIGenerated: true,
+			mcpContext:       &MCPToolContext{BotUserID: botID},
+			fallbackUserID:   fallbackID,
+			wantProp:         botID,
+		},
+		{
+			name:             "invalid bot user id falls back to fallbackUserID",
+			trackAIGenerated: true,
+			mcpContext:       &MCPToolContext{BotUserID: "notanid"},
+			fallbackUserID:   fallbackID,
+			wantProp:         fallbackID,
+		},
+		{
+			name:             "no bot or fallback falls back to GetMe",
+			trackAIGenerated: true,
+			mcpContext:       &MCPToolContext{Ctx: context.Background(), Client: newTestClient(meServer.URL)},
+			fallbackUserID:   "",
+			wantProp:         getMeID,
+		},
+		{
+			name:             "no id available leaves prop absent without panic",
+			trackAIGenerated: true,
+			mcpContext:       &MCPToolContext{Ctx: context.Background(), Client: nil},
+			fallbackUserID:   "",
+			wantProp:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &MattermostToolProvider{trackAIGenerated: tt.trackAIGenerated, logger: &testLogger{t: t}}
+			post := &model.Post{}
+
+			require.NotPanics(t, func() {
+				p.stampAIGenerated(post, tt.mcpContext, tt.fallbackUserID)
+			})
+
+			got := post.GetProp("ai_generated_by")
+			if tt.wantProp == nil {
+				assert.Nil(t, got, "ai_generated_by prop should be absent")
+			} else {
+				assert.Equal(t, tt.wantProp, got)
+			}
+		})
+	}
+}
+
+// newTestReadPostServer builds an httptest server stubbing the endpoints
+// toolReadPost touches. The thread endpoint returns the root post plus a
+// sibling reply; the single-post endpoint returns only the root post. Which
+// endpoint was hit is recorded on the returned *readPostHits.
+func newTestReadPostServer(t *testing.T, rootID, channelID, teamID, userID string) (*httptest.Server, *readPostHits) {
+	t.Helper()
+
+	hits := &readPostHits{}
+	siblingID := model.NewId()
+
+	rootPost := &model.Post{Id: rootID, ChannelId: channelID, UserId: userID, Message: rootPostMessage}
+	siblingPost := &model.Post{Id: siblingID, ChannelId: channelID, UserId: userID, RootId: rootID, Message: siblingPostMessage}
+
+	mux := http.NewServeMux()
+
+	// Thread endpoint: /api/v4/posts/{id}/thread
+	mux.HandleFunc("/api/v4/posts/"+rootID+"/thread", func(w http.ResponseWriter, r *http.Request) {
+		hits.thread = true
+		postList := &model.PostList{
+			Order: []string{rootID, siblingID},
+			Posts: map[string]*model.Post{rootID: rootPost, siblingID: siblingPost},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(postList)
+	})
+
+	// Single-post endpoint: /api/v4/posts/{id}
+	mux.HandleFunc("/api/v4/posts/"+rootID, func(w http.ResponseWriter, r *http.Request) {
+		hits.single = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rootPost)
+	})
+
+	// Formatting stubs.
+	mux.HandleFunc("/api/v4/channels/"+channelID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.Channel{Id: channelID, TeamId: teamID, DisplayName: "Town Square"})
+	})
+	mux.HandleFunc("/api/v4/teams/"+teamID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.Team{Id: teamID, DisplayName: "Core Team"})
+	})
+	mux.HandleFunc("/api/v4/users/"+userID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.User{Id: userID, Username: "alice"})
+	})
+
+	return httptest.NewServer(mux), hits
+}
+
+type readPostHits struct {
+	thread bool
+	single bool
+}
+
+const (
+	rootPostMessage    = "this is the root post"
+	siblingPostMessage = "this is a thread reply sibling"
+)
+
+func TestReadPostIncludeThread(t *testing.T) {
+	rootID := model.NewId()
+	channelID := model.NewId()
+	teamID := model.NewId()
+	userID := model.NewId()
+
+	tests := []struct {
+		name          string
+		includeThread *bool
+		wantThreadHit bool
+		wantSingleHit bool
+	}{
+		{
+			name:          "nil includes the thread",
+			includeThread: nil,
+			wantThreadHit: true,
+			wantSingleHit: false,
+		},
+		{
+			name:          "true includes the thread",
+			includeThread: boolPtr(true),
+			wantThreadHit: true,
+			wantSingleHit: false,
+		},
+		{
+			name:          "false fetches only the single post",
+			includeThread: boolPtr(false),
+			wantThreadHit: false,
+			wantSingleHit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, hits := newTestReadPostServer(t, rootID, channelID, teamID, userID)
+			defer ts.Close()
+
+			provider := newTestProvider(t, ts.URL)
+			mcpCtx := &MCPToolContext{Ctx: context.Background(), Client: newTestClient(ts.URL)}
+
+			result, err := provider.toolReadPost(mcpCtx, ReadPostArgs{PostID: rootID, IncludeThread: tt.includeThread})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantThreadHit, hits.thread, "thread endpoint hit")
+			assert.Equal(t, tt.wantSingleHit, hits.single, "single-post endpoint hit")
+
+			// The root post message is always present.
+			assert.Contains(t, result, rootPostMessage)
+
+			if tt.wantThreadHit {
+				// The thread sibling must be included.
+				assert.Contains(t, result, siblingPostMessage)
+				assert.Contains(t, result, "Thread with")
+			} else {
+				// Only the single post — the sibling must NOT appear.
+				assert.NotContains(t, result, siblingPostMessage)
+			}
+		})
+	}
+}

--- a/mcpserver/tools/provider.go
+++ b/mcpserver/tools/provider.go
@@ -120,27 +120,28 @@ func NewMattermostToolProvider(authProvider auth.AuthenticationProvider, logger 
 }
 
 func (p *MattermostToolProvider) mcpTools() []MCPTool {
-	mcpTools := []MCPTool{}
-
-	// Add regular tools
-	mcpTools = append(mcpTools, p.getPostTools()...)
-	mcpTools = append(mcpTools, p.getChannelTools()...)
-	mcpTools = append(mcpTools, p.getTeamTools()...)
-	mcpTools = append(mcpTools, p.getSearchTools()...)
-	mcpTools = append(mcpTools, p.getFileTools()...)
-	mcpTools = append(mcpTools, p.getAgentTools()...)
-
-	// Automation tools are always registered; each carries an Available predicate
-	// so they are hidden from tools/list when the automation plugin is absent.
-	mcpTools = append(mcpTools, p.getAutomationTools()...)
-
-	// Add dev tools if dev mode is enabled
-	if p.devMode {
-		mcpTools = append(mcpTools, p.getDevUserTools()...)
-		mcpTools = append(mcpTools, p.getDevPostTools()...)
-		mcpTools = append(mcpTools, p.getDevTeamTools()...)
+	// Tool groups in registration order. Automation tools are always included;
+	// each carries an Available predicate so it is hidden from tools/list when the
+	// automation plugin is absent.
+	groups := []func() []MCPTool{
+		p.getPostTools,
+		p.getChannelTools,
+		p.getTeamTools,
+		p.getSearchTools,
+		p.getFileTools,
+		p.getAgentTools,
+		p.getAutomationTools,
 	}
 
+	// Dev tools are only exposed when dev mode is enabled.
+	if p.devMode {
+		groups = append(groups, p.getDevUserTools, p.getDevPostTools, p.getDevTeamTools)
+	}
+
+	var mcpTools []MCPTool
+	for _, group := range groups {
+		mcpTools = append(mcpTools, group()...)
+	}
 	return mcpTools
 }
 

--- a/mcpserver/tools/provider.go
+++ b/mcpserver/tools/provider.go
@@ -171,7 +171,10 @@ func (p *MattermostToolProvider) ProvideTools(mcpServer *mcp.Server) {
 }
 
 // toolAvailabilityMiddleware returns MCP receiving middleware that drops any tool
-// from tools/list whose Available predicate reports it as unavailable.
+// from tools/list whose Available predicate reports it as unavailable. Each
+// distinct predicate is evaluated at most once per request, so tools that share
+// a predicate (e.g. all automation tools) trigger a single probe rather than one
+// per tool.
 func toolAvailabilityMiddleware(availability map[string]func() bool) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
@@ -184,9 +187,22 @@ func toolAvailabilityMiddleware(availability map[string]func() bool) mcp.Middlew
 				return result, nil
 			}
 
+			// Memoize each distinct predicate (keyed by its code pointer) for the
+			// duration of this filtering pass.
+			cache := map[uintptr]bool{}
+			isAvailable := func(predicate func() bool) bool {
+				key := reflect.ValueOf(predicate).Pointer()
+				if v, cached := cache[key]; cached {
+					return v
+				}
+				v := predicate()
+				cache[key] = v
+				return v
+			}
+
 			filtered := make([]*mcp.Tool, 0, len(listResult.Tools))
 			for _, tool := range listResult.Tools {
-				if available, gated := availability[tool.Name]; gated && !available() {
+				if available, gated := availability[tool.Name]; gated && !isAvailable(available) {
 					continue
 				}
 				filtered = append(filtered, tool)

--- a/mcpserver/tools/provider.go
+++ b/mcpserver/tools/provider.go
@@ -66,6 +66,11 @@ type MCPTool struct {
 	Description string
 	Schema      *jsonschema.Schema
 	Resolver    MCPToolResolver
+
+	// Available, when set, gates the tool's visibility: it is evaluated on each
+	// tools/list request and the tool is hidden when it returns false. Nil means
+	// always available.
+	Available func() bool
 }
 
 type ToolProvider interface {
@@ -125,8 +130,8 @@ func (p *MattermostToolProvider) mcpTools() []MCPTool {
 	mcpTools = append(mcpTools, p.getFileTools()...)
 	mcpTools = append(mcpTools, p.getAgentTools()...)
 
-	// Automation tools are always registered; availability is checked dynamically
-	// via middleware on each tools/list request.
+	// Automation tools are always registered; each carries an Available predicate
+	// so they are hidden from tools/list when the automation plugin is absent.
 	mcpTools = append(mcpTools, p.getAutomationTools()...)
 
 	// Add dev tools if dev mode is enabled
@@ -151,44 +156,42 @@ func (p *MattermostToolProvider) ToolNames() []string {
 
 // ProvideTools registers all available MCP tools with the server.
 func (p *MattermostToolProvider) ProvideTools(mcpServer *mcp.Server) {
+	availability := map[string]func() bool{}
 	for _, mcpTool := range p.mcpTools() {
 		p.registerDynamicTool(mcpServer, mcpTool)
-	}
-
-	// Add middleware to dynamically filter automation tools from tools/list
-	// when the channel automation plugin is not installed.
-	mcpServer.AddReceivingMiddleware(p.automationToolFilterMiddleware())
-}
-
-func (p *MattermostToolProvider) stripAutomationFromToolsListResult(result mcp.Result) mcp.Result {
-	listResult, ok := result.(*mcp.ListToolsResult)
-	if !ok {
-		return result
-	}
-	filtered := make([]*mcp.Tool, 0, len(listResult.Tools))
-	for _, tool := range listResult.Tools {
-		if !IsAutomationTool(tool.Name) {
-			filtered = append(filtered, tool)
+		if mcpTool.Available != nil {
+			availability[mcpTool.Name] = mcpTool.Available
 		}
 	}
-	listResult.Tools = filtered
-	return listResult
+
+	// Hide tools whose Available predicate currently returns false on each
+	// tools/list request (e.g. automation tools when the plugin is absent).
+	mcpServer.AddReceivingMiddleware(toolAvailabilityMiddleware(availability))
 }
 
-// automationToolFilterMiddleware returns MCP receiving middleware that filters
-// automation tools from tools/list when the channel automation plugin is not installed.
-func (p *MattermostToolProvider) automationToolFilterMiddleware() mcp.Middleware {
+// toolAvailabilityMiddleware returns MCP receiving middleware that drops any tool
+// from tools/list whose Available predicate reports it as unavailable.
+func toolAvailabilityMiddleware(availability map[string]func() bool) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 			result, err := next(ctx, method, req)
 			if err != nil || method != "tools/list" {
 				return result, err
 			}
-
-			if !p.isAutomationPluginInstalled() {
-				return p.stripAutomationFromToolsListResult(result), nil
+			listResult, ok := result.(*mcp.ListToolsResult)
+			if !ok {
+				return result, nil
 			}
-			return result, nil
+
+			filtered := make([]*mcp.Tool, 0, len(listResult.Tools))
+			for _, tool := range listResult.Tools {
+				if available, gated := availability[tool.Name]; gated && !available() {
+					continue
+				}
+				filtered = append(filtered, tool)
+			}
+			listResult.Tools = filtered
+			return listResult, nil
 		}
 	}
 }

--- a/mcpserver/tools/provider.go
+++ b/mcpserver/tools/provider.go
@@ -362,75 +362,71 @@ func NewJSONSchemaForAccessMode[T any](accessMode string) *jsonschema.Schema {
 		panic(fmt.Sprintf("failed to create JSON schema from struct: %v", err))
 	}
 
-	// If no properties to filter, return the base schema
-	if baseSchema.Properties == nil {
+	// Identify the properties the current access mode is not allowed to set.
+	excluded := excludedFieldsForAccessMode(reflect.TypeFor[T](), accessMode)
+	if len(excluded) == 0 {
 		return baseSchema
 	}
 
-	// Get the struct type to inspect field tags
-	var zero T
-	structType := reflect.TypeOf(zero)
+	// Shallow-copy the base schema and drop only the excluded properties, so that
+	// everything else the generator produced ($defs, AdditionalProperties, item
+	// schemas, ...) is preserved.
+	filtered := *baseSchema
+	filtered.Properties = make(map[string]*jsonschema.Schema, len(baseSchema.Properties))
+	for name, prop := range baseSchema.Properties {
+		if !excluded[name] {
+			filtered.Properties[name] = prop
+		}
+	}
+	if len(baseSchema.Required) > 0 {
+		required := make([]string, 0, len(baseSchema.Required))
+		for _, name := range baseSchema.Required {
+			if !excluded[name] {
+				required = append(required, name)
+			}
+		}
+		filtered.Required = required
+	}
+	return &filtered
+}
 
-	// If it's a pointer, get the underlying type
-	if structType.Kind() == reflect.Ptr {
-		structType = structType.Elem()
+// excludedFieldsForAccessMode returns the set of JSON field names on struct type
+// t that the given access mode is not allowed to use, per each field's `access:`
+// tag. Returns nil when nothing is restricted.
+func excludedFieldsForAccessMode(t reflect.Type, accessMode string) map[string]bool {
+	for t != nil && t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t == nil || t.Kind() != reflect.Struct {
+		return nil
 	}
 
-	// If it's not a struct, return the base schema
-	if structType.Kind() != reflect.Struct {
-		return baseSchema
-	}
-
-	// Create a new schema with filtered properties
-	filteredSchema := &jsonschema.Schema{
-		Type:        baseSchema.Type,
-		Title:       baseSchema.Title,
-		Description: baseSchema.Description,
-		Properties:  make(map[string]*jsonschema.Schema),
-		Required:    []string{},
-	}
-
-	// Check each field and its access tag
-	for i := 0; i < structType.NumField(); i++ {
-		field := structType.Field(i)
-
-		// Get the JSON field name
-		jsonTag := field.Tag.Get("json")
-		if jsonTag == "" || jsonTag == "-" {
+	var excluded map[string]bool
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		name := jsonFieldName(field)
+		if name == "" {
 			continue
 		}
-
-		// Extract field name (ignore omitempty and other options)
-		jsonFieldName := strings.Split(jsonTag, ",")[0]
-		if jsonFieldName == "" {
-			continue
-		}
-
-		// Check access tag
 		restrictionTag := field.Tag.Get("access")
-
-		// Include field if:
-		// - No restriction tag (available for all access modes)
-		// - Current access mode is in the comma-separated list of allowed modes
-		includeField := restrictionTag == "" || isAccessAllowed(restrictionTag, accessMode)
-
-		if includeField {
-			// Copy the property from base schema if it exists
-			if baseProperty, exists := baseSchema.Properties[jsonFieldName]; exists {
-				filteredSchema.Properties[jsonFieldName] = baseProperty
+		if restrictionTag != "" && !isAccessAllowed(restrictionTag, accessMode) {
+			if excluded == nil {
+				excluded = make(map[string]bool)
 			}
-
-			// Check if field was required in original schema
-			for _, requiredField := range baseSchema.Required {
-				if requiredField == jsonFieldName {
-					filteredSchema.Required = append(filteredSchema.Required, jsonFieldName)
-					break
-				}
-			}
+			excluded[name] = true
 		}
 	}
+	return excluded
+}
 
-	return filteredSchema
+// jsonFieldName returns the JSON object key for a struct field, or "" when the
+// field has no usable json tag (omitted or "-").
+func jsonFieldName(field reflect.StructField) string {
+	jsonTag := field.Tag.Get("json")
+	if jsonTag == "" || jsonTag == "-" {
+		return ""
+	}
+	return strings.Split(jsonTag, ",")[0]
 }
 
 // isAccessAllowed checks if the current access mode is allowed based on the access tag
@@ -484,20 +480,13 @@ func validateAccessRestrictions(jsonData []byte, target interface{}, currentAcce
 	for i := 0; i < targetType.NumField(); i++ {
 		field := targetType.Field(i)
 
-		// Get the JSON field name
-		jsonTag := field.Tag.Get("json")
-		if jsonTag == "" || jsonTag == "-" {
-			continue
-		}
-
-		// Extract field name (ignore omitempty and other options)
-		jsonFieldName := strings.Split(jsonTag, ",")[0]
-		if jsonFieldName == "" {
+		name := jsonFieldName(field)
+		if name == "" {
 			continue
 		}
 
 		// Check if this field is present in the incoming data
-		if _, fieldPresent := incomingData[jsonFieldName]; !fieldPresent {
+		if _, fieldPresent := incomingData[name]; !fieldPresent {
 			continue // Field not provided, so no validation needed
 		}
 
@@ -506,7 +495,7 @@ func validateAccessRestrictions(jsonData []byte, target interface{}, currentAcce
 
 		// If field has access restrictions and current access mode is not allowed
 		if restrictionTag != "" && !isAccessAllowed(restrictionTag, currentAccessMode) {
-			return fmt.Errorf("field '%s' is not available in %s access mode (requires: %s)", jsonFieldName, currentAccessMode, restrictionTag)
+			return fmt.Errorf("field '%s' is not available in %s access mode (requires: %s)", name, currentAccessMode, restrictionTag)
 		}
 	}
 

--- a/mcpserver/tools/provider.go
+++ b/mcpserver/tools/provider.go
@@ -45,6 +45,21 @@ type MCPToolContext struct {
 // MCPToolResolver defines the signature for MCP tool resolvers
 type MCPToolResolver func(*MCPToolContext, llm.ToolArgumentGetter) (string, error)
 
+// typed adapts a resolver that accepts an already-decoded argument struct into
+// an MCPToolResolver. It owns argument decoding and the standard "invalid
+// arguments" error, so individual resolvers start at their real logic. The
+// returned resolver is an ordinary MCPToolResolver, so registerDynamicTool and
+// the before-hook (which still sees the raw request arguments) are unchanged.
+func typed[T any](name string, fn func(*MCPToolContext, T) (string, error)) MCPToolResolver {
+	return func(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
+		var args T
+		if err := argsGetter(&args); err != nil {
+			return "", fmt.Errorf("failed to get arguments for tool %s: %w", name, err)
+		}
+		return fn(mcpContext, args)
+	}
+}
+
 // MCPTool represents a tool specifically for MCP use with our custom context
 type MCPTool struct {
 	Name        string

--- a/mcpserver/tools/provider_test.go
+++ b/mcpserver/tools/provider_test.go
@@ -264,3 +264,94 @@ func TestValidateAccessRestrictions_AttackScenario(t *testing.T) {
 	err = validateAccessRestrictions([]byte(cleanRemoteRequest), &target, "remote")
 	require.NoError(t, err, "Remote access mode should allow requests without restricted fields")
 }
+
+// toolNames extracts the names from a slice of *mcp.Tool.
+func toolNames(tools []*mcp.Tool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+// newToolsListHandler returns a fake "next" MethodHandler that responds to any
+// method with a ListToolsResult carrying tools named by the given names.
+func newToolsListHandler(names ...string) mcp.MethodHandler {
+	return func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		tools := make([]*mcp.Tool, 0, len(names))
+		for _, name := range names {
+			tools = append(tools, &mcp.Tool{Name: name})
+		}
+		return &mcp.ListToolsResult{Tools: tools}, nil
+	}
+}
+
+func alwaysTrue() bool  { return true }
+func alwaysFalse() bool { return false }
+
+func TestToolAvailabilityMiddleware(t *testing.T) {
+	t.Run("drops unavailable tool, keeps the rest", func(t *testing.T) {
+		availability := map[string]func() bool{"b": alwaysFalse}
+		handler := toolAvailabilityMiddleware(availability)(newToolsListHandler("a", "b", "c"))
+
+		// req is unread by the middleware; mcp.Request is an interface, so nil compiles.
+		result, err := handler(context.Background(), "tools/list", nil)
+		require.NoError(t, err)
+
+		listResult, ok := result.(*mcp.ListToolsResult)
+		require.True(t, ok)
+		assert.ElementsMatch(t, []string{"a", "c"}, toolNames(listResult.Tools))
+	})
+
+	t.Run("keeps available tool", func(t *testing.T) {
+		availability := map[string]func() bool{"a": alwaysTrue}
+		handler := toolAvailabilityMiddleware(availability)(newToolsListHandler("a"))
+
+		result, err := handler(context.Background(), "tools/list", nil)
+		require.NoError(t, err)
+
+		listResult, ok := result.(*mcp.ListToolsResult)
+		require.True(t, ok)
+		assert.Equal(t, []string{"a"}, toolNames(listResult.Tools))
+	})
+
+	t.Run("tools not in the availability map are always kept", func(t *testing.T) {
+		availability := map[string]func() bool{"b": alwaysFalse}
+		handler := toolAvailabilityMiddleware(availability)(newToolsListHandler("a", "c"))
+
+		result, err := handler(context.Background(), "tools/list", nil)
+		require.NoError(t, err)
+
+		listResult, ok := result.(*mcp.ListToolsResult)
+		require.True(t, ok)
+		assert.ElementsMatch(t, []string{"a", "c"}, toolNames(listResult.Tools))
+	})
+
+	t.Run("non-tools/list method is passed through untouched", func(t *testing.T) {
+		availability := map[string]func() bool{"b": alwaysFalse}
+		handler := toolAvailabilityMiddleware(availability)(newToolsListHandler("a", "b", "c"))
+
+		// A different method: the middleware must NOT filter "b" out.
+		result, err := handler(context.Background(), "tools/call", nil)
+		require.NoError(t, err)
+
+		listResult, ok := result.(*mcp.ListToolsResult)
+		require.True(t, ok)
+		assert.ElementsMatch(t, []string{"a", "b", "c"}, toolNames(listResult.Tools))
+	})
+
+	t.Run("shared predicate is evaluated once per call (memoization)", func(t *testing.T) {
+		calls := 0
+		pred := func() bool {
+			calls++
+			return true
+		}
+		availability := map[string]func() bool{"x": pred, "y": pred}
+		handler := toolAvailabilityMiddleware(availability)(newToolsListHandler("x", "y"))
+
+		_, err := handler(context.Background(), "tools/list", nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, calls, "the shared predicate must be probed once, not once per tool")
+	})
+}

--- a/mcpserver/tools/provider_test.go
+++ b/mcpserver/tools/provider_test.go
@@ -26,31 +26,6 @@ func (fakeToolAuthProvider) GetAuthenticatedMattermostClient(context.Context) (*
 	return model.NewAPIv4Client("https://mm.example.com"), nil
 }
 
-// testLogger is a simple no-op logger for testing
-type testLogger struct {
-	t *testing.T
-}
-
-func (l *testLogger) Debug(msg string, keyValuePairs ...any) {
-	// Could use l.t.Log if we wanted to see debug output during tests
-}
-
-func (l *testLogger) Info(msg string, keyValuePairs ...any) {
-	// Could use l.t.Log if we wanted to see info output during tests
-}
-
-func (l *testLogger) Warn(msg string, keyValuePairs ...any) {
-	// Could use l.t.Log if we wanted to see warnings during tests
-}
-
-func (l *testLogger) Error(msg string, keyValuePairs ...any) {
-	l.t.Logf("ERROR: %s %v", msg, keyValuePairs)
-}
-
-func (l *testLogger) Flush() error {
-	return nil
-}
-
 func TestCreateMCPToolContextReadsBeforeHookResolver(t *testing.T) {
 	expectedResolver := auth.BeforeHookResolver(func(_, _, _ string) (string, error) {
 		return "/plugins/com.example.plugin/hooks/before", nil

--- a/mcpserver/tools/provider_test.go
+++ b/mcpserver/tools/provider_test.go
@@ -5,6 +5,7 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/mattermost/mattermost-plugin-agents/mcpserver/auth"
@@ -45,6 +46,18 @@ func TestCreateMCPToolContextReadsBeforeHookResolver(t *testing.T) {
 	got, err := mcpCtx.BeforeHookResolver("user-1", "search_posts", "beforeHook:secret")
 	require.NoError(t, err)
 	require.Equal(t, "/plugins/com.example.plugin/hooks/before", got)
+}
+
+// TestTypedWrapperDecodeError verifies the typed wrapper owns argument decoding
+// and surfaces the standard "invalid arguments" error for the tool when the
+// argument getter fails, before the underlying resolver runs.
+func TestTypedWrapperDecodeError(t *testing.T) {
+	provider := &MattermostToolProvider{logger: &testLogger{t: t}}
+
+	r := typed("delete_automation", provider.toolDeleteAutomation)
+	_, err := r(&MCPToolContext{}, func(any) error { return fmt.Errorf("bad json") })
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get arguments for tool delete_automation")
 }
 
 // TestSchemaArgs is a test struct for schema conversion testing

--- a/mcpserver/tools/search.go
+++ b/mcpserver/tools/search.go
@@ -55,7 +55,7 @@ func (p *MattermostToolProvider) getSearchTools() []MCPTool {
 	mentionHint := "To find posts mentioning a specific person, query their username only (e.g. `john.smith`); at-mentions in posts use the username, never the display name. Do not combine username and display name (e.g. `john.smith John Smith`) in a single query — that requires all of those tokens to co-occur and will miss most posts."
 
 	if semanticEnabled {
-		schema = llm.NewJSONSchemaFromStruct[CombinedSearchArgs]()
+		schema = NewJSONSchemaForAccessMode[CombinedSearchArgs](string(p.accessMode))
 		description = "Search for posts in Mattermost using both semantic (AI-powered) and keyword search. " +
 			"Semantic search finds posts by meaning and does not require exact term matches. " +
 			"Keyword search treats the query as a literal AND match — every whitespace-separated token must appear in the same post — so prefer short, focused queries (1-2 key terms) over long multi-word phrases. " +
@@ -67,7 +67,7 @@ func (p *MattermostToolProvider) getSearchTools() []MCPTool {
 			"Returns matching posts with content, author, channel, and relevance score for semantic results. " +
 			contextHint
 	} else {
-		schema = llm.NewJSONSchemaFromStruct[KeywordOnlySearchArgs]()
+		schema = NewJSONSchemaForAccessMode[KeywordOnlySearchArgs](string(p.accessMode))
 		description = "Search for posts in Mattermost using keyword search. " +
 			"Treats the query as a literal AND match — every whitespace-separated token must appear in the same post — so prefer short, focused queries (1-2 key terms) over long multi-word phrases. " +
 			"Parameters: query (required), team_id (optional), channel_id (optional). " +
@@ -87,7 +87,7 @@ func (p *MattermostToolProvider) getSearchTools() []MCPTool {
 		{
 			Name:        "search_users",
 			Description: "Search for existing users by username, email, or name. Parameters: term (required search text), limit (1-100, default 20). Returns user details including username, email, display name, and position for matching users. Example: {\"term\": \"john\", \"limit\": 5}",
-			Schema:      llm.NewJSONSchemaFromStruct[SearchUsersArgs](),
+			Schema:      NewJSONSchemaForAccessMode[SearchUsersArgs](string(p.accessMode)),
 			Resolver:    p.toolSearchUsers,
 		},
 	}

--- a/mcpserver/tools/search.go
+++ b/mcpserver/tools/search.go
@@ -42,6 +42,11 @@ type SearchUsersArgs struct {
 	Limit int    `json:"limit,omitempty" jsonschema:"Maximum number of results to return (default: 20, max: 100),minimum=1,maximum=100"`
 }
 
+// searchUsersDescription is the MCP tool metadata description for search_users.
+// (The search_posts description is composed at runtime in getSearchTools because it
+// varies with whether semantic search is enabled.)
+const searchUsersDescription = "Search for existing users by username, email, or name. Parameters: term (required search text), limit (1-100, default 20). Returns user details including username, email, display name, and position for matching users. Example: {\"term\": \"john\", \"limit\": 5}"
+
 // getSearchTools returns all search-related tools.
 func (p *MattermostToolProvider) getSearchTools() []MCPTool {
 	semanticEnabled := p.searchService != nil && p.searchService.Enabled()
@@ -85,7 +90,7 @@ func (p *MattermostToolProvider) getSearchTools() []MCPTool {
 		},
 		{
 			Name:        "search_users",
-			Description: "Search for existing users by username, email, or name. Parameters: term (required search text), limit (1-100, default 20). Returns user details including username, email, display name, and position for matching users. Example: {\"term\": \"john\", \"limit\": 5}",
+			Description: searchUsersDescription,
 			Schema:      NewJSONSchemaForAccessMode[SearchUsersArgs](string(p.accessMode)),
 			Resolver:    typed("search_users", p.toolSearchUsers),
 		},

--- a/mcpserver/tools/search.go
+++ b/mcpserver/tools/search.go
@@ -145,9 +145,6 @@ func (p *MattermostToolProvider) toolCombinedSearch(mcpContext *MCPToolContext, 
 		args.KeywordOffset = 0
 	}
 
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -477,9 +474,6 @@ func (p *MattermostToolProvider) toolSearchUsers(mcpContext *MCPToolContext, arg
 		args.Limit = 100
 	}
 
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 

--- a/mcpserver/tools/search.go
+++ b/mcpserver/tools/search.go
@@ -112,18 +112,18 @@ type searchPostResult struct {
 func (p *MattermostToolProvider) toolCombinedSearch(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
 	var args CombinedSearchArgs
 	if err := argsGetter(&args); err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool search_posts: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool search_posts: %w", err)
 	}
 
 	if args.Query == "" {
-		return "query is required", fmt.Errorf("query cannot be empty")
+		return "", fmt.Errorf("query cannot be empty")
 	}
 
 	if args.TeamID != "" && !model.IsValidId(args.TeamID) {
-		return "invalid team_id format", fmt.Errorf("team_id must be a valid ID")
+		return "", fmt.Errorf("team_id must be a valid ID")
 	}
 	if args.ChannelID != "" && !model.IsValidId(args.ChannelID) {
-		return "invalid channel_id format", fmt.Errorf("channel_id must be a valid ID")
+		return "", fmt.Errorf("channel_id must be a valid ID")
 	}
 
 	if args.SemanticLimit <= 0 {
@@ -146,7 +146,7 @@ func (p *MattermostToolProvider) toolCombinedSearch(mcpContext *MCPToolContext, 
 	}
 
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -156,7 +156,7 @@ func (p *MattermostToolProvider) toolCombinedSearch(mcpContext *MCPToolContext, 
 	if semanticEnabled {
 		user, _, err := client.GetMe(ctx, "")
 		if err != nil {
-			return "failed to get user", fmt.Errorf("failed to get current user: %w", err)
+			return "", fmt.Errorf("failed to get current user: %w", err)
 		}
 		userID = user.Id
 	}
@@ -191,9 +191,9 @@ func (p *MattermostToolProvider) toolCombinedSearch(mcpContext *MCPToolContext, 
 
 	if keywordErr != nil && (!semanticEnabled || semanticErr != nil) {
 		if semanticEnabled {
-			return "search failed", fmt.Errorf("both search methods failed: semantic: %v, keyword: %v", semanticErr, keywordErr)
+			return "", fmt.Errorf("both search methods failed: semantic: %v, keyword: %v", semanticErr, keywordErr)
 		}
-		return "search failed", fmt.Errorf("keyword search failed: %v", keywordErr)
+		return "", fmt.Errorf("keyword search failed: %v", keywordErr)
 	}
 
 	return p.formatCombinedResults(args.Query, semanticResults, keywordResults, semanticEnabled, args.ChannelID)
@@ -463,11 +463,11 @@ func (p *MattermostToolProvider) toolSearchUsers(mcpContext *MCPToolContext, arg
 	var args SearchUsersArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool search_users: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool search_users: %w", err)
 	}
 
 	if args.Term == "" {
-		return "term is required", fmt.Errorf("search term cannot be empty")
+		return "", fmt.Errorf("search term cannot be empty")
 	}
 
 	if args.Limit <= 0 {
@@ -478,7 +478,7 @@ func (p *MattermostToolProvider) toolSearchUsers(mcpContext *MCPToolContext, arg
 	}
 
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -492,7 +492,7 @@ func (p *MattermostToolProvider) toolSearchUsers(mcpContext *MCPToolContext, arg
 
 	users, _, err := client.SearchUsers(ctx, searchOptions)
 	if err != nil {
-		return "user search failed", fmt.Errorf("error searching users: %w", err)
+		return "", fmt.Errorf("error searching users: %w", err)
 	}
 
 	if len(users) == 0 {

--- a/mcpserver/tools/search.go
+++ b/mcpserver/tools/search.go
@@ -119,11 +119,11 @@ func (p *MattermostToolProvider) toolCombinedSearch(mcpContext *MCPToolContext, 
 		return "", fmt.Errorf("query cannot be empty")
 	}
 
-	if args.TeamID != "" && !model.IsValidId(args.TeamID) {
-		return "", fmt.Errorf("team_id must be a valid ID")
+	if err := optionalID("team_id", args.TeamID); err != nil {
+		return "", err
 	}
-	if args.ChannelID != "" && !model.IsValidId(args.ChannelID) {
-		return "", fmt.Errorf("channel_id must be a valid ID")
+	if err := optionalID("channel_id", args.ChannelID); err != nil {
+		return "", err
 	}
 
 	if args.SemanticLimit <= 0 {

--- a/mcpserver/tools/search.go
+++ b/mcpserver/tools/search.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/mattermost/mattermost-plugin-agents/format"
-	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost-plugin-agents/search"
 	"github.com/mattermost/mattermost/server/public/model"
 )
@@ -82,13 +81,13 @@ func (p *MattermostToolProvider) getSearchTools() []MCPTool {
 			Name:        "search_posts",
 			Description: description,
 			Schema:      schema,
-			Resolver:    p.toolCombinedSearch,
+			Resolver:    typed("search_posts", p.toolCombinedSearch),
 		},
 		{
 			Name:        "search_users",
 			Description: "Search for existing users by username, email, or name. Parameters: term (required search text), limit (1-100, default 20). Returns user details including username, email, display name, and position for matching users. Example: {\"term\": \"john\", \"limit\": 5}",
 			Schema:      NewJSONSchemaForAccessMode[SearchUsersArgs](string(p.accessMode)),
-			Resolver:    p.toolSearchUsers,
+			Resolver:    typed("search_users", p.toolSearchUsers),
 		},
 	}
 }
@@ -109,12 +108,7 @@ type searchPostResult struct {
 }
 
 // toolCombinedSearch implements the search_posts tool.
-func (p *MattermostToolProvider) toolCombinedSearch(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args CombinedSearchArgs
-	if err := argsGetter(&args); err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool search_posts: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolCombinedSearch(mcpContext *MCPToolContext, args CombinedSearchArgs) (string, error) {
 	if args.Query == "" {
 		return "", fmt.Errorf("query cannot be empty")
 	}
@@ -456,13 +450,7 @@ func (p *MattermostToolProvider) formatSingleResult(result *strings.Builder, ind
 }
 
 // toolSearchUsers implements the search_users tool.
-func (p *MattermostToolProvider) toolSearchUsers(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args SearchUsersArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool search_users: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolSearchUsers(mcpContext *MCPToolContext, args SearchUsersArgs) (string, error) {
 	if args.Term == "" {
 		return "", fmt.Errorf("search term cannot be empty")
 	}

--- a/mcpserver/tools/search_http.go
+++ b/mcpserver/tools/search_http.go
@@ -4,14 +4,11 @@
 package tools
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
-	"github.com/mattermost/mattermost-plugin-agents/mcpserver/auth"
 	"github.com/mattermost/mattermost-plugin-agents/search"
 )
 
@@ -76,50 +73,18 @@ func (s *HTTPSemanticSearchService) Search(ctx context.Context, query string, op
 		Offset:    opts.Offset,
 	}
 
-	bodyBytes, err := json.Marshal(reqBody)
+	status, respBody, err := postPluginJSON(ctx, s.client, s.pluginURL+"/api/v1/search/raw", reqBody, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
-	}
-
-	// Create HTTP request
-	url := s.pluginURL + "/api/v1/search/raw"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	// Extract auth token from context and add to request
-	if token, ok := ctx.Value(auth.AuthTokenContextKey).(string); ok && token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-
-	// Extract user ID from context (for session-based auth)
-	if userID, ok := ctx.Value(auth.UserIDContextKey).(string); ok && userID != "" {
-		req.Header.Set("Mattermost-User-Id", userID)
-	}
-
-	// Execute request
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Read response body
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+		return nil, err
 	}
 
 	// Handle non-200 responses
-	if resp.StatusCode != http.StatusOK {
+	if status != http.StatusOK {
 		var errResp httpSearchResponse
 		if json.Unmarshal(respBody, &errResp) == nil && errResp.Error != "" {
 			return nil, fmt.Errorf("search failed: %s", errResp.Error)
 		}
-		return nil, fmt.Errorf("search failed with status %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("search failed with status %d: %s", status, string(respBody))
 	}
 
 	// Parse successful response

--- a/mcpserver/tools/search_test.go
+++ b/mcpserver/tools/search_test.go
@@ -68,6 +68,7 @@ func TestGetSearchTools_SchemaReflectsCapabilities(t *testing.T) {
 			provider := &MattermostToolProvider{
 				logger:        &testLogger{t: t},
 				searchService: tc.searchService,
+				accessMode:    AccessModeRemote,
 			}
 
 			tools := provider.getSearchTools()

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -240,42 +240,15 @@ func (p *MattermostToolProvider) toolGetTeamMembers(mcpContext *MCPToolContext, 
 		return "no members found in this team", nil
 	}
 
-	// Get user details for each member, optionally filtering bots
-	var result strings.Builder
-	botsExcluded := 0
-	var written int
-
-	for _, member := range members {
-		user, _, err := client.GetUser(ctx, member.UserId, "")
-		if err != nil {
-			p.logger.Warn("failed to get user details for member", "user_id", member.UserId, "error", err)
-			format.WriteUser(&result, format.UserEntry{User: &model.User{Id: member.UserId, Username: "details unavailable"}})
-			written++
-			continue
+	rendered := make([]renderMember, len(members))
+	for i, member := range members {
+		rendered[i] = renderMember{
+			userID: member.UserId,
+			role:   format.MemberRole(member.SchemeAdmin, member.SchemeGuest, member.SchemeUser),
 		}
-
-		if excludeBots && user.IsBot {
-			botsExcluded++
-			continue
-		}
-
-		format.WriteUser(&result, format.UserEntry{
-			User: user,
-			Role: format.MemberRole(member.SchemeAdmin, member.SchemeGuest, member.SchemeUser),
-		})
-		written++
 	}
 
-	// Build header and footer
-	var header strings.Builder
-	header.WriteString(fmt.Sprintf("Team Members (page %d, showing %d members):\n", args.Page, written))
-
-	var footer string
-	if botsExcluded > 0 {
-		footer = fmt.Sprintf("\n(%d bot account(s) excluded — set exclude_bots=false to include them)\n", botsExcluded)
-	}
-
-	return header.String() + result.String() + footer, nil
+	return p.renderMembers(ctx, client, "Team Members", args.Page, rendered, excludeBots), nil
 }
 
 // toolCreateTeam implements the create_team tool using the context client

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -44,7 +44,7 @@ type AddUserToTeamArgs struct {
 const (
 	getTeamInfoDescription = "Get information about a team. Provide team_id (fastest) or team_name (matches against both display name and URL name, case-insensitive, supports partial matches). Returns team metadata including ID, names, type, description, and member count. Example: {\"team_name\": \"Engineering\"} or {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\"}"
 
-	getTeamMembersDescription = "Get members of a team with pagination support. Parameters: team_id (required), limit (1-200, default 50), page (0+, default 0). Returns user details for each member including username, email, display name, and roles. Example: {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\", \"limit\": 10, \"page\": 0}"
+	getTeamMembersDescription = "Get members of a team with pagination support. Parameters: team_id (required), limit (1-200, default 50), page (0+, default 0), exclude_bots (optional, default true). Returns user details for each member including username, email, display name, and roles. Example: {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\", \"limit\": 10, \"page\": 0}"
 )
 
 // getTeamTools returns all team-related tools
@@ -95,8 +95,8 @@ func (p *MattermostToolProvider) toolGetTeamInfo(mcpContext *MCPToolContext, arg
 
 	switch {
 	case args.TeamID != "":
-		if err := requireID("team_id", args.TeamID); err != nil {
-			return "", err
+		if validationErr := requireID("team_id", args.TeamID); validationErr != nil {
+			return "", validationErr
 		}
 		team, _, err = client.GetTeam(ctx, args.TeamID, "")
 		if err != nil {
@@ -195,6 +195,9 @@ func (p *MattermostToolProvider) resolveTeamByName(mcpContext *MCPToolContext, n
 	}
 	if searchErr == nil && len(searchResults) > 1 {
 		return nil, formatTeamDisambiguation(name, searchResults), nil
+	}
+	if searchErr != nil {
+		return nil, "", fmt.Errorf("error searching teams: %w", searchErr)
 	}
 
 	// Nothing found — surface recovery guidance to the model as an informational

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -96,8 +96,8 @@ func (p *MattermostToolProvider) toolGetTeamInfo(mcpContext *MCPToolContext, arg
 
 	switch {
 	case args.TeamID != "":
-		if !model.IsValidId(args.TeamID) {
-			return "", fmt.Errorf("team_id must be a valid ID")
+		if err := requireID("team_id", args.TeamID); err != nil {
+			return "", err
 		}
 		team, _, err = client.GetTeam(ctx, args.TeamID, "")
 		if err != nil {
@@ -222,8 +222,8 @@ func (p *MattermostToolProvider) toolGetTeamMembers(mcpContext *MCPToolContext, 
 	}
 
 	// Validate required fields
-	if !model.IsValidId(args.TeamID) {
-		return "", fmt.Errorf("team_id must be a valid ID")
+	if err := requireID("team_id", args.TeamID); err != nil {
+		return "", err
 	}
 
 	// Set defaults and validate
@@ -373,11 +373,11 @@ func (p *MattermostToolProvider) toolAddUserToTeam(mcpContext *MCPToolContext, a
 	}
 
 	// Validate required fields
-	if !model.IsValidId(args.UserID) {
-		return "", fmt.Errorf("user_id must be a valid ID")
+	if err := requireID("user_id", args.UserID); err != nil {
+		return "", err
 	}
-	if !model.IsValidId(args.TeamID) {
-		return "", fmt.Errorf("team_id must be a valid ID")
+	if err := requireID("team_id", args.TeamID); err != nil {
+		return "", err
 	}
 
 	// Get client from context

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -40,18 +40,25 @@ type AddUserToTeamArgs struct {
 	TeamID string `json:"team_id" jsonschema:"ID of the team to add user to,minLength=26,maxLength=26"`
 }
 
+// Tool description constants for team-related tools.
+const (
+	getTeamInfoDescription = "Get information about a team. Provide team_id (fastest) or team_name (matches against both display name and URL name, case-insensitive, supports partial matches). Returns team metadata including ID, names, type, description, and member count. Example: {\"team_name\": \"Engineering\"} or {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\"}"
+
+	getTeamMembersDescription = "Get members of a team with pagination support. Parameters: team_id (required), limit (1-200, default 50), page (0+, default 0). Returns user details for each member including username, email, display name, and roles. Example: {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\", \"limit\": 10, \"page\": 0}"
+)
+
 // getTeamTools returns all team-related tools
 func (p *MattermostToolProvider) getTeamTools() []MCPTool {
 	return []MCPTool{
 		{
 			Name:        "get_team_info",
-			Description: "Get information about a team. Provide team_id (fastest) or team_name (matches against both display name and URL name, case-insensitive, supports partial matches). Returns team metadata including ID, names, type, description, and member count. Example: {\"team_name\": \"Engineering\"} or {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\"}",
+			Description: getTeamInfoDescription,
 			Schema:      NewJSONSchemaForAccessMode[GetTeamInfoArgs](string(p.accessMode)),
 			Resolver:    typed("get_team_info", p.toolGetTeamInfo),
 		},
 		{
 			Name:        "get_team_members",
-			Description: "Get members of a team with pagination support. Parameters: team_id (required), limit (1-200, default 50), page (0+, default 0). Returns user details for each member including username, email, display name, and roles. Example: {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\", \"limit\": 10, \"page\": 0}",
+			Description: getTeamMembersDescription,
 			Schema:      NewJSONSchemaForAccessMode[GetTeamMembersArgs](string(p.accessMode)),
 			Resolver:    typed("get_team_members", p.toolGetTeamMembers),
 		},

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -86,9 +86,6 @@ func (p *MattermostToolProvider) toolGetTeamInfo(mcpContext *MCPToolContext, arg
 	}
 
 	// Get client from context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -238,9 +235,6 @@ func (p *MattermostToolProvider) toolGetTeamMembers(mcpContext *MCPToolContext, 
 	}
 
 	// Get client from context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -320,9 +314,6 @@ func (p *MattermostToolProvider) toolCreateTeam(mcpContext *MCPToolContext, args
 	}
 
 	// Get client from context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
@@ -381,9 +372,6 @@ func (p *MattermostToolProvider) toolAddUserToTeam(mcpContext *MCPToolContext, a
 	}
 
 	// Get client from context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -13,7 +13,7 @@ import (
 
 // GetTeamInfoArgs represents arguments for the get_team_info tool
 type GetTeamInfoArgs struct {
-	TeamID   string `json:"team_id,omitempty" jsonschema:"The exact team ID (fastest, most reliable method)"`
+	TeamID   string `json:"team_id,omitempty" jsonschema:"The exact team ID (fastest, most reliable method),maxLength=26"`
 	TeamName string `json:"team_name,omitempty" jsonschema:"Team name to search for — matches against both display name and URL name (case-insensitive, supports partial matches)"`
 }
 
@@ -36,8 +36,8 @@ type CreateTeamArgs struct {
 
 // AddUserToTeamArgs represents arguments for the add_user_to_team tool (dev mode only)
 type AddUserToTeamArgs struct {
-	UserID string `json:"user_id" jsonschema:"ID of the user to add"`
-	TeamID string `json:"team_id" jsonschema:"ID of the team to add user to"`
+	UserID string `json:"user_id" jsonschema:"ID of the user to add,minLength=26,maxLength=26"`
+	TeamID string `json:"team_id" jsonschema:"ID of the team to add user to,minLength=26,maxLength=26"`
 }
 
 // getTeamTools returns all team-related tools

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -82,12 +82,12 @@ func (p *MattermostToolProvider) toolGetTeamInfo(mcpContext *MCPToolContext, arg
 	var args GetTeamInfoArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool get_team_info: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool get_team_info: %w", err)
 	}
 
 	// Get client from context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -97,11 +97,11 @@ func (p *MattermostToolProvider) toolGetTeamInfo(mcpContext *MCPToolContext, arg
 	switch {
 	case args.TeamID != "":
 		if !model.IsValidId(args.TeamID) {
-			return "invalid team_id format", fmt.Errorf("team_id must be a valid ID")
+			return "", fmt.Errorf("team_id must be a valid ID")
 		}
 		team, _, err = client.GetTeam(ctx, args.TeamID, "")
 		if err != nil {
-			return "team not found by ID", fmt.Errorf("error fetching team by ID: %w", err)
+			return "", fmt.Errorf("error fetching team by ID: %w", err)
 		}
 	case args.TeamName != "":
 		var msg string
@@ -114,7 +114,7 @@ func (p *MattermostToolProvider) toolGetTeamInfo(mcpContext *MCPToolContext, arg
 			return msg, nil
 		}
 	default:
-		return "either team_id or team_name must be provided", fmt.Errorf("insufficient parameters for team lookup")
+		return "", fmt.Errorf("insufficient parameters for team lookup")
 	}
 
 	// Get member count
@@ -218,12 +218,12 @@ func (p *MattermostToolProvider) toolGetTeamMembers(mcpContext *MCPToolContext, 
 	var args GetTeamMembersArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool get_team_members: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool get_team_members: %w", err)
 	}
 
 	// Validate required fields
 	if !model.IsValidId(args.TeamID) {
-		return "invalid team_id format", fmt.Errorf("team_id must be a valid ID")
+		return "", fmt.Errorf("team_id must be a valid ID")
 	}
 
 	// Set defaults and validate
@@ -239,7 +239,7 @@ func (p *MattermostToolProvider) toolGetTeamMembers(mcpContext *MCPToolContext, 
 
 	// Get client from context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -250,7 +250,7 @@ func (p *MattermostToolProvider) toolGetTeamMembers(mcpContext *MCPToolContext, 
 	// Get team members
 	members, _, err := client.GetTeamMembers(ctx, args.TeamID, args.Page, args.Limit, "")
 	if err != nil {
-		return "failed to fetch team members", fmt.Errorf("error fetching team members: %w", err)
+		return "", fmt.Errorf("error fetching team members: %w", err)
 	}
 
 	if len(members) == 0 {
@@ -300,28 +300,28 @@ func (p *MattermostToolProvider) toolCreateTeam(mcpContext *MCPToolContext, args
 	var args CreateTeamArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool create_team: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool create_team: %w", err)
 	}
 
 	// Validate required fields
 	if args.Name == "" {
-		return "name is required", fmt.Errorf("name cannot be empty")
+		return "", fmt.Errorf("name cannot be empty")
 	}
 	if args.DisplayName == "" {
-		return "display_name is required", fmt.Errorf("display_name cannot be empty")
+		return "", fmt.Errorf("display_name cannot be empty")
 	}
 	if args.Type == "" {
-		return "type is required", fmt.Errorf("type cannot be empty")
+		return "", fmt.Errorf("type cannot be empty")
 	}
 
 	// Validate team type
 	if args.Type != "O" && args.Type != "I" {
-		return "type must be 'O' for open or 'I' for invite only", fmt.Errorf("invalid team type: %s", args.Type)
+		return "", fmt.Errorf("invalid team type: %s", args.Type)
 	}
 
 	// Get client from context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -336,7 +336,7 @@ func (p *MattermostToolProvider) toolCreateTeam(mcpContext *MCPToolContext, args
 
 	createdTeam, _, err := client.CreateTeam(ctx, team)
 	if err != nil {
-		return "failed to create team", fmt.Errorf("error creating team: %w", err)
+		return "", fmt.Errorf("error creating team: %w", err)
 	}
 
 	var teamIconMessage string
@@ -369,20 +369,20 @@ func (p *MattermostToolProvider) toolAddUserToTeam(mcpContext *MCPToolContext, a
 	var args AddUserToTeamArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool add_user_to_team: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool add_user_to_team: %w", err)
 	}
 
 	// Validate required fields
 	if !model.IsValidId(args.UserID) {
-		return "invalid user_id format", fmt.Errorf("user_id must be a valid ID")
+		return "", fmt.Errorf("user_id must be a valid ID")
 	}
 	if !model.IsValidId(args.TeamID) {
-		return "invalid team_id format", fmt.Errorf("team_id must be a valid ID")
+		return "", fmt.Errorf("team_id must be a valid ID")
 	}
 
 	// Get client from context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -390,7 +390,7 @@ func (p *MattermostToolProvider) toolAddUserToTeam(mcpContext *MCPToolContext, a
 	// Add user to team
 	_, _, err = client.AddTeamMember(ctx, args.TeamID, args.UserID)
 	if err != nil {
-		return "failed to add user to team", fmt.Errorf("error adding user to team: %w", err)
+		return "", fmt.Errorf("error adding user to team: %w", err)
 	}
 
 	// Get user and team info for confirmation

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -99,10 +99,11 @@ func (p *MattermostToolProvider) toolGetTeamInfo(mcpContext *MCPToolContext, arg
 		var msg string
 		team, msg, err = p.resolveTeamByName(mcpContext, args.TeamName)
 		if err != nil {
-			return msg, err
+			return "", err
 		}
 		if msg != "" {
-			// Multiple matches — return disambiguation message (not an error)
+			// No unique match — surface the disambiguation list or the
+			// not-found guidance to the model (not an error).
 			return msg, nil
 		}
 	default:
@@ -132,20 +133,22 @@ func (p *MattermostToolProvider) toolGetTeamInfo(mcpContext *MCPToolContext, arg
 // 3. Substring display name match from user's teams
 // 4. SearchTeams API as final fallback
 //
-// Returns (team, "", nil) on unique match, ("", disambiguationMsg, nil) on multiple matches,
-// or ("", errorMsg, error) on failure.
+// Returns (team, "", nil) on a unique match; (nil, message, nil) when there is no
+// unique match, where message is either a disambiguation list (multiple matches)
+// or recovery guidance (none found) to relay to the model; or (nil, "", error)
+// when a lookup API call fails.
 func (p *MattermostToolProvider) resolveTeamByName(mcpContext *MCPToolContext, name string) (*model.Team, string, error) {
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 
 	user, _, userErr := client.GetMe(ctx, "")
 	if userErr != nil {
-		return nil, "failed to get current user", fmt.Errorf("error getting current user: %w", userErr)
+		return nil, "", fmt.Errorf("error getting current user: %w", userErr)
 	}
 
 	teams, _, teamsErr := client.GetTeamsForUser(ctx, user.Id, "")
 	if teamsErr != nil {
-		return nil, "failed to fetch user teams", fmt.Errorf("error fetching user teams: %w", teamsErr)
+		return nil, "", fmt.Errorf("error fetching user teams: %w", teamsErr)
 	}
 
 	// 1. Exact display name match (case-insensitive)
@@ -187,12 +190,13 @@ func (p *MattermostToolProvider) resolveTeamByName(mcpContext *MCPToolContext, n
 		return nil, formatTeamDisambiguation(name, searchResults), nil
 	}
 
-	// Nothing found — return error with recovery guidance
+	// Nothing found — surface recovery guidance to the model as an informational
+	// result (not an error), so the guidance actually reaches the model.
 	msg := fmt.Sprintf("No team found matching '%s'.", name)
 	msg += "\n\nACTION REQUIRED - Try these alternatives before asking the user:\n"
 	msg += "1. Call get_user_channels to list all channels (includes team info) you have access to\n"
 	msg += "2. Only ask the user for help after trying alternatives above."
-	return nil, msg, fmt.Errorf("no team found matching: %s", name)
+	return nil, msg, nil
 }
 
 // formatTeamDisambiguation builds a message listing multiple team matches for the LLM to choose from.

--- a/mcpserver/tools/teams.go
+++ b/mcpserver/tools/teams.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-plugin-agents/format"
-	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -48,13 +47,13 @@ func (p *MattermostToolProvider) getTeamTools() []MCPTool {
 			Name:        "get_team_info",
 			Description: "Get information about a team. Provide team_id (fastest) or team_name (matches against both display name and URL name, case-insensitive, supports partial matches). Returns team metadata including ID, names, type, description, and member count. Example: {\"team_name\": \"Engineering\"} or {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\"}",
 			Schema:      NewJSONSchemaForAccessMode[GetTeamInfoArgs](string(p.accessMode)),
-			Resolver:    p.toolGetTeamInfo,
+			Resolver:    typed("get_team_info", p.toolGetTeamInfo),
 		},
 		{
 			Name:        "get_team_members",
 			Description: "Get members of a team with pagination support. Parameters: team_id (required), limit (1-200, default 50), page (0+, default 0). Returns user details for each member including username, email, display name, and roles. Example: {\"team_id\": \"w1jkn9ebkiby7qezqfxk7o5ney\", \"limit\": 10, \"page\": 0}",
 			Schema:      NewJSONSchemaForAccessMode[GetTeamMembersArgs](string(p.accessMode)),
-			Resolver:    p.toolGetTeamMembers,
+			Resolver:    typed("get_team_members", p.toolGetTeamMembers),
 		},
 	}
 }
@@ -66,24 +65,20 @@ func (p *MattermostToolProvider) getDevTeamTools() []MCPTool {
 			Name:        "create_team",
 			Description: "Create a new team (dev mode only)",
 			Schema:      NewJSONSchemaForAccessMode[CreateTeamArgs](string(p.accessMode)),
-			Resolver:    p.toolCreateTeam,
+			Resolver:    typed("create_team", p.toolCreateTeam),
 		},
 		{
 			Name:        "add_user_to_team",
 			Description: "Add a user to a team (dev mode only)",
 			Schema:      NewJSONSchemaForAccessMode[AddUserToTeamArgs](string(p.accessMode)),
-			Resolver:    p.toolAddUserToTeam,
+			Resolver:    typed("add_user_to_team", p.toolAddUserToTeam),
 		},
 	}
 }
 
 // toolGetTeamInfo implements the get_team_info tool
-func (p *MattermostToolProvider) toolGetTeamInfo(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args GetTeamInfoArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool get_team_info: %w", err)
-	}
+func (p *MattermostToolProvider) toolGetTeamInfo(mcpContext *MCPToolContext, args GetTeamInfoArgs) (string, error) {
+	var err error
 
 	// Get client from context
 	client := mcpContext.Client
@@ -211,13 +206,7 @@ func formatTeamDisambiguation(searchTerm string, teams []*model.Team) string {
 }
 
 // toolGetTeamMembers implements the get_team_members tool
-func (p *MattermostToolProvider) toolGetTeamMembers(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args GetTeamMembersArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool get_team_members: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolGetTeamMembers(mcpContext *MCPToolContext, args GetTeamMembersArgs) (string, error) {
 	// Validate required fields
 	if err := requireID("team_id", args.TeamID); err != nil {
 		return "", err
@@ -290,13 +279,7 @@ func (p *MattermostToolProvider) toolGetTeamMembers(mcpContext *MCPToolContext, 
 }
 
 // toolCreateTeam implements the create_team tool using the context client
-func (p *MattermostToolProvider) toolCreateTeam(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args CreateTeamArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool create_team: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolCreateTeam(mcpContext *MCPToolContext, args CreateTeamArgs) (string, error) {
 	// Validate required fields
 	if args.Name == "" {
 		return "", fmt.Errorf("name cannot be empty")
@@ -356,13 +339,7 @@ func (p *MattermostToolProvider) toolCreateTeam(mcpContext *MCPToolContext, args
 }
 
 // toolAddUserToTeam implements the add_user_to_team tool using the context client
-func (p *MattermostToolProvider) toolAddUserToTeam(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args AddUserToTeamArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool add_user_to_team: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolAddUserToTeam(mcpContext *MCPToolContext, args AddUserToTeamArgs) (string, error) {
 	// Validate required fields
 	if err := requireID("user_id", args.UserID); err != nil {
 		return "", err
@@ -376,7 +353,7 @@ func (p *MattermostToolProvider) toolAddUserToTeam(mcpContext *MCPToolContext, a
 	ctx := mcpContext.Ctx
 
 	// Add user to team
-	_, _, err = client.AddTeamMember(ctx, args.TeamID, args.UserID)
+	_, _, err := client.AddTeamMember(ctx, args.TeamID, args.UserID)
 	if err != nil {
 		return "", fmt.Errorf("error adding user to team: %w", err)
 	}

--- a/mcpserver/tools/teams_test.go
+++ b/mcpserver/tools/teams_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestTeamLookupServer builds an httptest server stubbing the endpoints
+// resolveTeamByName touches: users/me, the user's teams, and teams/search.
+// userTeams is what GET /api/v4/users/{id}/teams returns; searchStatus and
+// searchResults control POST /api/v4/teams/search.
+func newTestTeamLookupServer(t *testing.T, userTeams []*model.Team, searchStatus int, searchResults []*model.Team) *httptest.Server {
+	t.Helper()
+
+	userID := model.NewId()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v4/users/me", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&model.User{Id: userID, Username: "me"})
+	})
+
+	mux.HandleFunc("/api/v4/users/"+userID+"/teams", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(userTeams)
+	})
+
+	mux.HandleFunc("/api/v4/teams/search", func(w http.ResponseWriter, r *http.Request) {
+		if searchStatus != http.StatusOK {
+			http.Error(w, `{"message":"internal error"}`, searchStatus)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(searchResults)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestGetTeamInfoByName(t *testing.T) {
+	tests := []struct {
+		name          string
+		userTeams     []*model.Team
+		searchStatus  int
+		searchResults []*model.Team
+		teamName      string
+		wantErr       bool
+		wantErrSubstr string
+		wantContains  []string
+	}{
+		{
+			name:          "no match returns guidance, not an error",
+			userTeams:     []*model.Team{},
+			searchStatus:  http.StatusOK,
+			searchResults: []*model.Team{},
+			teamName:      "Nonexistent",
+			wantErr:       false,
+			wantContains:  []string{"No team found matching", "ACTION REQUIRED"},
+		},
+		{
+			name:          "search API failure returns an error",
+			userTeams:     []*model.Team{},
+			searchStatus:  http.StatusInternalServerError,
+			searchResults: nil,
+			teamName:      "Anything",
+			wantErr:       true,
+			wantErrSubstr: "error searching teams",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestTeamLookupServer(t, tt.userTeams, tt.searchStatus, tt.searchResults)
+			defer ts.Close()
+
+			provider := newTestProvider(t, ts.URL)
+			mcpCtx := &MCPToolContext{Ctx: context.Background(), Client: newTestClient(ts.URL)}
+
+			result, err := provider.toolGetTeamInfo(mcpCtx, GetTeamInfoArgs{TeamName: tt.teamName})
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSubstr)
+				return
+			}
+
+			require.NoError(t, err)
+			for _, substr := range tt.wantContains {
+				assert.Contains(t, result, substr)
+			}
+		})
+	}
+}

--- a/mcpserver/tools/users.go
+++ b/mcpserver/tools/users.go
@@ -38,23 +38,23 @@ func (p *MattermostToolProvider) toolCreateUser(mcpContext *MCPToolContext, args
 	var args CreateUserArgs
 	err := argsGetter(&args)
 	if err != nil {
-		return "invalid parameters to function", fmt.Errorf("failed to get arguments for tool create_user: %w", err)
+		return "", fmt.Errorf("failed to get arguments for tool create_user: %w", err)
 	}
 
 	// Validate required fields
 	if args.Username == "" {
-		return "username is required", fmt.Errorf("username cannot be empty")
+		return "", fmt.Errorf("username cannot be empty")
 	}
 	if args.Email == "" {
-		return "email is required", fmt.Errorf("email cannot be empty")
+		return "", fmt.Errorf("email cannot be empty")
 	}
 	if args.Password == "" {
-		return "password is required", fmt.Errorf("password cannot be empty")
+		return "", fmt.Errorf("password cannot be empty")
 	}
 
 	// Get client from context
 	if mcpContext.Client == nil {
-		return "client not available", fmt.Errorf("client not available in context")
+		return "", fmt.Errorf("client not available in context")
 	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
@@ -71,7 +71,7 @@ func (p *MattermostToolProvider) toolCreateUser(mcpContext *MCPToolContext, args
 
 	createdUser, _, err := client.CreateUser(ctx, user)
 	if err != nil {
-		return "failed to create user", fmt.Errorf("error creating user: %w", err)
+		return "", fmt.Errorf("error creating user: %w", err)
 	}
 
 	var profileImageMessage string

--- a/mcpserver/tools/users.go
+++ b/mcpserver/tools/users.go
@@ -6,7 +6,6 @@ package tools
 import (
 	"fmt"
 
-	"github.com/mattermost/mattermost-plugin-agents/llm"
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
@@ -28,19 +27,13 @@ func (p *MattermostToolProvider) getDevUserTools() []MCPTool {
 			Name:        "create_user",
 			Description: "Create a new user account (dev mode only)",
 			Schema:      NewJSONSchemaForAccessMode[CreateUserArgs](string(p.accessMode)),
-			Resolver:    p.toolCreateUser,
+			Resolver:    typed("create_user", p.toolCreateUser),
 		},
 	}
 }
 
 // toolCreateUser implements the create_user tool using the context client
-func (p *MattermostToolProvider) toolCreateUser(mcpContext *MCPToolContext, argsGetter llm.ToolArgumentGetter) (string, error) {
-	var args CreateUserArgs
-	err := argsGetter(&args)
-	if err != nil {
-		return "", fmt.Errorf("failed to get arguments for tool create_user: %w", err)
-	}
-
+func (p *MattermostToolProvider) toolCreateUser(mcpContext *MCPToolContext, args CreateUserArgs) (string, error) {
 	// Validate required fields
 	if args.Username == "" {
 		return "", fmt.Errorf("username cannot be empty")

--- a/mcpserver/tools/users.go
+++ b/mcpserver/tools/users.go
@@ -53,9 +53,6 @@ func (p *MattermostToolProvider) toolCreateUser(mcpContext *MCPToolContext, args
 	}
 
 	// Get client from context
-	if mcpContext.Client == nil {
-		return "", fmt.Errorf("client not available in context")
-	}
 	client := mcpContext.Client
 	ctx := mcpContext.Ctx
 

--- a/mcpserver/tools/validate.go
+++ b/mcpserver/tools/validate.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package tools
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// requireID returns an error when id is not a syntactically valid Mattermost ID.
+// field is the argument name and is embedded in the error so the model can tell
+// which parameter was malformed.
+func requireID(field, id string) error {
+	if !model.IsValidId(id) {
+		return fmt.Errorf("%s must be a valid ID", field)
+	}
+	return nil
+}
+
+// optionalID is like requireID but treats an empty value as valid, for arguments
+// that may be omitted.
+func optionalID(field, id string) error {
+	if id == "" {
+		return nil
+	}
+	return requireID(field, id)
+}


### PR DESCRIPTION
#### Summary

Simplifies the MCP **server** tool code (`mcpserver/tools/`) to cut per-tool boilerplate and make adding the next tool cheap. The package carried a fixed tax that repeated ~25× (arg-decode prologue, dead nil-client guards, a dishonest `(string,error)` return, duplicated attribution/member-listing/HTTP blocks, two schema helpers). This PR removes that tax.

Net **−232 lines** across `mcpserver` (778 insertions / 1010 deletions), but the deletions are concentrated in the repeated boilerplate, so the per-tool cost drops much more.

**Adding a tool now** = an args struct + one registration-table row + a resolver that starts at real logic + a direct struct-based test. The framework owns arg decoding, ID validation, error formatting, the live client, and access-mode schema filtering.

Each commit is an independent, reviewable change:

- **Typed resolver wrapper** — `typed("x", p.toolX)` decodes args centrally; 22 resolvers now start at their real logic instead of a ~10-line prologue.
- **Honest `(string,error)` contract** — failure paths return `"", err`; the ~150 write-only first-return strings are gone, with guidance folded into the errors that reach the model.
- **`requireID`/`optionalID`** — 23 hand-rolled `model.IsValidId` blocks collapse to one-liners.
- **One access-mode-aware schema builder** — every tool routes through it (now filters in place, preserving `$defs`), so `access:` tags are always honored.
- **Removed 23 dead nil-client guards** (unreachable in production).
- **`stampAIGenerated`** dedups the `ai_generated_by` logic across create_post/dm/group_message.
- **`renderMembers`** shares channel + team member-listing rendering.
- **Generic `Available` predicate** replaces the bespoke automation-tool filter middleware (visibility is now data on the tool).
- **`postPluginJSON`** shares HTTP request plumbing across the embedded/external capability services.
- **Descriptions → consts**, **group-table registration**, **standardized ID schema constraints**, and **consolidated test helpers** for readability.

Two latent bugs fixed along the way:
- Automation resolvers used `context.Background()`, dropping request cancellation/tracing — now threaded through.
- `get_team_info` returned its "no team found" recovery guidance as `(msg, err)`, so the guidance never reached the model (the error path discards the message) — now surfaced as an informational result, matching `get_channel_info`.

Verification: full `mcpserver` test suite passes; `go vet` and `gofmt` clean. `golangci-lint` was not run locally (Makefile-pinned tool) — relying on CI `make check-style`.

#### Ticket Link

NONE

#### Screenshots

N/A — backend only, no UI changes.

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool argument handling is now more consistent across posts, channels, teams, files, agents, automations, and search, using structured inputs.
  * Tool availability now respects optional plugin capability during tool listing.

* **Bug Fixes**
  * Improved and more consistent error messages for lookups, searches, file reads, and automation actions.
  * Stricter input validation for various IDs and pagination, with clearer feedback on invalid or missing values.

* **Documentation**
  * Expanded guidance for adding new tools and tool argument conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->