### PR TITLE
Keep thread context on channel tool follow-ups

### DIFF
--- a/conversations/ask_user_question_flow_test.go
+++ b/conversations/ask_user_question_flow_test.go
@@ -338,15 +338,23 @@ func TestStreamToolFollowUpInteractiveFlag(t *testing.T) {
 		rootID := "root-id"
 		conv.RootPostID = &rootID
 
-		rootPost := &model.Post{UserId: "automation-bot"}
+		rootPost := &model.Post{Id: "root-id", UserId: "automation-bot", Message: "automated request"}
 		rootPost.AddProp(ActivateAIProp, true)
+		// A human reply posted to the thread that was never stored as a turn;
+		// the rebuilt request must carry it so the follow-up keeps its context.
+		threadReply := &model.Post{Id: "reply-id", RootId: "root-id", UserId: "human-user", Message: "non-turn thread reply"}
 		mmClient := mocks.NewMockClient(t)
 		mmClient.On("LogDebug", mock.Anything, mock.Anything).Maybe().Return()
 		mmClient.On("GetPost", "root-id").Return(rootPost, nil).Once()
-		mmClient.On("GetUser", "automation-bot").Return(&model.User{Id: "automation-bot", IsBot: true}, nil).Once()
+		mmClient.On("GetUser", "automation-bot").Return(&model.User{Id: "automation-bot", IsBot: true}, nil)
+		mmClient.On("GetUser", "human-user").Return(&model.User{Id: "human-user", Username: "human"}, nil)
 		mmClient.On("GetConfig").Maybe().Return(&model.Config{})
-		// Channel follow-ups rebuild thread context via GetThreadData.
-		mmClient.On("GetPostThread", "root-id").Return(&model.PostList{Posts: map[string]*model.Post{}, Order: []string{}}, nil).Once()
+		// Channel follow-ups rebuild thread context via GetThreadData; return a
+		// live thread with a non-turn reply to exercise the thread-aware path.
+		mmClient.On("GetPostThread", "root-id").Return(&model.PostList{
+			Order: []string{"root-id", "reply-id"},
+			Posts: map[string]*model.Post{"root-id": rootPost, "reply-id": threadReply},
+		}, nil).Once()
 
 		lm := &loadedStateLLM{}
 		streamingService := &loadedStateStreamingService{}
@@ -372,6 +380,13 @@ func TestStreamToolFollowUpInteractiveFlag(t *testing.T) {
 		streamingService.waitForStreaming()
 		require.Len(t, lm.requests, 1)
 		assert.False(t, lm.requests[0].Context.ToolCatalog.InteractiveUserPresent)
+
+		var threadContext string
+		for _, p := range lm.requests[0].Posts {
+			threadContext += p.Message + "\n"
+		}
+		assert.Contains(t, threadContext, "non-turn thread reply",
+			"channel follow-up must rebuild live thread context for non-turn posts")
 	})
 }
 

