### PR TITLE
Mark auto-executing tool calls with would_auto_execute to prevent approval UI race

### DIFF
--- a/conversation/approval_state_test.go
+++ b/conversation/approval_state_test.go
@@ -51,6 +51,17 @@ func TestComputePostApprovalState(t *testing.T) {
 			want: ApprovalStageCall,
 		},
 		{
+			name:   "post with only pending auto-execute tool_use returns call",
+			postID: "p1",
+			turns: []store.Turn{
+				{Role: "user", Sequence: 1, Content: blockJSON(t, nil)},
+				{Role: "assistant", Sequence: 2, PostID: postPtr("p1"), Content: blockJSON(t, []ContentBlock{
+					{Type: BlockTypeToolUse, ID: "tc1", Name: "x", Status: StatusPending, WouldAutoExecute: true},
+				})},
+			},
+			want: ApprovalStageCall,
+		},
+		{
 			name:   "executed tool with undecided tool_result returns result",
 			postID: "p1",
 			turns: []store.Turn{

--- a/conversation/content_block.go
+++ b/conversation/content_block.go
@@ -53,9 +53,8 @@ type ContentBlock struct {
 	// UserInteraction is the persisted form of llm.Tool.UserInteraction.
 	UserInteraction string `json:"user_interaction,omitempty"`
 
-	// WouldAutoExecute marks a pending tool_use block that passed the
-	// auto-execution policy but was paused with the rest of its batch.
-	// Display-only (see llm.ToolCall.WouldAutoExecute).
+	// WouldAutoExecute marks any pending tool_use block that passed the
+	// auto-execution policy (see llm.ToolCall.WouldAutoExecute).
 	WouldAutoExecute bool `json:"would_auto_execute,omitempty"`
 
 	// DecidedAt (tool_result blocks) records when the share/keep-private

--- a/conversations/ask_user_question_flow_test.go
+++ b/conversations/ask_user_question_flow_test.go
@@ -393,17 +393,17 @@ func TestStreamToolFollowUpInteractiveFlag(t *testing.T) {
 }
 
 // TestHandleToolCallAutoExecutesPolicyEligiblePendingTools pins the deferred
-// auto-execution contract: a tool paused only because its batch contained a
-// question runs server-side when the user answers — without being in
-// accepted_tool_ids — based on a fresh policy check, with its result terminal
-// and shared like any auto-run round. A policy disabled since the pause must
-// fall back to rejection.
+// auto-execution contract: marked tools run server-side without appearing in
+// accepted_tool_ids, including when an interrupted all-auto batch is resumed
+// with an empty list. A policy disabled since the pause must fall back to
+// rejection.
 func TestHandleToolCallAutoExecutesPolicyEligiblePendingTools(t *testing.T) {
 	const origin = "https://jira.example.com"
 
 	cases := []struct {
 		name             string
 		wouldAutoExecute bool
+		includeQuestion  bool
 		policyChecker    mapPolicyChecker
 		wantToolStatus   string
 		wantToolResult   string
@@ -411,8 +411,31 @@ func TestHandleToolCallAutoExecutesPolicyEligiblePendingTools(t *testing.T) {
 		wantFollowUp     bool
 	}{
 		{
+			name:             "interrupted all-auto batch resumes with empty accepted list",
+			wouldAutoExecute: true,
+			policyChecker: mapPolicyChecker{
+				origin: {"get_issue": {policy: mcp.ToolPolicyAutoRunEverywhere, enabled: true}},
+			},
+			wantToolStatus: conversation.StatusAutoApproved,
+			wantToolResult: "restored-result",
+			wantToolShared: true,
+			wantFollowUp:   true,
+		},
+		{
+			name:             "interrupted all-auto resume rejects when policy was disabled",
+			wouldAutoExecute: true,
+			policyChecker: mapPolicyChecker{
+				origin: {"get_issue": {policy: mcp.ToolPolicyAutoRunEverywhere, enabled: false}},
+			},
+			wantToolStatus: conversation.StatusRejected,
+			wantToolResult: "Tool call rejected by user",
+			wantToolShared: false,
+			wantFollowUp:   false, // nothing executed, so nothing to follow up on
+		},
+		{
 			name:             "auto_run_everywhere policy executes on resume",
 			wouldAutoExecute: true,
+			includeQuestion:  true,
 			policyChecker: mapPolicyChecker{
 				origin: {"get_issue": {policy: mcp.ToolPolicyAutoRunEverywhere, enabled: true}},
 			},
@@ -424,6 +447,7 @@ func TestHandleToolCallAutoExecutesPolicyEligiblePendingTools(t *testing.T) {
 		{
 			name:             "policy disabled since the pause rejects instead",
 			wouldAutoExecute: true,
+			includeQuestion:  true,
 			policyChecker: mapPolicyChecker{
 				origin: {"get_issue": {policy: mcp.ToolPolicyAutoRunEverywhere, enabled: false}},
 			},
@@ -435,6 +459,7 @@ func TestHandleToolCallAutoExecutesPolicyEligiblePendingTools(t *testing.T) {
 		{
 			name:             "unmarked tool does not auto-run even if policy flipped to auto",
 			wouldAutoExecute: false,
+			includeQuestion:  true,
 			policyChecker: mapPolicyChecker{
 				origin: {"get_issue": {policy: mcp.ToolPolicyAutoRunEverywhere, enabled: true}},
 			},
@@ -451,17 +476,17 @@ func TestHandleToolCallAutoExecutesPolicyEligiblePendingTools(t *testing.T) {
 			nextSeq := 1
 			seedLoadToolPair(t, convStore, conv.ID, "load-1", "jira__get_issue", &nextSeq)
 
-			blocks := []conversation.ContentBlock{
-				{
-					Type:             conversation.BlockTypeToolUse,
-					ID:               "tool-use-1",
-					Name:             "jira__get_issue",
-					Input:            json.RawMessage(`{}`),
-					Status:           conversation.StatusPending,
-					Shared:           conversation.BoolPtr(false),
-					WouldAutoExecute: tc.wouldAutoExecute,
-				},
-				{
+			blocks := []conversation.ContentBlock{{
+				Type:             conversation.BlockTypeToolUse,
+				ID:               "tool-use-1",
+				Name:             "jira__get_issue",
+				Input:            json.RawMessage(`{}`),
+				Status:           conversation.StatusPending,
+				Shared:           conversation.BoolPtr(false),
+				WouldAutoExecute: tc.wouldAutoExecute,
+			}}
+			if tc.includeQuestion {
+				blocks = append(blocks, conversation.ContentBlock{
 					Type: conversation.BlockTypeToolUse,
 					ID:   "q-1",
 					Name: "AskUserQuestion",
@@ -472,7 +497,7 @@ func TestHandleToolCallAutoExecutesPolicyEligiblePendingTools(t *testing.T) {
 					Status:          conversation.StatusPending,
 					UserInteraction: llm.UserInteractionSelect,
 					Shared:          conversation.BoolPtr(false),
-				},
+				})
 			}
 			content, err := json.Marshal(blocks)
 			require.NoError(t, err)
@@ -513,10 +538,15 @@ func TestHandleToolCallAutoExecutesPolicyEligiblePendingTools(t *testing.T) {
 			approvalPost.AddProp(streaming.ConversationIDProp, conv.ID)
 			channel := &model.Channel{Id: "channel-id", TeamId: "team-id", Type: model.ChannelTypeOpen}
 
-			// Only the question is in accepted_tool_ids: the paused tool is
-			// hidden in the UI and must be resolved by policy, not by click.
-			answers := map[string]mmtools.UserInteractionAnswer{"q-1": {Selected: []string{"UX Design"}}}
-			require.NoError(t, c.HandleToolCall(context.Background(), "user-id", approvalPost, channel, []string{"q-1"}, answers))
+			acceptedIDs := []string{}
+			var answers map[string]mmtools.UserInteractionAnswer
+			if tc.includeQuestion {
+				// Only the question is accepted: the marked tool must be
+				// resolved by policy, not by the user's selection.
+				acceptedIDs = []string{"q-1"}
+				answers = map[string]mmtools.UserInteractionAnswer{"q-1": {Selected: []string{"UX Design"}}}
+			}
+			require.NoError(t, c.HandleToolCall(context.Background(), "user-id", approvalPost, channel, acceptedIDs, answers))
 			streamingService.waitForStreaming()
 
 			turns, err := convStore.GetTurnsForConversation(conv.ID)
@@ -528,16 +558,20 @@ func TestHandleToolCallAutoExecutesPolicyEligiblePendingTools(t *testing.T) {
 			assert.Equal(t, tc.wantToolStatus, updatedBlocks[0].Status)
 			require.NotNil(t, updatedBlocks[0].Shared)
 			assert.Equal(t, tc.wantToolShared, *updatedBlocks[0].Shared)
-			assert.Equal(t, conversation.StatusSuccess, updatedBlocks[1].Status)
+			if tc.includeQuestion {
+				assert.Equal(t, conversation.StatusSuccess, updatedBlocks[1].Status)
+			}
 
 			var resultBlocks []conversation.ContentBlock
 			require.NoError(t, json.Unmarshal(turns[3].Content, &resultBlocks))
-			require.Len(t, resultBlocks, 2)
+			require.Len(t, resultBlocks, len(blocks))
 			assert.Equal(t, tc.wantToolResult, resultBlocks[0].Content)
 			require.NotNil(t, resultBlocks[0].Shared)
 			assert.Equal(t, tc.wantToolShared, *resultBlocks[0].Shared)
 			assert.NotNil(t, resultBlocks[0].DecidedAt, "auto/rejected results are terminal")
-			assert.NotNil(t, resultBlocks[1].DecidedAt, "answer result is terminal")
+			if tc.includeQuestion {
+				assert.NotNil(t, resultBlocks[1].DecidedAt, "answer result is terminal")
+			}
 
 			if tc.wantFollowUp {
 				assert.Len(t, lm.requests, 1, "expected a follow-up LLM request")

--- a/llm/tools.go
+++ b/llm/tools.go
@@ -253,9 +253,8 @@ type ToolCall struct {
 	// the matching interaction UI (e.g. a question card) for pending calls.
 	UserInteraction string `json:"user_interaction,omitempty"`
 
-	// WouldAutoExecute marks a pending call that passed the auto-execution
-	// policy but was paused because another call in the batch needs the user.
-	// Display-only: the webapp hides the approval UI for it, and the server
+	// WouldAutoExecute marks any pending call that passed the auto-execution
+	// policy. The webapp must not show approval controls for it; the server
 	// re-checks the policy before executing it on resume.
 	WouldAutoExecute bool `json:"would_auto_execute,omitempty"`
 

--- a/toolrunner/toolrunner.go
+++ b/toolrunner/toolrunner.go
@@ -308,7 +308,13 @@ func (r *ToolRunner) runLoop(
 			return
 		}
 
-		// Forward pending tool calls so the UI can show spinners.
+		// All calls passed the policy: stamp them so the pending broadcast
+		// (and, if the stream is interrupted mid-execution, the persisted
+		// blocks) carry the auto-execute signal instead of implying an
+		// approval request, then forward so the UI can show spinners.
+		for i := range toolCalls {
+			toolCalls[i].WouldAutoExecute = true
+		}
 		output <- llm.TextStreamEvent{Type: llm.EventTypeToolCalls, Value: toolCalls}
 
 		// Execute each tool call.

--- a/toolrunner/toolrunner_extended_test.go
+++ b/toolrunner/toolrunner_extended_test.go
@@ -569,6 +569,60 @@ func TestExecuteToolsDefensiveUnloadedGuard(t *testing.T) {
 	assert.Contains(t, results[0].Result, `load_tool`)
 }
 
+// TestToolRunner_AllApprovedMarksOnlyPendingCallsWouldAutoExecute pins that an
+// all-approved batch stamps WouldAutoExecute on the pending broadcast only;
+// the resolved broadcast and the persisted tool turns drop the flag once
+// execution completes.
+func TestToolRunner_AllApprovedMarksOnlyPendingCallsWouldAutoExecute(t *testing.T) {
+	inner := &testLLM{
+		responses: []testResponse{
+			{events: []llm.TextStreamEvent{
+				{Type: llm.EventTypeToolCalls, Value: []llm.ToolCall{
+					{ID: "tc1", Name: "tool_a", Arguments: json.RawMessage(`{}`)},
+					{ID: "tc2", Name: "tool_b", Arguments: json.RawMessage(`{}`)},
+				}},
+				{Type: llm.EventTypeEnd},
+			}},
+			{events: []llm.TextStreamEvent{
+				{Type: llm.EventTypeText, Value: "done"},
+				{Type: llm.EventTypeEnd},
+			}},
+		},
+	}
+
+	store := newTestToolStore(
+		testToolDef{name: "tool_a", result: "result_a"},
+		testToolDef{name: "tool_b", result: "result_b"},
+	)
+	result, err := New(inner).Run(context.Background(), llm.CompletionRequest{
+		Posts:   []llm.Post{{Role: llm.PostRoleUser, Message: "go"}},
+		Context: &llm.Context{Tools: store},
+	}, alwaysExecute, nil)
+	require.NoError(t, err)
+
+	var toolCallEvents [][]llm.ToolCall
+	for event := range result.Stream.Stream {
+		if event.Type == llm.EventTypeToolCalls {
+			toolCallEvents = append(toolCallEvents, event.Value.([]llm.ToolCall))
+		}
+	}
+
+	require.Len(t, toolCallEvents, 2)
+	for _, call := range toolCallEvents[0] {
+		assert.Equal(t, llm.ToolCallStatusPending, call.Status)
+		assert.True(t, call.WouldAutoExecute)
+	}
+	for _, call := range toolCallEvents[1] {
+		assert.Equal(t, llm.ToolCallStatusAutoApproved, call.Status)
+		assert.False(t, call.WouldAutoExecute)
+	}
+
+	require.Len(t, result.ToolTurns, 1)
+	for _, call := range result.ToolTurns[0].AssistantToolCalls {
+		assert.False(t, call.WouldAutoExecute)
+	}
+}
+
 // TestToolRunner_PausedBatchMarksWouldAutoExecute pins that a paused mixed
 // batch tags the policy-passing calls (and only those) so the UI can hide
 // their approval controls, while still executing nothing in the batch.

--- a/webapp/src/components/tool_approval_set.test.tsx
+++ b/webapp/src/components/tool_approval_set.test.tsx
@@ -2,11 +2,24 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import {render} from '@testing-library/react';
+import {fireEvent, render, waitFor} from '@testing-library/react';
 import {IntlProvider} from 'react-intl';
 
 import ToolApprovalSet from './tool_approval_set';
 import {ToolApprovalStage, ToolCall, ToolCallStatus} from './tool_types';
+
+const mockDoToolCall = jest.fn();
+const mockInvalidateConversation = jest.fn();
+
+jest.mock('@/client', () => ({
+    doToolCall: (postID: string, toolIDs: string[], toolAnswers: Record<string, unknown>) =>
+        mockDoToolCall(postID, toolIDs, toolAnswers),
+    doToolResult: jest.fn(),
+}));
+
+jest.mock('@/hooks/use_conversation', () => ({
+    invalidateConversation: (conversationID: string) => mockInvalidateConversation(conversationID),
+}));
 
 type MockToolCardProps = {
     tool: ToolCall;
@@ -34,7 +47,7 @@ function makeTool(overrides: Partial<ToolCall>): ToolCall {
     };
 }
 
-function renderComponent(toolCalls: ToolCall[], approvalStage: ToolApprovalStage = 'call') {
+function renderComponent(toolCalls: ToolCall[], approvalStage: ToolApprovalStage = 'call', canApprove = true) {
     return render(
         <IntlProvider locale='en'>
             <ToolApprovalSet
@@ -42,7 +55,7 @@ function renderComponent(toolCalls: ToolCall[], approvalStage: ToolApprovalStage
                 conversationID='conv_1'
                 toolCalls={toolCalls}
                 approvalStage={approvalStage}
-                canApprove={true}
+                canApprove={canApprove}
                 canExpand={true}
                 showArguments={true}
                 showResults={true}
@@ -59,6 +72,9 @@ function getToolCardProps(toolID: string): MockToolCardProps {
 
 beforeEach(() => {
     mockToolCard.mockClear();
+    mockDoToolCall.mockReset();
+    mockDoToolCall.mockImplementation(() => Promise.resolve());
+    mockInvalidateConversation.mockClear();
 });
 
 describe('ToolApprovalSet', () => {
@@ -98,6 +114,42 @@ describe('ToolApprovalSet', () => {
         const manualTool = getToolCardProps('tool_manual');
         expect(manualTool.onApprove).toEqual(expect.any(Function));
         expect(manualTool.onReject).toEqual(expect.any(Function));
+    });
+
+    test('renders live pending auto-executing tools without decision controls', () => {
+        renderComponent([
+            makeTool({id: 'tool_auto', would_auto_execute: true}),
+        ], 'done');
+
+        const autoTool = getToolCardProps('tool_auto');
+        expect(autoTool.onApprove).toBeUndefined();
+        expect(autoTool.onReject).toBeUndefined();
+    });
+
+    test('resumes an interrupted all-auto round with an empty accepted list', async () => {
+        const {getByRole} = renderComponent([
+            makeTool({id: 'tool_auto_a', would_auto_execute: true}),
+            makeTool({id: 'tool_auto_b', would_auto_execute: true}),
+        ]);
+
+        expect(getToolCardProps('tool_auto_a').onApprove).toBeUndefined();
+        expect(getToolCardProps('tool_auto_b').onReject).toBeUndefined();
+
+        fireEvent.click(getByRole('button', {name: 'Run tools'}));
+
+        await waitFor(() => {
+            expect(mockDoToolCall).toHaveBeenCalledWith('post_1', [], {});
+        });
+        expect(mockInvalidateConversation).toHaveBeenCalledWith('conv_1');
+    });
+
+    test('does not offer resume to non-owners', () => {
+        const {queryByRole} = renderComponent([
+            makeTool({id: 'tool_auto', would_auto_execute: true}),
+        ], 'call', false);
+
+        expect(getToolCardProps('tool_auto').onApprove).toBeUndefined();
+        expect(queryByRole('button', {name: 'Run tools'})).toBeNull();
     });
 
     test('excludes already-decided results from share decisions', () => {

--- a/webapp/src/components/tool_approval_set.tsx
+++ b/webapp/src/components/tool_approval_set.tsx
@@ -93,6 +93,12 @@ const ToolApprovalSet: React.FC<ToolApprovalSetProps> = (props) => {
 
     const isCallStage = props.approvalStage === 'call';
     const isResultStage = props.approvalStage === 'result';
+    const pendingToolCalls = useMemo(() => {
+        return props.toolCalls.filter((call) => call.status === ToolCallStatus.Pending);
+    }, [props.toolCalls]);
+    const isInterruptedAutoRound = isCallStage &&
+        pendingToolCalls.length > 0 &&
+        pendingToolCalls.every((call) => call.would_auto_execute);
 
     // Approval is per pending tool. Earlier auto-approved tools in the same
     // response should not suppress controls for later manual ones.
@@ -303,11 +309,13 @@ const ToolApprovalSet: React.FC<ToolApprovalSetProps> = (props) => {
             {props.toolCalls.map((tool) => {
                 const isDecisionCall = decisionToolIDSet.has(tool.id);
 
-                // Paused-but-auto-approved calls run server-side once the
-                // user resolves the rest of the batch; showing them pending
-                // would look like they need approval. They reappear as
-                // normal auto-approved cards once executed.
-                if (tool.status === ToolCallStatus.Pending && tool.would_auto_execute) {
+                // In a mixed approval batch, policy-approved calls stay
+                // hidden until the user's decisions let the server run them.
+                // Live calls and interrupted all-auto rounds remain visible.
+                if (tool.status === ToolCallStatus.Pending &&
+                    tool.would_auto_execute &&
+                    isCallStage &&
+                    !isInterruptedAutoRound) {
                     return null;
                 }
 
@@ -337,7 +345,7 @@ const ToolApprovalSet: React.FC<ToolApprovalSetProps> = (props) => {
                         postID={props.postID}
                         tool={tool}
                         isCollapsed={isToolCollapsed(tool)}
-                        isProcessing={isDecisionCall && isSubmitting}
+                        isProcessing={(isDecisionCall || isInterruptedAutoRound) && isSubmitting}
                         localDecision={isDecisionCall ? toolDecisions[tool.id] : undefined} // eslint-disable-line no-undefined
                         onToggleCollapse={() => toggleCollapse(tool.id)}
                         onApprove={isDecisionCall ? () => handleToolDecision(tool.id, true) : undefined} // eslint-disable-line no-undefined
@@ -392,6 +400,29 @@ const ToolApprovalSet: React.FC<ToolApprovalSetProps> = (props) => {
                             />
                         </BatchButton>
                     </BatchButtonContainer>
+                </StatusBar>
+            )}
+
+            {isInterruptedAutoRound && effectiveCanApprove && (
+                <StatusBar>
+                    {isSubmitting ? (
+                        <div>
+                            <FormattedMessage
+                                id='ai.tool_call.submitting'
+                                defaultMessage='Submitting...'
+                            />
+                        </div>
+                    ) : (
+                        <BatchButton
+                            type='button'
+                            onClick={() => submitDecisions([])}
+                        >
+                            <FormattedMessage
+                                id='ai.tool_call.run_tools'
+                                defaultMessage='Run tools'
+                            />
+                        </BatchButton>
+                    )}
                 </StatusBar>
             )}
         </ToolCallsContainer>

--- a/webapp/src/components/tool_card.test.tsx
+++ b/webapp/src/components/tool_card.test.tsx
@@ -7,7 +7,7 @@ import {IntlProvider} from 'react-intl';
 import {useSelector} from 'react-redux';
 
 import ToolCard from './tool_card';
-import {ToolCall, ToolCallStatus} from './tool_types';
+import {ToolApprovalStage, ToolCall, ToolCallStatus} from './tool_types';
 
 jest.mock('react-redux', () => ({
     useSelector: jest.fn(),
@@ -32,7 +32,14 @@ function makeTool(overrides: Partial<ToolCall> = {}): ToolCall {
     };
 }
 
-function renderComponent(tool: ToolCall) {
+function renderComponent(
+    tool: ToolCall,
+    decisionProps: {
+        onApprove?: () => void;
+        onReject?: () => void;
+        approvalStage?: ToolApprovalStage;
+    } = {},
+) {
     return render(
         <IntlProvider locale='en'>
             <ToolCard
@@ -44,6 +51,7 @@ function renderComponent(tool: ToolCall) {
                 canExpand={false}
                 showArguments={true}
                 showResults={false}
+                {...decisionProps}
             />
         </IntlProvider>,
     );
@@ -90,5 +98,32 @@ describe('ToolCard argument rendering', () => {
         expect(screen.queryByText(/No parameters required/)).toBeNull();
         expect(formatTextMock).not.toHaveBeenCalled();
         expect(messageHtmlToComponentMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('ToolCard pending state', () => {
+    test('shows a spinner without buttons for a live auto-executing tool', () => {
+        const {container} = renderComponent(
+            makeTool({would_auto_execute: true}),
+            {approvalStage: 'done'},
+        );
+
+        expect(container.querySelector('svg')).not.toBeNull();
+        expect(screen.queryByRole('button', {name: 'Accept'})).toBeNull();
+        expect(screen.queryByRole('button', {name: 'Reject'})).toBeNull();
+    });
+
+    test('never shows accept or reject for a policy-approved pending tool', () => {
+        renderComponent(
+            makeTool({would_auto_execute: true}),
+            {
+                approvalStage: 'call',
+                onApprove: jest.fn(),
+                onReject: jest.fn(),
+            },
+        );
+
+        expect(screen.queryByRole('button', {name: 'Accept'})).toBeNull();
+        expect(screen.queryByRole('button', {name: 'Reject'})).toBeNull();
     });
 });

--- a/webapp/src/components/tool_card.tsx
+++ b/webapp/src/components/tool_card.tsx
@@ -356,9 +356,11 @@ const ToolCard: React.FC<ToolCardProps> = ({
     const isSuccess = tool.status === ToolCallStatus.Success || tool.status === ToolCallStatus.AutoApproved;
     const isError = tool.status === ToolCallStatus.Error;
     const isRejected = tool.status === ToolCallStatus.Rejected;
-    const showDecisionButtons = Boolean(onApprove && onReject);
-    const showProcessingSpinner = isProcessing || isPending || isAccepted;
     const isResultApprovalStage = approvalStage === 'result';
+    const showDecisionButtons = Boolean(onApprove && onReject) &&
+        (isResultApprovalStage ||
+            (approvalStage === 'call' && isPending && !tool.would_auto_execute));
+    const showProcessingSpinner = isProcessing || isPending || isAccepted;
     const showResultReviewCallout = !isCollapsed && showDecisionButtons && isResultApprovalStage;
 
     // Tool-call cards lack server context, so strip the pluginmcp prefix

--- a/webapp/src/components/tool_types.ts
+++ b/webapp/src/components/tool_types.ts
@@ -42,9 +42,9 @@ export interface ToolCall {
     // server (e.g. AskUserQuestion). See UserInteractionSelect.
     user_interaction?: string;
 
-    // True for a pending call that passed the auto-execution policy but was
-    // paused with its batch. It runs server-side once the user resolves the
-    // rest, so no approval UI should render for it.
+    // True for a pending call that passed the auto-execution policy. The call
+    // may be running live or paused in a persisted round, but never needs an
+    // individual approval decision.
     would_auto_execute?: boolean;
 
     // True when the matching tool result has already received its terminal

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -302,6 +302,7 @@
   "ai.tool_call.reject_all": "Reject all",
   "ai.tool_call.response": "Response",
   "ai.tool_call.review_tool_response": "Review tool response",
+  "ai.tool_call.run_tools": "Run tools",
   "ai.tool_call.share": "Share",
   "ai.tool_call.status.accepted": "Accepted",
   "ai.tool_call.status.rejected": "Rejected",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

The pending tool-call payload broadcast while auto-approved tools execute was indistinguishable from a payload awaiting user approval, and a stream interrupted mid auto-execution persisted those tools as plain `pending`. On refetch the turn computed `approval_state: 'call'` and the webapp rendered Accept/Reject buttons for tools the auto-execution policy (`shouldAutoExecuteTool`) had already decided to auto-run — clicking them raced with server-side resolution.

This change makes "passed the auto-execution policy" an affirmative wire signal and gates the approval UI on its absence:

**Server**
- `toolrunner`: the all-approved path now stamps `WouldAutoExecute: true` on every pending tool call before the pending broadcast, so both the live payload and interrupted-stream persistence carry the signal. Resolved calls never carry it (`buildResolvedToolCalls` builds fresh structs).
- Broadened `WouldAutoExecute` doc comments in `llm/tools.go` and `conversation/content_block.go`; previously the flag only marked policy-passing calls paused in a mixed batch.
- Verified (and pinned with tests) that `HandleToolCall` with empty `accepted_tool_ids` resumes an interrupted all-auto round: marked tools re-check policy and auto-execute rather than being rejected; a policy disabled since the pause still rejects.

**Webapp**
- Accept/Reject now requires `approval_state === 'call' && status === pending && !would_auto_execute` (or result stage) — buttons never render for policy-approved tools.
- Live rounds: pending `would_auto_execute` tools render as non-interactive spinner cards (previously the flag hid cards entirely, which would have removed execution visibility with the new server behavior).
- Mixed `'call'`-stage batches: policy-approved siblings stay hidden until the user resolves the rest, unchanged.
- Interrupted all-auto rounds (`'call'` stage, every pending tool flagged): cards render non-interactively with an owner-only "Run tools" button that posts an empty accepted list to resume, instead of leaving an invisible dead end.

QA steps:
1. Configure an MCP tool with an auto-run policy; trigger it in a DM — the tool card shows only a spinner (no Accept/Reject) while executing, then flips to Auto-approved.
2. Trigger a batch mixing auto-run and ask tools — ask tools show buttons, auto siblings stay hidden until resolution.
3. Stop generation while auto tools are executing, reload — cards show with a "Run tools" button instead of Accept/Reject; clicking it executes the tools and continues the response.

Notes for reviewers: two pre-existing behaviors are intentionally unchanged — a policy flipped from auto to ask between pause and resume rejects the tool on "Run tools" (matches documented mixed-batch resume semantics), and non-owners viewing an interrupted round see non-interactive cards only (parity with approval controls).

`make check` passes (lint, 3,701 Go + 271 webapp unit tests, shard coverage, i18n/lockfile drift).

#### Release Note

```release-note
Fixed the tool approval UI briefly offering Accept/Reject for tool calls that were configured to run automatically, which could race with server-side auto-execution. Interrupted auto-run tool rounds now show a "Run tools" option instead of approval buttons.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed367864-b0fc-45f3-a148-cc700fa3e8ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed367864-b0fc-45f3-a148-cc700fa3e8ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for tools approved for automatic execution.
  * Added a **“Run tools”** option to resume interrupted automatic tool runs.
* **Bug Fixes**
  * Approval controls are now hidden for tools that do not require individual approval.
  * Improved tool status and processing indicators during interrupted or resumed runs.
  * Prevented resume controls from appearing when the viewer cannot approve actions.
* **Tests**
  * Expanded coverage for automatic execution, interrupted runs, approval visibility, and resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->