### PR TITLE
Include service name and model in agent "Powered by" description

### DIFF
--- a/bots/bots.go
+++ b/bots/bots.go
@@ -438,6 +438,12 @@ func botDescription(service llm.ServiceConfig) string {
 	if service.DefaultModel != "" {
 		description += " (" + service.DefaultModel + ")"
 	}
+	// Nothing bounds service names or model identifiers in config, but
+	// Mattermost rejects bot descriptions longer than BotDescriptionMaxRunes.
+	// Truncate so CreateBot/PatchBot can't fail on an oversized description.
+	if runes := []rune(description); len(runes) > model.BotDescriptionMaxRunes {
+		description = string(runes[:model.BotDescriptionMaxRunes-1]) + "…"
+	}
 	return description
 }
 

--- a/bots/bots.go
+++ b/bots/bots.go
@@ -361,7 +361,7 @@ func (b *MMBots) EnsureBots() error {
 	// For each bot in the configuration, try to find an existing bot matching the username.
 	// If it exists, update it to match. Otherwise, create a new bot.
 	for _, bot := range bots {
-		description := "Powered by " + bot.service.Type
+		description := botDescription(bot.service)
 		if prevBot, ok := prevousMMBotsByUsername[bot.cfg.Name]; ok {
 			var err error
 			bot.mmBot, err = b.pluginAPI.Bot.Patch(prevBot.UserId, &model.BotPatch{
@@ -422,6 +422,23 @@ func (b *MMBots) EnsureBots() error {
 	b.botsLock.Unlock()
 
 	return nil
+}
+
+// botDescription builds the bot user's description shown in the user popover,
+// e.g. "Powered by My OpenAI (gpt-4o)". The service's Name falls back to its
+// Type when the admin left the name empty (same convention as the admin UI).
+// The service passed in is the bot's resolved copy, so DefaultModel already
+// reflects a per-agent model override when one is set.
+func botDescription(service llm.ServiceConfig) string {
+	name := service.Name
+	if name == "" {
+		name = service.Type
+	}
+	description := "Powered by " + name
+	if service.DefaultModel != "" {
+		description += " (" + service.DefaultModel + ")"
+	}
+	return description
 }
 
 func (b *MMBots) ensureDefaultProfileImage(bot *Bot) {

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -817,6 +817,100 @@ func TestEnsureBots(t *testing.T) {
 	}
 }
 
+func TestBotDescription(t *testing.T) {
+	testCases := []struct {
+		name     string
+		service  llm.ServiceConfig
+		expected string
+	}{
+		{
+			name: "service name and model",
+			service: llm.ServiceConfig{
+				Name:         "My OpenAI",
+				Type:         llm.ServiceTypeOpenAI,
+				DefaultModel: "gpt-4o",
+			},
+			expected: "Powered by My OpenAI (gpt-4o)",
+		},
+		{
+			name: "empty service name falls back to type",
+			service: llm.ServiceConfig{
+				Type:         llm.ServiceTypeAnthropic,
+				DefaultModel: "claude-sonnet-4-20250514",
+			},
+			expected: "Powered by anthropic (claude-sonnet-4-20250514)",
+		},
+		{
+			name: "no model omits the parenthetical",
+			service: llm.ServiceConfig{
+				Name: "My Azure",
+				Type: llm.ServiceTypeAzure,
+			},
+			expected: "Powered by My Azure",
+		},
+		{
+			name:     "empty name and no model",
+			service:  llm.ServiceConfig{Type: llm.ServiceTypeOpenAI},
+			expected: "Powered by openai",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, botDescription(tc.service))
+		})
+	}
+}
+
+// TestEnsureBotsDescriptionUsesBotModelOverride pins that the bot description
+// reflects the per-agent model override, not the service's default model.
+func TestEnsureBotsDescriptionUsesBotModelOverride(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	client := pluginapi.NewClient(mockAPI, nil)
+
+	mockAPI.On("GetConfig").Return(&model.Config{}).Maybe()
+	mockAPI.On("GetLicense").Return((*model.License)(nil)).Maybe()
+	mockAPI.On("GetBots", mock.AnythingOfType("*model.BotGetOptions")).Return([]*model.Bot{}, nil).Maybe()
+
+	var createdDescription string
+	mockAPI.On("CreateBot", mock.AnythingOfType("*model.Bot")).Return(func(bot *model.Bot) *model.Bot {
+		createdDescription = bot.Description
+		return bot
+	}, nil).Once()
+	mockAPI.On("GetUser", mock.AnythingOfType("string")).Return(&model.User{LastPictureUpdate: 0}, nil).Maybe()
+	mockAPI.On("SetProfileImage", mock.AnythingOfType("string"), mock.AnythingOfType("[]uint8")).Return(nil).Maybe()
+	mockAPI.On("KVSetWithOptions", mock.AnythingOfType("string"), mock.AnythingOfType("[]uint8"), mock.AnythingOfType("model.PluginKVSetOptions")).Return(true, nil).Maybe()
+	mockAPI.On("KVDelete", mock.AnythingOfType("string")).Return(nil).Maybe()
+	mockAPI.On("LogError", mock.Anything).Return(nil).Maybe()
+
+	cfg := &mockConfig{
+		bots: []llm.BotConfig{
+			{
+				ID:          "bot1",
+				Name:        "testbot1",
+				DisplayName: "Test Bot 1",
+				ServiceID:   "svc1",
+				Model:       "gpt-4o-mini",
+			},
+		},
+		services: []llm.ServiceConfig{
+			{
+				ID:           "svc1",
+				Name:         "My OpenAI",
+				Type:         llm.ServiceTypeOpenAI,
+				APIKey:       "key",
+				DefaultModel: "gpt-4o",
+			},
+		},
+	}
+	mmBots := New(mockAPI, client, enterprise.NewLicenseChecker(client), cfg, nil, &http.Client{}, nil)
+
+	defer mockAPI.AssertExpectations(t)
+
+	require.NoError(t, mmBots.EnsureBots())
+	require.Equal(t, "Powered by My OpenAI (gpt-4o-mini)", createdDescription)
+}
+
 // stubAgentStore returns a fixed slice. Tests can swap the slice between
 // EnsureBots calls to mimic a config save changing the DB-backed agent.
 type stubAgentStore struct {

--- a/bots/bots_test.go
+++ b/bots/bots_test.go
@@ -853,6 +853,15 @@ func TestBotDescription(t *testing.T) {
 			service:  llm.ServiceConfig{Type: llm.ServiceTypeOpenAI},
 			expected: "Powered by openai",
 		},
+		{
+			name: "oversized description is truncated to the bot description limit",
+			service: llm.ServiceConfig{
+				Name:         strings.Repeat("n", model.BotDescriptionMaxRunes),
+				Type:         llm.ServiceTypeOpenAI,
+				DefaultModel: "gpt-4o",
+			},
+			expected: "Powered by " + strings.Repeat("n", model.BotDescriptionMaxRunes-12) + "…",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
The agent bot description shown in the user popover previously read `Powered by <service type>` (e.g. "Powered by openai"). It now shows the configured service name and the model the agent actually uses, e.g. `Powered by OpenAI (gpt-4o)`.

Details:
- The service name falls back to the service type when the admin left the name empty, matching the existing webapp convention (`service.name || service.type`).
- The model in the description reflects a per-agent model override when one is set; otherwise the service's default model is used. When no model is configured, the parenthetical is omitted.

QA test steps:
1. Configure a service with a name (e.g. "OpenAI") and a default model.
2. Create an agent using that service, optionally with a model override.
3. Open a DM with the agent and click its name/avatar to open the user popover; the description should read `Powered by OpenAI (<model>)`.

#### Ticket Link
NONE

#### Screenshots

|  before  |  after  |
|----|----|
| [before-powered-by.mp4](https://cursor.com/agents/bc-6b06bd59-ac3c-4d7e-96f8-dbaf1b0981f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore-powered-by.mp4) | [after-powered-by.mp4](https://cursor.com/agents/bc-6b06bd59-ac3c-4d7e-96f8-dbaf1b0981f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter-powered-by.mp4) |

#### Release Note
```release-note
The agent bot description ("Powered by ...") now shows the configured service name and the model used by that agent instead of only the service type.
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b06bd59-ac3c-4d7e-96f8-dbaf1b0981f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b06bd59-ac3c-4d7e-96f8-dbaf1b0981f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Bot descriptions now display the service name and selected model when available.
  * Descriptions fall back to the service type when no service name is provided.
  * Per-bot model overrides are accurately reflected in bot descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->