### PR TITLE
Cherry-pick #862 to release-2.4: Keep thread context on channel tool follow-ups

### DIFF
--- a/conversations/tool_approval.go
+++ b/conversations/tool_approval.go
@@ -425,7 +425,8 @@ func (c *Conversations) streamToolFollowUp(
 		c.applyBotChannelAutoEverywhereToolFilter(llmContext)
 	}
 
-	completionReq, err := c.convService.BuildCompletionRequest(conv, llmContext)
+	// Channel thread posts aren't stored as turns, so rebuild with thread context.
+	completionReq, err := c.buildToolFollowUpRequest(conv, llmContext, isDM)
 	if err != nil {
 		return fmt.Errorf("failed to build completion request for tool follow-up: %w", err)
 	}
@@ -459,6 +460,25 @@ func (c *Conversations) streamToolFollowUp(
 	}
 
 	return nil
+}
+
+// buildToolFollowUpRequest rebuilds the completion request for a tool follow-up.
+// Channel conversations re-fetch the live thread so non-turn thread posts stay in
+// context (matching the initial mention); DMs persist every post as a turn.
+func (c *Conversations) buildToolFollowUpRequest(conv *store.Conversation, llmContext *llm.Context, isDM bool) (*llm.CompletionRequest, error) {
+	if !isDM && conv.RootPostID != nil {
+		// Best-effort: if the live thread can't be fetched (deleted root,
+		// permissions, API blip), degrade to turns-only context rather than
+		// failing the resume. BuildChannelMentionRequest does the same on
+		// empty thread data.
+		threadData, err := mmapi.GetThreadData(c.mmClient, *conv.RootPostID)
+		if err != nil {
+			c.mmClient.LogWarn("Failed to get thread data for tool follow-up, falling back to turns-only context", "error", err)
+			return c.convService.BuildCompletionRequest(conv, llmContext)
+		}
+		return c.convService.BuildChannelMentionRequest(conv, llmContext, threadData)
+	}
+	return c.convService.BuildCompletionRequest(conv, llmContext)
 }
 
 func resolveApprovedToolUseBlock(ctx context.Context, llmContext *llm.Context, block conversation.ContentBlock) (string, error) {


### PR DESCRIPTION
#### Summary

Cherry-pick of #862 (merged to `master`) onto `release-2.4`.

In a channel/thread conversation, the agent could lose thread context after a paused-and-resumed run — for example after a tool approval — and respond with "I don't have access to the thread context."

The tool follow-up path rebuilt the completion request from stored conversation turns only. In channel conversations, surrounding thread posts (including the root post) are never stored as turns — they're injected at request-build time by `BuildChannelMentionRequest`. Channel tool follow-ups now route through the same thread-aware builder as the initial @mention path.

**Cherry-pick notes:**
- Dropped `conversations/ask_user_question_flow_test.go` because `AskUserQuestion` is not on `release-2.4`.
- `conversations/tool_approval.go` applied cleanly.

#### Ticket Link
NONE

#### Test Plan
- [x] `go test ./conversations/...` passes on `release-2.4`.
- [ ] Manually verify the agent retains thread context through a channel tool-approval follow-up.

#### Release Note
```release-note
Fixed an issue where the agent could lose thread context after a paused/resumed run in a channel (e.g. after a tool approval).
```

Made with [Cursor](https://cursor.com)