### PR TITLE
Enable Anthropic automatic prompt caching

### DIFF
--- a/bifrost/bifrost.go
+++ b/bifrost/bifrost.go
@@ -1198,6 +1198,9 @@ func (b *LLM) convertToBifrostRequest(request llm.CompletionRequest, cfg llm.Lan
 	if cfg.JSONOutputFormat != nil {
 		params.ResponseFormat = buildChatResponseFormat(cfg.JSONOutputFormat)
 	}
+	if b.promptCachingEnabled() {
+		params.CacheControl = &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
+	}
 	req.Params = params
 
 	// Attach fallback chain so Bifrost retries with alternative providers on failure.
@@ -1608,6 +1611,27 @@ func (b *LLM) shouldUseResponsesAPI(cfg llm.LanguageModelConfig) bool {
 	return false
 }
 
+// promptCachingEnabled reports whether to request Anthropic automatic prompt
+// caching (top-level cache_control). Anthropic caches nothing unless asked,
+// so without this every turn re-bills the full system prompt, tool schemas,
+// and history at the base input rate. OpenAI-family and Gemini cache prompt
+// prefixes automatically and need no marker. Bifrost forwards the field
+// unstripped to non-Anthropic providers, so it is only attached when the
+// primary and every fallback are Anthropic; a mixed chain would 400 the
+// fallback request.
+func (b *LLM) promptCachingEnabled() bool {
+	if b.provider != schemas.Anthropic {
+		return false
+	}
+	for _, fb := range b.fallbacks {
+		if fb.Provider != schemas.Anthropic &&
+			!strings.HasPrefix(string(fb.Provider), string(schemas.Anthropic)+"::") {
+			return false
+		}
+	}
+	return true
+}
+
 // isNativeToolEnabled checks if a native tool is enabled by name.
 func (b *LLM) isNativeToolEnabled(name string) bool {
 	for _, t := range b.enabledNativeTools {
@@ -1897,6 +1921,13 @@ func (b *LLM) convertToBifrostResponsesRequest(request llm.CompletionRequest, cf
 			return nil, fmt.Errorf("failed to build responses text config: %w", err)
 		}
 		params.Text = textConfig
+	}
+	// The Anthropic provider reads cache_control from ExtraParams on the
+	// Responses path (there is no typed field on ResponsesParameters).
+	if b.promptCachingEnabled() {
+		params.ExtraParams = map[string]interface{}{
+			"cache_control": &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+		}
 	}
 	req.Params = params
 

--- a/bifrost/bifrost_test.go
+++ b/bifrost/bifrost_test.go
@@ -336,6 +336,89 @@ func TestConvertToBifrostRequestOpus47Reasoning(t *testing.T) {
 		"Opus 4.7 does not accept budget_tokens alongside adaptive thinking")
 }
 
+// TestPromptCaching verifies that automatic prompt caching (top-level
+// cache_control) is requested for Anthropic and reaches the Anthropic wire
+// request, but is never attached for other providers or for Anthropic with
+// non-Anthropic fallbacks (where the marker would 400 the fallback request).
+func TestPromptCaching(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  schemas.ModelProvider
+		fallbacks []schemas.Fallback
+		want      bool
+	}{
+		{
+			name:     "anthropic without fallbacks",
+			provider: schemas.Anthropic,
+			want:     true,
+		},
+		{
+			name:      "anthropic with anthropic custom-provider fallback",
+			provider:  schemas.Anthropic,
+			fallbacks: []schemas.Fallback{{Provider: customProviderName(schemas.Anthropic, "svc2")}},
+			want:      true,
+		},
+		{
+			name:      "anthropic with openai fallback",
+			provider:  schemas.Anthropic,
+			fallbacks: []schemas.Fallback{{Provider: schemas.OpenAI}},
+			want:      false,
+		},
+		{
+			name:     "openai",
+			provider: schemas.OpenAI,
+			want:     false,
+		},
+		{
+			name:     "bedrock",
+			provider: schemas.Bedrock,
+			want:     false,
+		},
+	}
+
+	request := llm.CompletionRequest{
+		Posts: []llm.Post{
+			{Role: llm.PostRoleSystem, Message: "system prompt"},
+			{Role: llm.PostRoleUser, Message: "hello"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &LLM{provider: tt.provider, fallbacks: tt.fallbacks}
+			cfg := llm.LanguageModelConfig{Model: "test-model", MaxGeneratedTokens: 100}
+
+			chatReq := b.convertToBifrostRequest(request, cfg)
+			respReq, err := b.convertToBifrostResponsesRequest(request, cfg)
+			require.NoError(t, err)
+
+			if !tt.want {
+				assert.Nil(t, chatReq.Params.CacheControl)
+				assert.NotContains(t, respReq.Params.ExtraParams, "cache_control")
+				return
+			}
+
+			require.NotNil(t, chatReq.Params.CacheControl)
+			assert.Equal(t, schemas.CacheControlTypeEphemeral, chatReq.Params.CacheControl.Type)
+			require.Contains(t, respReq.Params.ExtraParams, "cache_control")
+
+			// Feed both requests through bifrost's Anthropic converters to
+			// confirm the marker survives onto the wire request.
+			ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+			defer cancel()
+			wireChat, err := anthropic.ToAnthropicChatRequest(ctx, chatReq)
+			require.NoError(t, err)
+			require.NotNil(t, wireChat.CacheControl)
+			assert.Equal(t, schemas.CacheControlTypeEphemeral, wireChat.CacheControl.Type)
+
+			wireResponses, err := anthropic.ToAnthropicResponsesRequest(ctx, respReq)
+			require.NoError(t, err)
+			require.NotNil(t, wireResponses.CacheControl)
+			assert.Equal(t, schemas.CacheControlTypeEphemeral, wireResponses.CacheControl.Type)
+		})
+	}
+}
+
 func TestBuildResponsesReasoning(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Anthropic bills the full prompt (system prompt, tool schemas, and conversation history) at the base input rate on every turn unless the request opts into prompt caching — unlike OpenAI/Azure/Gemini, which cache prompt prefixes automatically. This PR attaches Anthropic's top-level `cache_control: {"type": "ephemeral"}` (automatic prompt caching) to every request sent to Anthropic, on both the Chat Completions and Responses API paths. Anthropic then places the cache breakpoint on the last cacheable block and moves it forward automatically as the conversation grows; no breakpoint management is needed.

The marker is only attached when the primary provider and every configured fallback are Anthropic. Bifrost v1.5.18 forwards the top-level `cache_control` field unstripped to non-Anthropic providers, so a mixed fallback chain would 400 the fallback request.

Measured against the live Anthropic API with `claude-haiku-4-5` through the plugin's `bifrost.LLM` (5.5k-token system prompt + tools, 2-turn conversation, both request paths):

```
turn 1 usage: in=5467 cache_write=5464 cache_read=0    out=189
turn 2 usage: in=5673 cache_write=206  cache_read=5464 out=200
```

Cache reads are billed at 0.1x the base input rate (writes at 1.25x). On a 3-turn baseline comparison, the same conversation cost **46% less in dollar terms** overall (51% on the input side; output tokens are unaffected). Per-turn input cost approaches ~88-90% savings once the prefix is cached, so savings grow with conversation length and tool-call rounds since the whole history is re-sent each round. Cached token counts already flow into structured logs and OTel span attributes (`agents.llm.cached_read_tokens` / `cached_write_tokens`), so the effect is observable in existing telemetry.

Notes:
- Caching requires a byte-identical prefix and a model-dependent minimum cacheable length (e.g. 4,096 tokens for Haiku 4.5); shorter prompts are silently processed uncached, with no error.
- Default cache TTL is 5 minutes, refreshed on each hit.
- Bedrock/Vertex Claude are not covered; Bifrost v1.5.18 does not translate the top-level marker for them.

#### Release Note

```release-note
Enabled Anthropic automatic prompt caching. Requests to Anthropic services now reuse the cached system prompt, tool definitions, and conversation prefix across turns, reducing input token costs (cache reads are billed at 0.1x the base input rate).
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f04472d5-dca7-4db9-a7a9-11135fe8fa6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f04472d5-dca7-4db9-a7a9-11135fe8fa6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic prompt caching for Anthropic requests using ephemeral cache controls.
  * Prompt caching now works across both Chat Completions and Responses requests.
  * Caching is enabled only for compatible Anthropic-only provider and fallback configurations.

* **Bug Fixes**
  * Prevented incompatible caching markers from being sent through non-Anthropic or mixed provider chains, avoiding fallback request errors.

* **Tests**
  * Added coverage for supported providers, fallback configurations, and converted Anthropic requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->