### PR TITLE
Add UnixMillisUTC helper for Mattermost millis timestamps

### DIFF
--- a/format/time.go
+++ b/format/time.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package format
+
+import "time"
+
+// UnixMillisUTC formats a Mattermost millisecond timestamp as UTC RFC3339.
+func UnixMillisUTC(ms int64) string {
+	return time.Unix(ms/1000, (ms%1000)*int64(time.Millisecond)).UTC().Format(time.RFC3339)
+}


### PR DESCRIPTION
#### Summary
Add `format.UnixMillisUTC` to centralize Mattermost millisecond timestamp → UTC RFC3339 formatting.

This is the bottom layer of a 3-PR stack testing `gh stack`.

#### Ticket Link
N/A — `gh stack` smoke test / small DRY cleanup.

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for converting Unix timestamps in milliseconds into UTC-formatted date and time strings.
  - Results use the standard RFC3339 format for consistent display and interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->