### PR TITLE
Show service type and model in bot "Powered by" description

### DIFF
--- a/bots/bots.go
+++ b/bots/bots.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"slices"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/assets"
 	"github.com/mattermost/mattermost-plugin-agents/v2/bifrost"
@@ -686,9 +687,15 @@ func (b *MMBots) GetAllBotUserIDs() []string {
 }
 
 // poweredByDescription builds the Mattermost bot description shown in the UI.
-func poweredByDescription(serviceType, model string) string {
-	if model == "" {
-		return "Powered by " + serviceType
+func poweredByDescription(serviceType, modelName string) string {
+	var description string
+	if modelName == "" {
+		description = "Powered by " + serviceType
+	} else {
+		description = "Powered by " + serviceType + " - " + modelName
 	}
-	return "Powered by " + serviceType + " - " + model
+	if utf8.RuneCountInString(description) > model.BotDescriptionMaxRunes {
+		return string([]rune(description)[:model.BotDescriptionMaxRunes])
+	}
+	return description
 }

--- a/bots/bots.go
+++ b/bots/bots.go
@@ -361,7 +361,7 @@ func (b *MMBots) EnsureBots() error {
 	// For each bot in the configuration, try to find an existing bot matching the username.
 	// If it exists, update it to match. Otherwise, create a new bot.
 	for _, bot := range bots {
-		description := "Powered by " + bot.service.Type
+		description := poweredByDescription(bot.service.Type, bot.service.DefaultModel)
 		if prevBot, ok := prevousMMBotsByUsername[bot.cfg.Name]; ok {
 			var err error
 			bot.mmBot, err = b.pluginAPI.Bot.Patch(prevBot.UserId, &model.BotPatch{
@@ -683,4 +683,12 @@ func (b *MMBots) GetAllBotUserIDs() []string {
 		}
 	}
 	return ids
+}
+
+// poweredByDescription builds the Mattermost bot description shown in the UI.
+func poweredByDescription(serviceType, model string) string {
+	if model == "" {
+		return "Powered by " + serviceType
+	}
+	return "Powered by " + serviceType + " - " + model
 }

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -785,7 +785,7 @@ func TestEnsureBots(t *testing.T) {
 			if tc.numCreatedBots > 0 {
 				mockAPI.On("CreateBot", mock.AnythingOfType("*model.Bot")).Return(func(bot *model.Bot) *model.Bot {
 					if len(tc.cfgServices) > 0 && tc.cfgServices[0].DefaultModel != "" {
-						assert.Equal(t, poweredByDescription(string(tc.cfgServices[0].Type), tc.cfgServices[0].DefaultModel), bot.Description)
+						assert.Equal(t, poweredByDescription(tc.cfgServices[0].Type, tc.cfgServices[0].DefaultModel), bot.Description)
 					}
 					return bot
 				}, nil).Times(tc.numCreatedBots)

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -784,8 +784,21 @@ func TestEnsureBots(t *testing.T) {
 			mockAPI.On("GetBots", mock.AnythingOfType("*model.BotGetOptions")).Return([]*model.Bot{}, nil).Maybe()
 			if tc.numCreatedBots > 0 {
 				mockAPI.On("CreateBot", mock.AnythingOfType("*model.Bot")).Return(func(bot *model.Bot) *model.Bot {
-					if len(tc.cfgServices) > 0 && tc.cfgServices[0].DefaultModel != "" {
-						assert.Equal(t, poweredByDescription(tc.cfgServices[0].Type, tc.cfgServices[0].DefaultModel), bot.Description)
+					for _, botCfg := range tc.cfgBots {
+						if botCfg.Name != bot.Username {
+							continue
+						}
+						for _, svc := range tc.cfgServices {
+							if svc.ID != botCfg.ServiceID {
+								continue
+							}
+							model := botCfg.Model
+							if model == "" {
+								model = svc.DefaultModel
+							}
+							assert.Equal(t, poweredByDescription(svc.Type, model), bot.Description)
+							return bot
+						}
 					}
 					return bot
 				}, nil).Times(tc.numCreatedBots)

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -684,9 +684,10 @@ func TestEnsureBots(t *testing.T) {
 			},
 			cfgServices: []llm.ServiceConfig{
 				{
-					ID:     "service1",
-					Type:   llm.ServiceTypeOpenAI,
-					APIKey: "test-api-key",
+					ID:           "service1",
+					Type:         llm.ServiceTypeOpenAI,
+					APIKey:       "test-api-key",
+					DefaultModel: "gpt-4o",
 				},
 			},
 			isMultiLLMLicensed: false,
@@ -783,6 +784,9 @@ func TestEnsureBots(t *testing.T) {
 			mockAPI.On("GetBots", mock.AnythingOfType("*model.BotGetOptions")).Return([]*model.Bot{}, nil).Maybe()
 			if tc.numCreatedBots > 0 {
 				mockAPI.On("CreateBot", mock.AnythingOfType("*model.Bot")).Return(func(bot *model.Bot) *model.Bot {
+					if len(tc.cfgServices) > 0 && tc.cfgServices[0].DefaultModel != "" {
+						assert.Equal(t, poweredByDescription(string(tc.cfgServices[0].Type), tc.cfgServices[0].DefaultModel), bot.Description)
+					}
 					return bot
 				}, nil).Times(tc.numCreatedBots)
 				mockAPI.On("GetUser", mock.AnythingOfType("string")).Return(&model.User{LastPictureUpdate: 0}, nil).Times(tc.numCreatedBots)
@@ -1078,4 +1082,38 @@ func TestHasNativeWebSearchEnabledSupportedServiceType(t *testing.T) {
 		nil,
 	)
 	require.True(t, b.HasNativeWebSearchEnabled())
+}
+
+func TestPoweredByDescription(t *testing.T) {
+	tests := []struct {
+		name        string
+		serviceType string
+		model       string
+		want        string
+	}{
+		{
+			name:        "service type and model",
+			serviceType: "openai",
+			model:       "gpt-4o",
+			want:        "Powered by openai - gpt-4o",
+		},
+		{
+			name:        "service type only when model empty",
+			serviceType: "anthropic",
+			model:       "",
+			want:        "Powered by anthropic",
+		},
+		{
+			name:        "azure with deployment model",
+			serviceType: "azure",
+			model:       "gpt-4",
+			want:        "Powered by azure - gpt-4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, poweredByDescription(tt.serviceType, tt.model))
+		})
+	}
 }

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/enterprise"
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
@@ -1098,6 +1099,9 @@ func TestHasNativeWebSearchEnabledSupportedServiceType(t *testing.T) {
 }
 
 func TestPoweredByDescription(t *testing.T) {
+	prefix := "Powered by openai - "
+	longModel := strings.Repeat("m", model.BotDescriptionMaxRunes)
+
 	tests := []struct {
 		name        string
 		serviceType string
@@ -1122,11 +1126,19 @@ func TestPoweredByDescription(t *testing.T) {
 			model:       "gpt-4",
 			want:        "Powered by azure - gpt-4",
 		},
+		{
+			name:        "truncates to Mattermost bot description limit",
+			serviceType: "openai",
+			model:       longModel,
+			want:        string([]rune(prefix + longModel)[:model.BotDescriptionMaxRunes]),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, poweredByDescription(tt.serviceType, tt.model))
+			got := poweredByDescription(tt.serviceType, tt.model)
+			assert.Equal(t, tt.want, got)
+			assert.LessOrEqual(t, utf8.RuneCountInString(got), model.BotDescriptionMaxRunes)
 		})
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Agent bot descriptions previously showed only the service type (e.g. `Powered by openai`). They now include the effective model as well: `Powered by <service type> - <model>` (e.g. `Powered by openai - gpt-4o`).

The model used is the bot's model override when set, otherwise the service default model. If no model is configured, the description falls back to `Powered by <service type>`.

**Test steps**
1. Configure an agent with a service that has a default model (or set a model override on the agent).
2. Save / ensure bots refresh.
3. Open the agent bot profile (or bot description) and confirm it shows `Powered by <service type> - <model>`.

#### Screenshots

| before | after |
|----|----|
| `Powered by openai` | `Powered by openai - gpt-4o` |

[Demo Agent profile showing Powered by openai - gpt-4o](https://cursor.com/agents/bc-f712f1ec-9767-4ab5-a201-0052c74e38d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpowered-by-openai-gpt-4o-profile.webp)

Demo video (login → DM with demoagent → profile popover):

[powered-by-service-model-demo.mp4](https://cursor.com/agents/bc-f712f1ec-9767-4ab5-a201-0052c74e38d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpowered-by-service-model-demo.mp4)

Also uploaded:
- [powered-by-service-model-demo.mp4](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/cursor/powered-by-service-model-38d6/powered-by-service-model-demo.mp4)
- ![powered-by-openai-gpt-4o-profile.webp](https://cursor-plugin-pr-assets.s3.amazonaws.com/cursor/cursor/powered-by-service-model-38d6/powered-by-openai-gpt-4o-profile.webp)

#### Release Note
```release-note
Changed agent bot descriptions to show "Powered by <service type> - <model>" instead of only the service type.
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f712f1ec-9767-4ab5-a201-0052c74e38d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f712f1ec-9767-4ab5-a201-0052c74e38d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bot descriptions now include the configured AI model (when available), making it easier to identify which model powers each bot.
  * Descriptions continue to show only the service type when no model is configured.
  * Descriptions are automatically truncated to the maximum supported length to ensure they display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->