### PR TITLE
[MM-69856] Safely parse short Zoom chat lines during summarization

### DIFF
--- a/meetings/meeting_summarization.go
+++ b/meetings/meeting_summarization.go
@@ -157,6 +157,11 @@ func (s *Service) newCallTranscriptionSummaryThread(bot *bots.Bot, requestingUse
 				s.pluginAPI.Log.Error("Error in call recording post", "error", reterr)
 			}
 		}()
+		defer func() {
+			if r := recover(); r != nil {
+				reterr = fmt.Errorf("panic summarizing transcription: %v", r)
+			}
+		}()
 
 		transcriptionFileID, err := GetCaptionsFileIDFromProps(transcriptionPost)
 		if err != nil {
@@ -239,6 +244,11 @@ func (s *Service) summarizeCallRecording(bot *bots.Bot, rootID string, requestin
 					s.pluginAPI.Log.Error("Failed to update post in error handling handleCallRecordingPost", "error", err)
 				}
 				s.pluginAPI.Log.Error("Error in call recording post", "error", reterr)
+			}
+		}()
+		defer func() {
+			if r := recover(); r != nil {
+				reterr = fmt.Errorf("panic summarizing call recording: %v", r)
 			}
 		}()
 

--- a/subtitles/subtitles.go
+++ b/subtitles/subtitles.go
@@ -23,6 +23,10 @@ func readZoomChat(chat io.Reader) (*astisub.Subtitles, error) {
 	scanner := bufio.NewScanner(chat)
 	for scanner.Scan() {
 		line := scanner.Text()
+		// Zoom chat lines are "HH:MM:SS <text>". Continuation/short lines lack a timestamp.
+		if len(line) < 9 {
+			continue
+		}
 		text := line[9:]
 		item := &astisub.Item{}
 		startAt, err := time.Parse("15:04:05", line[:8])

--- a/subtitles/subtitles_test.go
+++ b/subtitles/subtitles_test.go
@@ -53,3 +53,65 @@ func TestFormatTextOnly(t *testing.T) {
 
 	require.Equal(t, expectedFormatTextOnly, subtitles.FormatTextOnly())
 }
+
+func TestNewSubtitlesFromZoomChat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		input           string
+		wantLLM         string
+		wantEmpty       bool
+		wantErrContains string
+	}{
+		{
+			name: "valid zoom chat lines",
+			input: `00:00:01 Alice: Hello everyone
+00:00:05 Bob: Hi Alice`,
+			wantLLM: "00:01 to 00:06 - Alice: Hello everyone\n00:05 to 00:10 - Bob: Hi Alice",
+		},
+		{
+			name: "short continuation lines are skipped",
+			input: `00:00:01 Alice: Hello
+x
+00:00:05 Bob: Hi
+ab`,
+			wantLLM: "00:01 to 00:06 - Alice: Hello\n00:05 to 00:10 - Bob: Hi",
+		},
+		{
+			name:      "only short lines yields empty subtitles",
+			input:     "x\nab\n",
+			wantEmpty: true,
+		},
+		{
+			name:            "invalid timestamp returns error",
+			input:           "not-time More text here",
+			wantErrContains: "parsing time",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var subs *Subtitles
+			var err error
+			require.NotPanics(t, func() {
+				subs, err = NewSubtitlesFromZoomChat(strings.NewReader(tc.input))
+			})
+
+			if tc.wantErrContains != "" {
+				require.ErrorContains(t, err, tc.wantErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, subs)
+			if tc.wantEmpty {
+				require.True(t, subs.IsEmpty())
+				return
+			}
+			require.Equal(t, tc.wantLLM, subs.FormatForLLM())
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
Hardens Zoom chat transcription parsing used during meeting summarization so short/continuation lines are skipped instead of causing a plugin failure. Also recovers from unexpected panics in the background summarization goroutines and surfaces a user-facing error.

Regression tests added for valid Zoom chat input and short-line handling; verified they fail when the length guard is reverted and pass with the fix restored.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69856

#### Release Note
```release-note
Fixed Agents plugin failure when summarizing certain Zoom chat transcriptions containing short continuation lines.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting summarization reliability by safely handling unexpected failures and displaying an appropriate error message.
  * Improved Zoom chat subtitle processing by skipping short lines without timestamps, preventing parsing errors while preserving valid timestamps.

* **Tests**
  * Added coverage for valid, invalid, empty, and continuation-line Zoom chat subtitle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->