--- a/conversations/ask_user_question_flow_test.go
+++ b/conversations/ask_user_question_flow_test.go
@@ -345,6 +345,8 @@ func TestStreamToolFollowUpInteractiveFlag(t *testing.T) {
 		mmClient.On("GetPost", "root-id").Return(rootPost, nil).Once()
 		mmClient.On("GetUser", "automation-bot").Return(&model.User{Id: "automation-bot", IsBot: true}, nil).Once()
 		mmClient.On("GetConfig").Maybe().Return(&model.Config{})
+		// Channel follow-ups rebuild thread context via GetThreadData.
+		mmClient.On("GetPostThread", "root-id").Return(&model.PostList{Posts: map[string]*model.Post{}, Order: []string{}}, nil).Once()
 
 		lm := &loadedStateLLM{}
 		streamingService := &loadedStateStreamingService{}

--- a/conversations/tool_approval.go
+++ b/conversations/tool_approval.go
@@ -537,7 +537,8 @@ func (c *Conversations) streamToolFollowUp(
 		c.applyBotChannelAutoEverywhereToolFilter(llmContext)
 	}
 
-	completionReq, err := c.convService.BuildCompletionRequest(conv, llmContext)
+	// Channel thread posts aren't stored as turns, so rebuild with thread context.
+	completionReq, err := c.buildToolFollowUpRequest(conv, llmContext, isDM)
 	if err != nil {
 		return fmt.Errorf("failed to build completion request for tool follow-up: %w", err)
 	}
@@ -571,6 +572,20 @@ func (c *Conversations) streamToolFollowUp(
 	}
 
 	return nil
+}
+
+// buildToolFollowUpRequest rebuilds the completion request for a tool follow-up.
+// Channel conversations re-fetch the live thread so non-turn thread posts stay in
+// context (matching the initial mention); DMs persist every post as a turn.
+func (c *Conversations) buildToolFollowUpRequest(conv *store.Conversation, llmContext *llm.Context, isDM bool) (*llm.CompletionRequest, error) {
+	if !isDM && conv.RootPostID != nil {
+		threadData, err := mmapi.GetThreadData(c.mmClient, *conv.RootPostID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get thread data for tool follow-up: %w", err)
+		}
+		return c.convService.BuildChannelMentionRequest(conv, llmContext, threadData)
+	}
+	return c.convService.BuildCompletionRequest(conv, llmContext)
 }
 
 func resolveApprovedToolUseBlock(ctx context.Context, llmContext *llm.Context, block conversation.ContentBlock) (string, error) {

--- a/conversations/tool_approval.go
+++ b/conversations/tool_approval.go
@@ -579,9 +579,14 @@ func (c *Conversations) streamToolFollowUp(
 // context (matching the initial mention); DMs persist every post as a turn.
 func (c *Conversations) buildToolFollowUpRequest(conv *store.Conversation, llmContext *llm.Context, isDM bool) (*llm.CompletionRequest, error) {
 	if !isDM && conv.RootPostID != nil {
+		// Best-effort: if the live thread can't be fetched (deleted root,
+		// permissions, API blip), degrade to turns-only context rather than
+		// failing the resume. BuildChannelMentionRequest does the same on
+		// empty thread data.
 		threadData, err := mmapi.GetThreadData(c.mmClient, *conv.RootPostID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get thread data for tool follow-up: %w", err)
+			c.mmClient.LogWarn("Failed to get thread data for tool follow-up, falling back to turns-only context", "error", err)
+			return c.convService.BuildCompletionRequest(conv, llmContext)
 		}
 		return c.convService.BuildChannelMentionRequest(conv, llmContext, threadData)
 	}


### PR DESCRIPTION
#### Summary
In a channel/thread conversation, the agent could lose thread context after a paused-and-resumed run — for example after answering an `AskUserQuestion` card or a tool approval — and respond with "I don't have access to the thread context."

**Cause:** The tool follow-up path (`streamToolFollowUp`) rebuilt the completion request from stored conversation turns only (`BuildCompletionRequest`). In channel conversations, surrounding thread posts (including the root post) are never stored as turns — they're injected at request-build time by `BuildChannelMentionRequest`. So when a run paused and resumed, that thread context was dropped.

**Fix:** Channel tool follow-ups now route through the same thread-aware builder as the initial @mention path. `buildToolFollowUpRequest` re-fetches the live thread via `mmapi.GetThreadData` and uses `BuildChannelMentionRequest` for channel conversations. DMs are unchanged and stay turns-only, since every DM post is already a stored turn.

The request-builder asymmetry was introduced in #602 when conversation history moved to first-class turn storage. It became more noticeable once the `AskUserQuestion` tool (#826) was added, since that tool always forces an in-thread pause-and-resume follow-up.

**Backport:** This likely needs a backport to ESR 2.0+ versions of the Agents plugin.

#### Ticket Link
NONE

#### Test Plan
- `go build ./...` passes.
- `go test ./conversations/...` passes.
- Manually verified the agent retains thread context through an `AskUserQuestion` follow-up and reaches the tool call.

#### Release Note
```release-note
Fixed an issue where the agent could lose thread context after a paused/resumed run in a channel (e.g. after answering an AskUserQuestion card or a tool approval).
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved follow-up replies in channel conversations by ensuring responses use up-to-date thread context, including relevant non-turn thread replies.
  * Fixed an issue where interactive follow-up flows could miss required conversation context and not proceed correctly.
* **Tests**
  * Updated follow-up flow test coverage to validate the reconstructed thread context and interactive-user behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->