### PR TITLE
MCP Apps (1/3): backend plumbing — tool `_meta.ui`, `resources/read`, app-resource endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -75,6 +75,8 @@ type MCPClientManager interface {
 	IsPluginRegistered(pluginID string) bool
 
 	DiscoverPluginServerTools(ctx context.Context, userID string, cfg mcp.PluginServerConfig) ([]mcp.ToolInfo, error)
+
+	ReadUserAppResource(ctx context.Context, userID, serverOrigin, uri string) (*mcp.AppResource, error)
 }
 
 // ConfigStore provides read/write access to the plugin configuration in the database.
@@ -307,6 +309,7 @@ func (a *API) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Reques
 	router.GET("/mcp/user-preferences", a.handleGetUserPreferences)
 	router.PUT("/mcp/user-preferences", a.handlePutUserPreferences)
 	router.DELETE("/mcp/oauth/:serverName", a.handleDeleteUserMCPOAuth)
+	router.GET("/mcp/app-resource", a.handleGetMCPAppResource)
 
 	// Agent routes — authenticated. Free-tier instances (no multi-LLM license)
 	// can CRUD up to one self-service agent; the quota is enforced inside

--- a/api/api_conversation_test.go
+++ b/api/api_conversation_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mattermost/mattermost-plugin-agents/v2/conversation"
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/mattermost/mattermost-plugin-agents/v2/store"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
@@ -415,4 +416,52 @@ func mustMarshalBlocks(t *testing.T, blocks []conversation.ContentBlock) json.Ra
 	data, err := json.Marshal(blocks)
 	require.NoError(t, err)
 	return data
+}
+
+func TestHandleGetConversationFiltersUIMetaForNonOwner(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	channelID := testChannelID
+	uiMeta := &llm.ToolUIMeta{ResourceURI: "ui://srv/app.html"}
+	blocks := mustMarshalBlocks(t, []conversation.ContentBlock{
+		{
+			Type: conversation.BlockTypeToolUse, ID: "tc_priv", Name: "demo",
+			Input: json.RawMessage(`{}`), Shared: conversation.BoolPtr(false), UIMeta: uiMeta,
+		},
+		{
+			Type: conversation.BlockTypeToolUse, ID: "tc_shared", Name: "demo",
+			Input: json.RawMessage(`{}`), Shared: conversation.BoolPtr(true), UIMeta: uiMeta,
+		},
+	})
+
+	e := SetupTestEnvironment(t)
+	defer e.Cleanup(t)
+	e.conversationStore.conversations["conv-ui-meta"] = &store.Conversation{
+		ID:        "conv-ui-meta",
+		UserID:    testUserID,
+		BotID:     testBotUserID,
+		ChannelID: &channelID,
+	}
+	e.conversationStore.turns["conv-ui-meta"] = []store.Turn{
+		{ID: "turn-1", ConversationID: "conv-ui-meta", Role: "assistant", Content: blocks, Sequence: 1},
+	}
+	e.mockAPI.On("HasPermissionToChannel", testOtherUserID, channelID, model.PermissionReadChannel).Return(true)
+	e.mockAPI.On("LogError", mock.Anything).Maybe()
+
+	request := httptest.NewRequest(http.MethodGet, "/conversations/conv-ui-meta", nil)
+	request.Header.Add("Mattermost-User-ID", testOtherUserID)
+	recorder := httptest.NewRecorder()
+	e.api.ServeHTTP(&plugin.Context{}, recorder, request)
+	require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
+
+	var response ConversationResponse
+	require.NoError(t, json.NewDecoder(recorder.Result().Body).Decode(&response))
+	require.Len(t, response.Turns, 1)
+
+	var got []conversation.ContentBlock
+	require.NoError(t, json.Unmarshal(response.Turns[0].Content, &got))
+	require.Len(t, got, 2)
+	assert.Nil(t, got[0].UIMeta, "unshared tool_use must strip ui_meta for non-owner")
+	assert.Equal(t, uiMeta, got[1].UIMeta, "shared tool_use must keep ui_meta for non-owner")
 }

--- a/api/api_mcp_app_resource.go
+++ b/api/api_mcp_app_resource.go
@@ -4,14 +4,12 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/mattermost/mattermost-plugin-agents/v2/conversation"
-	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/mattermost/mattermost-plugin-agents/v2/mcp"
 	"github.com/mattermost/mattermost/server/public/model"
 )
@@ -25,60 +23,47 @@ const (
 	appResourceErrInvalidResourceMime = "invalid_resource_mime"
 )
 
-// AppResourceResponse is the JSON shape returned by GET /mcp/app-resource.
-// Phase 1c feeds Html/UIMeta directly into @mcp-ui/client's AppRenderer.
+// AppResourceContents is one contents[] entry in the MCP ReadResourceResult
+// wire shape returned by GET /mcp/app-resource on success.
+type AppResourceContents struct {
+	URI      string           `json:"uri"`
+	MIMEType string           `json:"mimeType"`
+	Text     string           `json:"text"`
+	Meta     *AppResourceMeta `json:"_meta,omitempty"`
+}
+
+// AppResourceMeta is the MCP `_meta` object on a resource contents item.
+type AppResourceMeta struct {
+	UI *mcp.AppResourceUIMeta `json:"ui,omitempty"`
+}
+
+// AppResourceResponse is the success JSON shape for GET /mcp/app-resource.
+// It mirrors MCP ReadResourceResult so Phase 1c's onReadResource callback can
+// return response.json() directly to @mcp-ui/client.
 type AppResourceResponse struct {
-	ServerOrigin string                 `json:"server_origin"`
-	URI          string                 `json:"uri"`
-	MIMEType     string                 `json:"mime_type"`
-	HTML         string                 `json:"html"`
-	UIMeta       *mcp.AppResourceUIMeta `json:"ui_meta,omitempty"`
+	Contents []AppResourceContents `json:"contents"`
 }
 
 // AppResourceErrorResponse is the JSON error shape for GET /mcp/app-resource.
 // ErrorCode drives webapp behavior: mcp_auth_required renders "Connect to
 // view" with AuthURL; forbidden renders the no-access popover.
+//
+// D5 state 3 ("can never gain access") is approximated client-side: after a
+// shared-result onlooker receives repeated mcp_auth_required responses and
+// OAuth fails/denies, the webapp renders the state-3 popover. The server has
+// no distinct definitive-rejection code beyond that flow.
 type AppResourceErrorResponse struct {
 	ErrorCode string `json:"error_code"`
 	Message   string `json:"message"`
 	AuthURL   string `json:"auth_url,omitempty"`
 }
 
-func (a *API) writeAppResourceError(c *gin.Context, status int, code, message, authURL string) {
+func writeAppResourceError(c *gin.Context, status int, code, message, authURL string) {
 	c.JSON(status, AppResourceErrorResponse{
 		ErrorCode: code,
 		Message:   message,
 		AuthURL:   authURL,
 	})
-}
-
-func (a *API) isKnownMCPServerOrigin(origin string) bool {
-	normalized := llm.NormalizeMCPServerOrigin(origin)
-	if normalized == "" {
-		return false
-	}
-	if normalized == llm.NormalizeMCPServerOrigin(mcp.EmbeddedClientKey) {
-		return true
-	}
-	for _, server := range a.config.MCP().Servers {
-		if !server.Enabled {
-			continue
-		}
-		if llm.NormalizeMCPServerOrigin(server.BaseURL) == normalized {
-			return true
-		}
-	}
-	if a.mcpClientManager != nil {
-		for _, cfg := range a.mcpClientManager.ListPluginServers() {
-			if !cfg.Enabled {
-				continue
-			}
-			if llm.NormalizeMCPServerOrigin("plugin://"+cfg.PluginID) == normalized {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (a *API) handleGetMCPAppResource(c *gin.Context) {
@@ -88,28 +73,33 @@ func (a *API) handleGetMCPAppResource(c *gin.Context) {
 	// gate (same reason), no tool-status gate (D3's Success/AutoApproved gating
 	// is a render-time webapp concern; the resource template itself is not
 	// result data).
+	//
+	// D6(b) uses the tool_use block's Shared flag — the same flag
+	// FilterForNonRequester uses when exposing ui_meta — so the invariant is
+	// exact: if GET /conversations/:id shows ui_meta to the caller, this
+	// fetch will not 403 for the share check.
 	userID := c.GetHeader("Mattermost-User-Id")
 	postID := c.Query("post_id")
 	toolCallID := c.Query("tool_call_id")
 	if postID == "" || toolCallID == "" || !model.IsValidId(postID) {
-		a.writeAppResourceError(c, http.StatusBadRequest, appResourceErrInvalidRequest, "post_id and tool_call_id are required", "")
+		writeAppResourceError(c, http.StatusBadRequest, appResourceErrInvalidRequest, "post_id and tool_call_id are required", "")
 		return
 	}
 
 	post, err := a.pluginAPI.Post.GetPost(postID)
 	if err != nil {
-		a.writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "post not found", "")
+		writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "post not found", "")
 		return
 	}
 
 	if !a.pluginAPI.User.HasPermissionToChannel(userID, post.ChannelId, model.PermissionReadChannel) {
-		a.writeAppResourceError(c, http.StatusForbidden, appResourceErrForbidden, "permission denied", "")
+		writeAppResourceError(c, http.StatusForbidden, appResourceErrForbidden, "permission denied", "")
 		return
 	}
 
 	turn, err := a.conversationStore.GetTurnByPostID(postID)
 	if err != nil || turn == nil {
-		a.writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "turn not found", "")
+		writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "turn not found", "")
 		return
 	}
 
@@ -126,69 +116,61 @@ func (a *API) handleGetMCPAppResource(c *gin.Context) {
 		return
 	}
 
-	var toolUse *conversation.ContentBlock
-	var toolResult *conversation.ContentBlock
-	for _, t := range turns {
-		var blocks []conversation.ContentBlock
-		if unmarshalErr := json.Unmarshal(t.Content, &blocks); unmarshalErr != nil {
-			c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to unmarshal turn content: %w", unmarshalErr))
+	toolUse, _, findErr := conversation.FindToolCallBlocks(turns, postID, toolCallID)
+	if findErr != nil {
+		if errors.Is(findErr, conversation.ErrAmbiguousToolCallID) {
+			writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "ambiguous tool call", "")
 			return
 		}
-		for i := range blocks {
-			block := &blocks[i]
-			if block.Type == conversation.BlockTypeToolUse && block.ID == toolCallID {
-				// Copy so the pointer outlives the loop body.
-				copied := *block
-				toolUse = &copied
-			}
-			if block.Type == conversation.BlockTypeToolResult && block.ToolUseID == toolCallID {
-				copied := *block
-				toolResult = &copied
-			}
-		}
-	}
-	if toolUse == nil {
-		a.writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "tool call not found", "")
+		writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "tool call not found", "")
 		return
 	}
 	if toolUse.UIMeta == nil || toolUse.UIMeta.ResourceURI == "" {
-		a.writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "tool call has no app resource", "")
+		writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "tool call has no app resource", "")
 		return
 	}
 
 	if userID != requesterID {
-		if toolResult == nil || toolResult.Shared == nil || !*toolResult.Shared {
-			a.writeAppResourceError(c, http.StatusForbidden, appResourceErrForbidden, "tool result is not shared", "")
+		if toolUse.Shared == nil || !*toolUse.Shared {
+			writeAppResourceError(c, http.StatusForbidden, appResourceErrForbidden, "tool result is not shared", "")
 			return
 		}
-	}
-
-	if !a.isKnownMCPServerOrigin(toolUse.ServerOrigin) {
-		a.writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "server no longer configured", "")
-		return
 	}
 
 	res, err := a.mcpClientManager.ReadUserAppResource(c.Request.Context(), userID, toolUse.ServerOrigin, toolUse.UIMeta.ResourceURI)
 	if err != nil {
 		var oauthErr *mcp.OAuthNeededError
 		if errors.As(err, &oauthErr) {
-			a.writeAppResourceError(c, http.StatusUnauthorized, appResourceErrAuthRequired, "MCP authentication required", oauthErr.AuthURL())
+			writeAppResourceError(c, http.StatusUnauthorized, appResourceErrAuthRequired, "MCP authentication required", oauthErr.AuthURL())
+			return
+		}
+		if errors.Is(err, mcp.ErrServerNotConfigured) {
+			writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "server no longer configured", "")
 			return
 		}
 		var invalidErr *mcp.InvalidAppResourceError
 		if errors.As(err, &invalidErr) {
-			a.writeAppResourceError(c, http.StatusBadGateway, appResourceErrInvalidResourceMime, invalidErr.Error(), "")
+			a.pluginAPI.Log.Error("Invalid MCP app resource",
+				"userID", userID, "serverOrigin", toolUse.ServerOrigin, "uri", toolUse.UIMeta.ResourceURI, "error", invalidErr)
+			writeAppResourceError(c, http.StatusBadGateway, appResourceErrInvalidResourceMime, "invalid app resource", "")
 			return
 		}
-		a.writeAppResourceError(c, http.StatusBadGateway, appResourceErrUpstreamUnreachable, err.Error(), "")
+		a.pluginAPI.Log.Error("MCP app resource upstream failure",
+			"userID", userID, "serverOrigin", toolUse.ServerOrigin, "uri", toolUse.UIMeta.ResourceURI, "error", err)
+		writeAppResourceError(c, http.StatusBadGateway, appResourceErrUpstreamUnreachable, "MCP server unreachable", "")
 		return
 	}
 
+	var meta *AppResourceMeta
+	if res.UIMeta != nil {
+		meta = &AppResourceMeta{UI: res.UIMeta}
+	}
 	c.JSON(http.StatusOK, AppResourceResponse{
-		ServerOrigin: toolUse.ServerOrigin,
-		URI:          res.URI,
-		MIMEType:     res.MIMEType,
-		HTML:         res.HTML,
-		UIMeta:       res.UIMeta,
+		Contents: []AppResourceContents{{
+			URI:      res.URI,
+			MIMEType: res.MIMEType,
+			Text:     res.HTML,
+			Meta:     meta,
+		}},
 	})
 }

--- a/api/api_mcp_app_resource.go
+++ b/api/api_mcp_app_resource.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mattermost/mattermost-plugin-agents/v2/conversation"
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/mattermost/mattermost-plugin-agents/v2/mcp"
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+const (
+	appResourceErrInvalidRequest      = "invalid_request"
+	appResourceErrNotFound            = "not_found"
+	appResourceErrForbidden           = "forbidden"
+	appResourceErrAuthRequired        = "mcp_auth_required"
+	appResourceErrUpstreamUnreachable = "upstream_unreachable"
+	appResourceErrInvalidResourceMime = "invalid_resource_mime"
+)
+
+// AppResourceResponse is the JSON shape returned by GET /mcp/app-resource.
+// Phase 1c feeds Html/UIMeta directly into @mcp-ui/client's AppRenderer.
+type AppResourceResponse struct {
+	ServerOrigin string                 `json:"server_origin"`
+	URI          string                 `json:"uri"`
+	MIMEType     string                 `json:"mime_type"`
+	HTML         string                 `json:"html"`
+	UIMeta       *mcp.AppResourceUIMeta `json:"ui_meta,omitempty"`
+}
+
+// AppResourceErrorResponse is the JSON error shape for GET /mcp/app-resource.
+// ErrorCode drives webapp behavior: mcp_auth_required renders "Connect to
+// view" with AuthURL; forbidden renders the no-access popover.
+type AppResourceErrorResponse struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+	AuthURL   string `json:"auth_url,omitempty"`
+}
+
+func (a *API) writeAppResourceError(c *gin.Context, status int, code, message, authURL string) {
+	c.JSON(status, AppResourceErrorResponse{
+		ErrorCode: code,
+		Message:   message,
+		AuthURL:   authURL,
+	})
+}
+
+func (a *API) isKnownMCPServerOrigin(origin string) bool {
+	normalized := llm.NormalizeMCPServerOrigin(origin)
+	if normalized == "" {
+		return false
+	}
+	if normalized == llm.NormalizeMCPServerOrigin(mcp.EmbeddedClientKey) {
+		return true
+	}
+	for _, server := range a.config.MCP().Servers {
+		if !server.Enabled {
+			continue
+		}
+		if llm.NormalizeMCPServerOrigin(server.BaseURL) == normalized {
+			return true
+		}
+	}
+	if a.mcpClientManager != nil {
+		for _, cfg := range a.mcpClientManager.ListPluginServers() {
+			if !cfg.Enabled {
+				continue
+			}
+			if llm.NormalizeMCPServerOrigin("plugin://"+cfg.PluginID) == normalized {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (a *API) handleGetMCPAppResource(c *gin.Context) {
+	// Explicit non-checks: no license gate (viewing an already-executed tool's
+	// UI is a read, consistent with un-gated GET /conversations/:id; execution
+	// was already license-gated at handleToolCall), no EnableChannelMentionToolCalling
+	// gate (same reason), no tool-status gate (D3's Success/AutoApproved gating
+	// is a render-time webapp concern; the resource template itself is not
+	// result data).
+	userID := c.GetHeader("Mattermost-User-Id")
+	postID := c.Query("post_id")
+	toolCallID := c.Query("tool_call_id")
+	if postID == "" || toolCallID == "" || !model.IsValidId(postID) {
+		a.writeAppResourceError(c, http.StatusBadRequest, appResourceErrInvalidRequest, "post_id and tool_call_id are required", "")
+		return
+	}
+
+	post, err := a.pluginAPI.Post.GetPost(postID)
+	if err != nil {
+		a.writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "post not found", "")
+		return
+	}
+
+	if !a.pluginAPI.User.HasPermissionToChannel(userID, post.ChannelId, model.PermissionReadChannel) {
+		a.writeAppResourceError(c, http.StatusForbidden, appResourceErrForbidden, "permission denied", "")
+		return
+	}
+
+	turn, err := a.conversationStore.GetTurnByPostID(postID)
+	if err != nil || turn == nil {
+		a.writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "turn not found", "")
+		return
+	}
+
+	conv, err := a.conversationStore.GetConversation(turn.ConversationID)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get conversation: %w", err))
+		return
+	}
+	requesterID := conv.UserID
+
+	turns, err := a.conversationStore.GetTurnsForConversation(conv.ID)
+	if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to get turns: %w", err))
+		return
+	}
+
+	var toolUse *conversation.ContentBlock
+	var toolResult *conversation.ContentBlock
+	for _, t := range turns {
+		var blocks []conversation.ContentBlock
+		if unmarshalErr := json.Unmarshal(t.Content, &blocks); unmarshalErr != nil {
+			c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to unmarshal turn content: %w", unmarshalErr))
+			return
+		}
+		for i := range blocks {
+			block := &blocks[i]
+			if block.Type == conversation.BlockTypeToolUse && block.ID == toolCallID {
+				// Copy so the pointer outlives the loop body.
+				copied := *block
+				toolUse = &copied
+			}
+			if block.Type == conversation.BlockTypeToolResult && block.ToolUseID == toolCallID {
+				copied := *block
+				toolResult = &copied
+			}
+		}
+	}
+	if toolUse == nil {
+		a.writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "tool call not found", "")
+		return
+	}
+	if toolUse.UIMeta == nil || toolUse.UIMeta.ResourceURI == "" {
+		a.writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "tool call has no app resource", "")
+		return
+	}
+
+	if userID != requesterID {
+		if toolResult == nil || toolResult.Shared == nil || !*toolResult.Shared {
+			a.writeAppResourceError(c, http.StatusForbidden, appResourceErrForbidden, "tool result is not shared", "")
+			return
+		}
+	}
+
+	if !a.isKnownMCPServerOrigin(toolUse.ServerOrigin) {
+		a.writeAppResourceError(c, http.StatusNotFound, appResourceErrNotFound, "server no longer configured", "")
+		return
+	}
+
+	res, err := a.mcpClientManager.ReadUserAppResource(c.Request.Context(), userID, toolUse.ServerOrigin, toolUse.UIMeta.ResourceURI)
+	if err != nil {
+		var oauthErr *mcp.OAuthNeededError
+		if errors.As(err, &oauthErr) {
+			a.writeAppResourceError(c, http.StatusUnauthorized, appResourceErrAuthRequired, "MCP authentication required", oauthErr.AuthURL())
+			return
+		}
+		var invalidErr *mcp.InvalidAppResourceError
+		if errors.As(err, &invalidErr) {
+			a.writeAppResourceError(c, http.StatusBadGateway, appResourceErrInvalidResourceMime, invalidErr.Error(), "")
+			return
+		}
+		a.writeAppResourceError(c, http.StatusBadGateway, appResourceErrUpstreamUnreachable, err.Error(), "")
+		return
+	}
+
+	c.JSON(http.StatusOK, AppResourceResponse{
+		ServerOrigin: toolUse.ServerOrigin,
+		URI:          res.URI,
+		MIMEType:     res.MIMEType,
+		HTML:         res.HTML,
+		UIMeta:       res.UIMeta,
+	})
+}

--- a/api/api_mcp_app_resource_test.go
+++ b/api/api_mcp_app_resource_test.go
@@ -30,6 +30,12 @@ const (
 	testAppResourceURI    = "ui://srv-a/app.html"
 )
 
+type readAppResourceCall struct {
+	userID       string
+	serverOrigin string
+	uri          string
+}
+
 func TestHandleGetMCPAppResource(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DefaultWriter = io.Discard
@@ -45,7 +51,7 @@ func TestHandleGetMCPAppResource(t *testing.T) {
 		},
 	}
 
-	seedDefaults := func(e *TestEnvironment, shared *bool, withUIMeta bool, withResult bool, serverConfigured bool) {
+	seedDefaults := func(e *TestEnvironment, toolUseShared *bool, withUIMeta bool, serverConfigured bool) *[]readAppResourceCall {
 		channelID := testChannelID
 		e.config.mcpConfig = mcp.Config{
 			Enabled: true,
@@ -72,22 +78,12 @@ func TestHandleGetMCPAppResource(t *testing.T) {
 			Name:         "demo",
 			ServerOrigin: testAppResourceOrigin,
 			Status:       conversation.StatusSuccess,
-			Shared:       conversation.BoolPtr(true),
+			Shared:       toolUseShared,
 		}
 		if withUIMeta {
 			toolUse.UIMeta = &llm.ToolUIMeta{ResourceURI: testAppResourceURI}
 		}
-		blocks := []conversation.ContentBlock{toolUse}
-		if withResult {
-			blocks = append(blocks, conversation.ContentBlock{
-				Type:      conversation.BlockTypeToolResult,
-				ToolUseID: "tc1",
-				Content:   "ok",
-				Status:    conversation.StatusSuccess,
-				Shared:    shared,
-			})
-		}
-		content, err := json.Marshal(blocks)
+		content, err := json.Marshal([]conversation.ContentBlock{toolUse})
 		require.NoError(t, err)
 		postID := testAppResourcePostID
 		turn := store.Turn{
@@ -106,21 +102,26 @@ func TestHandleGetMCPAppResource(t *testing.T) {
 			ChannelId: testChannelID,
 		}, nil).Maybe()
 		e.mockAPI.On("HasPermissionToChannel", mock.Anything, testChannelID, model.PermissionReadChannel).Return(true).Maybe()
-		e.mcp.readUserAppResource = func(_ context.Context, _, _, _ string) (*mcp.AppResource, error) {
+
+		calls := &[]readAppResourceCall{}
+		e.mcp.readUserAppResource = func(_ context.Context, userID, serverOrigin, uri string) (*mcp.AppResource, error) {
+			*calls = append(*calls, readAppResourceCall{userID: userID, serverOrigin: serverOrigin, uri: uri})
 			return successResource, nil
 		}
+		return calls
 	}
 
 	tests := []struct {
-		name          string
-		caller        string
-		query         string
-		setup         func(e *TestEnvironment)
-		wantStatus    int
-		wantErrorCode string
-		wantAuthURL   string
-		wantHTML      string
-		validateBody  func(t *testing.T, body []byte)
+		name            string
+		caller          string
+		query           string
+		setup           func(e *TestEnvironment) *[]readAppResourceCall
+		wantStatus      int
+		wantErrorCode   string
+		wantAuthURL     string
+		wantHTML        string
+		wantManagerCall bool
+		validateBody    func(t *testing.T, body []byte)
 	}{
 		{
 			name:          "missing post_id",
@@ -147,11 +148,12 @@ func TestHandleGetMCPAppResource(t *testing.T) {
 			name:   "post not found",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
 				e.mockAPI.On("GetPost", testAppResourcePostID).Return(
 					nil,
 					model.NewAppError("GetPost", "app.post.get.app_error", nil, "", http.StatusNotFound),
 				)
+				return nil
 			},
 			wantStatus:    http.StatusNotFound,
 			wantErrorCode: appResourceErrNotFound,
@@ -160,12 +162,13 @@ func TestHandleGetMCPAppResource(t *testing.T) {
 			name:   "caller lacks PermissionReadChannel",
 			caller: testOtherUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
 				e.mockAPI.On("GetPost", testAppResourcePostID).Return(&model.Post{
 					Id:        testAppResourcePostID,
 					ChannelId: testChannelID,
 				}, nil)
 				e.mockAPI.On("HasPermissionToChannel", testOtherUserID, testChannelID, model.PermissionReadChannel).Return(false)
+				return nil
 			},
 			wantStatus:    http.StatusForbidden,
 			wantErrorCode: appResourceErrForbidden,
@@ -174,22 +177,23 @@ func TestHandleGetMCPAppResource(t *testing.T) {
 			name:   "no turn for post",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
 				e.mockAPI.On("GetPost", testAppResourcePostID).Return(&model.Post{
 					Id:        testAppResourcePostID,
 					ChannelId: testChannelID,
 				}, nil)
 				e.mockAPI.On("HasPermissionToChannel", testUserID, testChannelID, model.PermissionReadChannel).Return(true)
+				return nil
 			},
 			wantStatus:    http.StatusNotFound,
 			wantErrorCode: appResourceErrNotFound,
 		},
 		{
-			name:   "tool_call_id not in any turn",
+			name:   "tool_call_id not in post span",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=missing",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				return seedDefaults(e, conversation.BoolPtr(true), true, true)
 			},
 			wantStatus:    http.StatusNotFound,
 			wantErrorCode: appResourceErrNotFound,
@@ -198,142 +202,175 @@ func TestHandleGetMCPAppResource(t *testing.T) {
 			name:   "tool_use has no UIMeta",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(true), false, true, true)
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				return seedDefaults(e, conversation.BoolPtr(true), false, true)
 			},
 			wantStatus:    http.StatusNotFound,
 			wantErrorCode: appResourceErrNotFound,
 		},
 		{
-			name:   "requester, result unshared",
+			name:   "requester, tool_use unshared",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(false), true, true, true)
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				return seedDefaults(e, conversation.BoolPtr(false), true, true)
 			},
-			wantStatus: http.StatusOK,
-			wantHTML:   "<html>app</html>",
+			wantStatus:      http.StatusOK,
+			wantHTML:        "<html>app</html>",
+			wantManagerCall: true,
 		},
 		{
-			name:   "requester, result shared",
+			name:   "requester, tool_use shared",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				return seedDefaults(e, conversation.BoolPtr(true), true, true)
 			},
-			wantStatus: http.StatusOK,
-			wantHTML:   "<html>app</html>",
+			wantStatus:      http.StatusOK,
+			wantHTML:        "<html>app</html>",
+			wantManagerCall: true,
 		},
 		{
-			name:   "requester, no result block yet",
-			caller: testUserID,
-			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, nil, true, false, true)
-			},
-			wantStatus: http.StatusOK,
-			wantHTML:   "<html>app</html>",
-		},
-		{
-			name:   "onlooker with channel access, result shared",
+			name:   "onlooker with channel access, tool_use shared",
 			caller: testOtherUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				return seedDefaults(e, conversation.BoolPtr(true), true, true)
 			},
-			wantStatus: http.StatusOK,
-			wantHTML:   "<html>app</html>",
+			wantStatus:      http.StatusOK,
+			wantHTML:        "<html>app</html>",
+			wantManagerCall: true,
 		},
 		{
-			name:   "onlooker, result unshared",
+			name:   "onlooker, tool_use unshared",
 			caller: testOtherUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(false), true, true, true)
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				return seedDefaults(e, conversation.BoolPtr(false), true, true)
 			},
-			wantStatus:    http.StatusForbidden,
-			wantErrorCode: appResourceErrForbidden,
-		},
-		{
-			name:   "onlooker, no result block",
-			caller: testOtherUserID,
-			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, nil, true, false, true)
-			},
-			wantStatus:    http.StatusForbidden,
-			wantErrorCode: appResourceErrForbidden,
+			wantStatus:      http.StatusForbidden,
+			wantErrorCode:   appResourceErrForbidden,
+			wantManagerCall: false,
 		},
 		{
 			name:   "server origin no longer configured",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(true), true, true, false)
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				calls := seedDefaults(e, conversation.BoolPtr(true), true, true)
+				e.mcp.readUserAppResource = func(_ context.Context, userID, serverOrigin, uri string) (*mcp.AppResource, error) {
+					*calls = append(*calls, readAppResourceCall{userID: userID, serverOrigin: serverOrigin, uri: uri})
+					return nil, mcp.ErrServerNotConfigured
+				}
+				return calls
 			},
-			wantStatus:    http.StatusNotFound,
-			wantErrorCode: appResourceErrNotFound,
+			wantStatus:      http.StatusNotFound,
+			wantErrorCode:   appResourceErrNotFound,
+			wantManagerCall: true,
 		},
 		{
 			name:   "manager returns OAuthNeededError",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
-				e.mcp.readUserAppResource = func(_ context.Context, _, _, _ string) (*mcp.AppResource, error) {
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				calls := seedDefaults(e, conversation.BoolPtr(true), true, true)
+				e.mcp.readUserAppResource = func(_ context.Context, userID, serverOrigin, uri string) (*mcp.AppResource, error) {
+					*calls = append(*calls, readAppResourceCall{userID: userID, serverOrigin: serverOrigin, uri: uri})
 					return nil, mcp.NewOAuthNeededError("https://auth.example/start")
 				}
+				return calls
 			},
-			wantStatus:    http.StatusUnauthorized,
-			wantErrorCode: appResourceErrAuthRequired,
-			wantAuthURL:   "https://auth.example/start",
+			wantStatus:      http.StatusUnauthorized,
+			wantErrorCode:   appResourceErrAuthRequired,
+			wantAuthURL:     "https://auth.example/start",
+			wantManagerCall: true,
 		},
 		{
 			name:   "manager returns InvalidAppResourceError",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
-				e.mcp.readUserAppResource = func(_ context.Context, _, _, _ string) (*mcp.AppResource, error) {
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				calls := seedDefaults(e, conversation.BoolPtr(true), true, true)
+				e.mcp.readUserAppResource = func(_ context.Context, userID, serverOrigin, uri string) (*mcp.AppResource, error) {
+					*calls = append(*calls, readAppResourceCall{userID: userID, serverOrigin: serverOrigin, uri: uri})
 					return nil, &mcp.InvalidAppResourceError{URI: testAppResourceURI, MIMEType: "text/html"}
 				}
+				return calls
 			},
-			wantStatus:    http.StatusBadGateway,
-			wantErrorCode: appResourceErrInvalidResourceMime,
+			wantStatus:      http.StatusBadGateway,
+			wantErrorCode:   appResourceErrInvalidResourceMime,
+			wantManagerCall: true,
 		},
 		{
 			name:   "manager returns ErrServerNotConnected",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
-				e.mcp.readUserAppResource = func(_ context.Context, _, _, _ string) (*mcp.AppResource, error) {
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				calls := seedDefaults(e, conversation.BoolPtr(true), true, true)
+				e.mcp.readUserAppResource = func(_ context.Context, userID, serverOrigin, uri string) (*mcp.AppResource, error) {
+					*calls = append(*calls, readAppResourceCall{userID: userID, serverOrigin: serverOrigin, uri: uri})
 					return nil, mcp.ErrServerNotConnected
 				}
+				return calls
 			},
-			wantStatus:    http.StatusBadGateway,
-			wantErrorCode: appResourceErrUpstreamUnreachable,
+			wantStatus:      http.StatusBadGateway,
+			wantErrorCode:   appResourceErrUpstreamUnreachable,
+			wantManagerCall: true,
 		},
 		{
-			name:   "success payload shape",
+			name:   "502 bodies are non-sensitive",
 			caller: testUserID,
 			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				calls := seedDefaults(e, conversation.BoolPtr(true), true, true)
+				e.mcp.readUserAppResource = func(_ context.Context, userID, serverOrigin, uri string) (*mcp.AppResource, error) {
+					*calls = append(*calls, readAppResourceCall{userID: userID, serverOrigin: serverOrigin, uri: uri})
+					return nil, errors.New("dial tcp 10.0.0.1:443: secret internals")
+				}
+				return calls
 			},
-			wantStatus: http.StatusOK,
+			wantStatus:      http.StatusBadGateway,
+			wantErrorCode:   appResourceErrUpstreamUnreachable,
+			wantManagerCall: true,
 			validateBody: func(t *testing.T, body []byte) {
+				require.NotContains(t, string(body), "10.0.0.1")
+				require.NotContains(t, string(body), "secret")
+				var errResp AppResourceErrorResponse
+				require.NoError(t, json.Unmarshal(body, &errResp))
+				require.Equal(t, "MCP server unreachable", errResp.Message)
+			},
+		},
+		{
+			name:   "success payload is ReadResourceResult wire shape",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				return seedDefaults(e, conversation.BoolPtr(true), true, true)
+			},
+			wantStatus:      http.StatusOK,
+			wantManagerCall: true,
+			validateBody: func(t *testing.T, body []byte) {
+				raw := string(body)
+				require.Contains(t, raw, `"contents"`)
+				require.Contains(t, raw, `"mimeType"`)
+				require.Contains(t, raw, `"text"`)
+				require.Contains(t, raw, `"_meta"`)
+				require.Contains(t, raw, `"connectDomains"`)
+				require.Contains(t, raw, `"prefersBorder"`)
+				require.NotContains(t, raw, `"mime_type"`)
+				require.NotContains(t, raw, `"html"`)
+				require.NotContains(t, raw, `"ui_meta"`)
+				require.NotContains(t, raw, `"server_origin"`)
+
 				var resp AppResourceResponse
 				require.NoError(t, json.Unmarshal(body, &resp))
-				require.Equal(t, testAppResourceOrigin, resp.ServerOrigin)
-				require.Equal(t, testAppResourceURI, resp.URI)
-				require.Equal(t, mcp.UIResourceMIMEType, resp.MIMEType)
-				require.Equal(t, "<html>app</html>", resp.HTML)
-				require.NotNil(t, resp.UIMeta)
-				require.NotNil(t, resp.UIMeta.CSP)
-				require.Equal(t, []string{"https://api.example"}, resp.UIMeta.CSP.ConnectDomains)
-				require.NotNil(t, resp.UIMeta.PrefersBorder)
-				require.True(t, *resp.UIMeta.PrefersBorder)
+				require.Len(t, resp.Contents, 1)
+				require.Equal(t, testAppResourceURI, resp.Contents[0].URI)
+				require.Equal(t, mcp.UIResourceMIMEType, resp.Contents[0].MIMEType)
+				require.Equal(t, "<html>app</html>", resp.Contents[0].Text)
+				require.NotNil(t, resp.Contents[0].Meta)
+				require.NotNil(t, resp.Contents[0].Meta.UI)
+				require.Equal(t, []string{"https://api.example"}, resp.Contents[0].Meta.UI.CSP.ConnectDomains)
 			},
 		},
 		{
@@ -343,17 +380,46 @@ func TestHandleGetMCPAppResource(t *testing.T) {
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
-			name:   "generic upstream error",
-			caller: testUserID,
-			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
-			setup: func(e *TestEnvironment) {
-				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
-				e.mcp.readUserAppResource = func(_ context.Context, _, _, _ string) (*mcp.AppResource, error) {
-					return nil, errors.New("boom")
+			name:   "duplicate tool_call_id across rounds does not cross-authorize",
+			caller: testOtherUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=reuse",
+			setup: func(e *TestEnvironment) *[]readAppResourceCall {
+				channelID := testChannelID
+				e.config.mcpConfig = mcp.Config{
+					Enabled: true,
+					Servers: []mcp.ServerConfig{{Name: "srv-a", BaseURL: testAppResourceOrigin, Enabled: true}},
 				}
+				e.conversationStore.conversations[testAppResourceConvID] = &store.Conversation{
+					ID: testAppResourceConvID, UserID: testUserID, BotID: testBotUserID, ChannelID: &channelID,
+				}
+				postA := testAppResourcePostID
+				postB := "postb23456789012345678901b"
+				uiMeta := &llm.ToolUIMeta{ResourceURI: testAppResourceURI}
+				unshared, _ := json.Marshal([]conversation.ContentBlock{{
+					Type: conversation.BlockTypeToolUse, ID: "reuse", ServerOrigin: testAppResourceOrigin,
+					Shared: conversation.BoolPtr(false), UIMeta: uiMeta,
+				}})
+				shared, _ := json.Marshal([]conversation.ContentBlock{{
+					Type: conversation.BlockTypeToolUse, ID: "reuse", ServerOrigin: testAppResourceOrigin,
+					Shared: conversation.BoolPtr(true), UIMeta: uiMeta,
+				}})
+				e.conversationStore.turns[testAppResourceConvID] = []store.Turn{
+					{ID: "t1", ConversationID: testAppResourceConvID, PostID: &postA, Role: "assistant", Content: unshared, Sequence: 1},
+					{ID: "t2", ConversationID: testAppResourceConvID, PostID: &postB, Role: "assistant", Content: shared, Sequence: 2},
+				}
+				e.conversationStore.turnsByPost[postA] = &e.conversationStore.turns[testAppResourceConvID][0]
+				e.mockAPI.On("GetPost", postA).Return(&model.Post{Id: postA, ChannelId: testChannelID}, nil)
+				e.mockAPI.On("HasPermissionToChannel", testOtherUserID, testChannelID, model.PermissionReadChannel).Return(true)
+				calls := &[]readAppResourceCall{}
+				e.mcp.readUserAppResource = func(_ context.Context, userID, serverOrigin, uri string) (*mcp.AppResource, error) {
+					*calls = append(*calls, readAppResourceCall{userID: userID, serverOrigin: serverOrigin, uri: uri})
+					return successResource, nil
+				}
+				return calls
 			},
-			wantStatus:    http.StatusBadGateway,
-			wantErrorCode: appResourceErrUpstreamUnreachable,
+			wantStatus:      http.StatusForbidden,
+			wantErrorCode:   appResourceErrForbidden,
+			wantManagerCall: false,
 		},
 	}
 
@@ -362,8 +428,9 @@ func TestHandleGetMCPAppResource(t *testing.T) {
 			e := SetupTestEnvironment(t)
 			defer e.Cleanup(t)
 			e.mockAPI.On("LogError", mock.Anything).Maybe()
+			var calls *[]readAppResourceCall
 			if tt.setup != nil {
-				tt.setup(e)
+				calls = tt.setup(e)
 			}
 
 			req := httptest.NewRequest(http.MethodGet, "/mcp/app-resource?"+tt.query, nil)
@@ -389,10 +456,21 @@ func TestHandleGetMCPAppResource(t *testing.T) {
 			if tt.wantHTML != "" {
 				var okResp AppResourceResponse
 				require.NoError(t, json.Unmarshal(body, &okResp))
-				require.Equal(t, tt.wantHTML, okResp.HTML)
+				require.Len(t, okResp.Contents, 1)
+				require.Equal(t, tt.wantHTML, okResp.Contents[0].Text)
 			}
 			if tt.validateBody != nil {
 				tt.validateBody(t, body)
+			}
+			if calls != nil {
+				if tt.wantManagerCall {
+					require.Len(t, *calls, 1)
+					require.Equal(t, tt.caller, (*calls)[0].userID)
+					require.Equal(t, testAppResourceOrigin, (*calls)[0].serverOrigin)
+					require.Equal(t, testAppResourceURI, (*calls)[0].uri)
+				} else {
+					require.Empty(t, *calls)
+				}
 			}
 		})
 	}

--- a/api/api_mcp_app_resource_test.go
+++ b/api/api_mcp_app_resource_test.go
@@ -1,0 +1,399 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mattermost/mattermost-plugin-agents/v2/conversation"
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/mattermost/mattermost-plugin-agents/v2/mcp"
+	"github.com/mattermost/mattermost-plugin-agents/v2/store"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAppResourcePostID = "post12345678901234567890ab"
+	testAppResourceConvID = "conv-app-resource-1"
+	testAppResourceOrigin = "http://srv-a/mcp"
+	testAppResourceURI    = "ui://srv-a/app.html"
+)
+
+func TestHandleGetMCPAppResource(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	gin.DefaultWriter = io.Discard
+
+	prefersBorder := true
+	successResource := &mcp.AppResource{
+		URI:      testAppResourceURI,
+		MIMEType: mcp.UIResourceMIMEType,
+		HTML:     "<html>app</html>",
+		UIMeta: &mcp.AppResourceUIMeta{
+			CSP:           &mcp.AppResourceCSP{ConnectDomains: []string{"https://api.example"}},
+			PrefersBorder: &prefersBorder,
+		},
+	}
+
+	seedDefaults := func(e *TestEnvironment, shared *bool, withUIMeta bool, withResult bool, serverConfigured bool) {
+		channelID := testChannelID
+		e.config.mcpConfig = mcp.Config{
+			Enabled: true,
+			Servers: []mcp.ServerConfig{},
+		}
+		if serverConfigured {
+			e.config.mcpConfig.Servers = []mcp.ServerConfig{{
+				Name:    "srv-a",
+				BaseURL: testAppResourceOrigin,
+				Enabled: true,
+			}}
+		}
+
+		e.conversationStore.conversations[testAppResourceConvID] = &store.Conversation{
+			ID:        testAppResourceConvID,
+			UserID:    testUserID,
+			BotID:     testBotUserID,
+			ChannelID: &channelID,
+		}
+
+		toolUse := conversation.ContentBlock{
+			Type:         conversation.BlockTypeToolUse,
+			ID:           "tc1",
+			Name:         "demo",
+			ServerOrigin: testAppResourceOrigin,
+			Status:       conversation.StatusSuccess,
+			Shared:       conversation.BoolPtr(true),
+		}
+		if withUIMeta {
+			toolUse.UIMeta = &llm.ToolUIMeta{ResourceURI: testAppResourceURI}
+		}
+		blocks := []conversation.ContentBlock{toolUse}
+		if withResult {
+			blocks = append(blocks, conversation.ContentBlock{
+				Type:      conversation.BlockTypeToolResult,
+				ToolUseID: "tc1",
+				Content:   "ok",
+				Status:    conversation.StatusSuccess,
+				Shared:    shared,
+			})
+		}
+		content, err := json.Marshal(blocks)
+		require.NoError(t, err)
+		postID := testAppResourcePostID
+		turn := store.Turn{
+			ID:             "turn-1",
+			ConversationID: testAppResourceConvID,
+			PostID:         &postID,
+			Role:           "assistant",
+			Content:        content,
+			Sequence:       1,
+		}
+		e.conversationStore.turns[testAppResourceConvID] = []store.Turn{turn}
+		e.conversationStore.turnsByPost[testAppResourcePostID] = &turn
+
+		e.mockAPI.On("GetPost", testAppResourcePostID).Return(&model.Post{
+			Id:        testAppResourcePostID,
+			ChannelId: testChannelID,
+		}, nil).Maybe()
+		e.mockAPI.On("HasPermissionToChannel", mock.Anything, testChannelID, model.PermissionReadChannel).Return(true).Maybe()
+		e.mcp.readUserAppResource = func(_ context.Context, _, _, _ string) (*mcp.AppResource, error) {
+			return successResource, nil
+		}
+	}
+
+	tests := []struct {
+		name          string
+		caller        string
+		query         string
+		setup         func(e *TestEnvironment)
+		wantStatus    int
+		wantErrorCode string
+		wantAuthURL   string
+		wantHTML      string
+		validateBody  func(t *testing.T, body []byte)
+	}{
+		{
+			name:          "missing post_id",
+			caller:        testUserID,
+			query:         "tool_call_id=tc1",
+			wantStatus:    http.StatusBadRequest,
+			wantErrorCode: appResourceErrInvalidRequest,
+		},
+		{
+			name:          "missing tool_call_id",
+			caller:        testUserID,
+			query:         "post_id=" + testAppResourcePostID,
+			wantStatus:    http.StatusBadRequest,
+			wantErrorCode: appResourceErrInvalidRequest,
+		},
+		{
+			name:          "malformed post_id",
+			caller:        testUserID,
+			query:         "post_id=not-valid&tool_call_id=tc1",
+			wantStatus:    http.StatusBadRequest,
+			wantErrorCode: appResourceErrInvalidRequest,
+		},
+		{
+			name:   "post not found",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				e.mockAPI.On("GetPost", testAppResourcePostID).Return(
+					nil,
+					model.NewAppError("GetPost", "app.post.get.app_error", nil, "", http.StatusNotFound),
+				)
+			},
+			wantStatus:    http.StatusNotFound,
+			wantErrorCode: appResourceErrNotFound,
+		},
+		{
+			name:   "caller lacks PermissionReadChannel",
+			caller: testOtherUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				e.mockAPI.On("GetPost", testAppResourcePostID).Return(&model.Post{
+					Id:        testAppResourcePostID,
+					ChannelId: testChannelID,
+				}, nil)
+				e.mockAPI.On("HasPermissionToChannel", testOtherUserID, testChannelID, model.PermissionReadChannel).Return(false)
+			},
+			wantStatus:    http.StatusForbidden,
+			wantErrorCode: appResourceErrForbidden,
+		},
+		{
+			name:   "no turn for post",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				e.mockAPI.On("GetPost", testAppResourcePostID).Return(&model.Post{
+					Id:        testAppResourcePostID,
+					ChannelId: testChannelID,
+				}, nil)
+				e.mockAPI.On("HasPermissionToChannel", testUserID, testChannelID, model.PermissionReadChannel).Return(true)
+			},
+			wantStatus:    http.StatusNotFound,
+			wantErrorCode: appResourceErrNotFound,
+		},
+		{
+			name:   "tool_call_id not in any turn",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=missing",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+			},
+			wantStatus:    http.StatusNotFound,
+			wantErrorCode: appResourceErrNotFound,
+		},
+		{
+			name:   "tool_use has no UIMeta",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(true), false, true, true)
+			},
+			wantStatus:    http.StatusNotFound,
+			wantErrorCode: appResourceErrNotFound,
+		},
+		{
+			name:   "requester, result unshared",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(false), true, true, true)
+			},
+			wantStatus: http.StatusOK,
+			wantHTML:   "<html>app</html>",
+		},
+		{
+			name:   "requester, result shared",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+			},
+			wantStatus: http.StatusOK,
+			wantHTML:   "<html>app</html>",
+		},
+		{
+			name:   "requester, no result block yet",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, nil, true, false, true)
+			},
+			wantStatus: http.StatusOK,
+			wantHTML:   "<html>app</html>",
+		},
+		{
+			name:   "onlooker with channel access, result shared",
+			caller: testOtherUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+			},
+			wantStatus: http.StatusOK,
+			wantHTML:   "<html>app</html>",
+		},
+		{
+			name:   "onlooker, result unshared",
+			caller: testOtherUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(false), true, true, true)
+			},
+			wantStatus:    http.StatusForbidden,
+			wantErrorCode: appResourceErrForbidden,
+		},
+		{
+			name:   "onlooker, no result block",
+			caller: testOtherUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, nil, true, false, true)
+			},
+			wantStatus:    http.StatusForbidden,
+			wantErrorCode: appResourceErrForbidden,
+		},
+		{
+			name:   "server origin no longer configured",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(true), true, true, false)
+			},
+			wantStatus:    http.StatusNotFound,
+			wantErrorCode: appResourceErrNotFound,
+		},
+		{
+			name:   "manager returns OAuthNeededError",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+				e.mcp.readUserAppResource = func(_ context.Context, _, _, _ string) (*mcp.AppResource, error) {
+					return nil, mcp.NewOAuthNeededError("https://auth.example/start")
+				}
+			},
+			wantStatus:    http.StatusUnauthorized,
+			wantErrorCode: appResourceErrAuthRequired,
+			wantAuthURL:   "https://auth.example/start",
+		},
+		{
+			name:   "manager returns InvalidAppResourceError",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+				e.mcp.readUserAppResource = func(_ context.Context, _, _, _ string) (*mcp.AppResource, error) {
+					return nil, &mcp.InvalidAppResourceError{URI: testAppResourceURI, MIMEType: "text/html"}
+				}
+			},
+			wantStatus:    http.StatusBadGateway,
+			wantErrorCode: appResourceErrInvalidResourceMime,
+		},
+		{
+			name:   "manager returns ErrServerNotConnected",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+				e.mcp.readUserAppResource = func(_ context.Context, _, _, _ string) (*mcp.AppResource, error) {
+					return nil, mcp.ErrServerNotConnected
+				}
+			},
+			wantStatus:    http.StatusBadGateway,
+			wantErrorCode: appResourceErrUpstreamUnreachable,
+		},
+		{
+			name:   "success payload shape",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+			},
+			wantStatus: http.StatusOK,
+			validateBody: func(t *testing.T, body []byte) {
+				var resp AppResourceResponse
+				require.NoError(t, json.Unmarshal(body, &resp))
+				require.Equal(t, testAppResourceOrigin, resp.ServerOrigin)
+				require.Equal(t, testAppResourceURI, resp.URI)
+				require.Equal(t, mcp.UIResourceMIMEType, resp.MIMEType)
+				require.Equal(t, "<html>app</html>", resp.HTML)
+				require.NotNil(t, resp.UIMeta)
+				require.NotNil(t, resp.UIMeta.CSP)
+				require.Equal(t, []string{"https://api.example"}, resp.UIMeta.CSP.ConnectDomains)
+				require.NotNil(t, resp.UIMeta.PrefersBorder)
+				require.True(t, *resp.UIMeta.PrefersBorder)
+			},
+		},
+		{
+			name:       "unauthenticated",
+			caller:     "",
+			query:      "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:   "generic upstream error",
+			caller: testUserID,
+			query:  "post_id=" + testAppResourcePostID + "&tool_call_id=tc1",
+			setup: func(e *TestEnvironment) {
+				seedDefaults(e, conversation.BoolPtr(true), true, true, true)
+				e.mcp.readUserAppResource = func(_ context.Context, _, _, _ string) (*mcp.AppResource, error) {
+					return nil, errors.New("boom")
+				}
+			},
+			wantStatus:    http.StatusBadGateway,
+			wantErrorCode: appResourceErrUpstreamUnreachable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := SetupTestEnvironment(t)
+			defer e.Cleanup(t)
+			e.mockAPI.On("LogError", mock.Anything).Maybe()
+			if tt.setup != nil {
+				tt.setup(e)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/mcp/app-resource?"+tt.query, nil)
+			if tt.caller != "" {
+				req.Header.Add("Mattermost-User-ID", tt.caller)
+			}
+			rec := httptest.NewRecorder()
+			e.api.ServeHTTP(&plugin.Context{}, rec, req)
+			resp := rec.Result()
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			if tt.wantErrorCode != "" {
+				var errResp AppResourceErrorResponse
+				require.NoError(t, json.Unmarshal(body, &errResp))
+				require.Equal(t, tt.wantErrorCode, errResp.ErrorCode)
+				if tt.wantAuthURL != "" {
+					require.Equal(t, tt.wantAuthURL, errResp.AuthURL)
+				}
+			}
+			if tt.wantHTML != "" {
+				var okResp AppResourceResponse
+				require.NoError(t, json.Unmarshal(body, &okResp))
+				require.Equal(t, tt.wantHTML, okResp.HTML)
+			}
+			if tt.validateBody != nil {
+				tt.validateBody(t, body)
+			}
+		})
+	}
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -135,6 +135,8 @@ type mockMCPClientManager struct {
 	discoverPluginToolsResponse  []mcp.ToolInfo
 	discoverPluginToolsErr       error
 	discoverPluginToolsCallCount int
+
+	readUserAppResource func(ctx context.Context, userID, serverOrigin, uri string) (*mcp.AppResource, error)
 }
 
 func newTestMCPClientManager(t *testing.T) *mockMCPClientManager {
@@ -256,6 +258,13 @@ func (m *mockMCPClientManager) IsPluginRegistered(pluginID string) bool {
 func (m *mockMCPClientManager) DiscoverPluginServerTools(ctx context.Context, userID string, cfg mcp.PluginServerConfig) ([]mcp.ToolInfo, error) {
 	m.discoverPluginToolsCallCount++
 	return m.discoverPluginToolsResponse, m.discoverPluginToolsErr
+}
+
+func (m *mockMCPClientManager) ReadUserAppResource(ctx context.Context, userID, serverOrigin, uri string) (*mcp.AppResource, error) {
+	if m.readUserAppResource != nil {
+		return m.readUserAppResource(ctx, userID, serverOrigin, uri)
+	}
+	return nil, mcp.ErrServerNotConnected
 }
 
 type fakeMCPOAuthClusterNotifier struct {

--- a/conversation/content_block.go
+++ b/conversation/content_block.go
@@ -50,6 +50,9 @@ type ContentBlock struct {
 	Status       string          `json:"status,omitempty"`
 	Shared       *bool           `json:"shared,omitempty"` // pointer to distinguish unset from false
 
+	// UIMeta is the persisted MCP Apps tool metadata (tool_use blocks only).
+	UIMeta *llm.ToolUIMeta `json:"ui_meta,omitempty"`
+
 	// UserInteraction is the persisted form of llm.Tool.UserInteraction.
 	UserInteraction string `json:"user_interaction,omitempty"`
 
@@ -104,11 +107,12 @@ func BoolPtr(b bool) *bool { return &b }
 func Int64Ptr(v int64) *int64 { return &v }
 
 // FilterForNonRequester returns a new slice of content blocks with private
-// tool data redacted. Tool use blocks with shared != true have their Input
-// field set to nil. Tool result blocks with shared != true have their Content
-// field set to empty string. All other block types pass through unchanged.
-// The original slice and its elements are never mutated.
-// Returns nil if the input is nil.
+// tool data redacted. Tool use blocks with shared != true have their Input,
+// MCPBareName, and UIMeta cleared. Tool result blocks with shared != true
+// have their Content field set to empty string. Shared tool_use blocks keep
+// UIMeta so onlookers can detect an app after a share. All other block types
+// pass through unchanged. The original slice and its elements are never
+// mutated. Returns nil if the input is nil.
 func FilterForNonRequester(blocks []ContentBlock) []ContentBlock {
 	if blocks == nil {
 		return nil
@@ -122,6 +126,7 @@ func FilterForNonRequester(blocks []ContentBlock) []ContentBlock {
 			if block.Shared == nil || !*block.Shared {
 				result[i].Input = nil
 				result[i].MCPBareName = ""
+				result[i].UIMeta = nil
 			}
 		case BlockTypeToolResult:
 			if block.Shared == nil || !*block.Shared {

--- a/conversation/content_block_test.go
+++ b/conversation/content_block_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -330,4 +331,41 @@ func TestFilterForNonRequesterDoesNotMutateOriginal(t *testing.T) {
 
 	assert.Equal(t, originalInputCopy, original[0].Input)
 	assert.Equal(t, originalContentCopy, original[1].Content)
+}
+
+func TestFilterForNonRequesterUIMeta(t *testing.T) {
+	uiMeta := &llm.ToolUIMeta{ResourceURI: "ui://srv/app.html"}
+
+	tests := []struct {
+		name       string
+		block      ContentBlock
+		wantUIMeta *llm.ToolUIMeta
+	}{
+		{
+			name: "unshared tool_use clears UIMeta",
+			block: ContentBlock{
+				Type: BlockTypeToolUse, ID: "tc1", Name: "demo",
+				Input: json.RawMessage(`{}`), Shared: BoolPtr(false), UIMeta: uiMeta,
+			},
+			wantUIMeta: nil,
+		},
+		{
+			name: "shared tool_use keeps UIMeta",
+			block: ContentBlock{
+				Type: BlockTypeToolUse, ID: "tc1", Name: "demo",
+				Input: json.RawMessage(`{}`), Shared: BoolPtr(true), UIMeta: uiMeta,
+			},
+			wantUIMeta: uiMeta,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := []ContentBlock{tt.block}
+			result := FilterForNonRequester(original)
+			require.Len(t, result, 1)
+			assert.Equal(t, tt.wantUIMeta, result[0].UIMeta)
+			assert.Equal(t, uiMeta, original[0].UIMeta, "original must not be mutated")
+		})
+	}
 }

--- a/conversation/convert.go
+++ b/conversation/convert.go
@@ -87,6 +87,7 @@ func BlocksToPost(
 				Arguments:    arguments,
 				MCPBareName:  block.MCPBareName,
 				Status:       StatusFromString(block.Status),
+				UIMeta:       block.UIMeta,
 			}
 			if redactToolUse {
 				toolCall.MCPBareName = ""
@@ -268,6 +269,7 @@ func PostToBlocks(post llm.Post, shared bool) []ContentBlock {
 			MCPBareName:  tc.MCPBareName,
 			Status:       StatusToString(tc.Status),
 			Shared:       BoolPtr(shared),
+			UIMeta:       tc.UIMeta,
 		})
 
 		if tc.Result != "" {

--- a/conversation/convert_test.go
+++ b/conversation/convert_test.go
@@ -273,6 +273,29 @@ func TestPostToBlocksPreservesToolIdentityMetadata(t *testing.T) {
 	assert.NotContains(t, string(data), "tool_description")
 }
 
+func TestPostToBlocksAndBlocksToPostRoundTripUIMeta(t *testing.T) {
+	uiMeta := &llm.ToolUIMeta{ResourceURI: "ui://srv/app.html", Visibility: []string{"model", "app"}}
+	post := llm.Post{
+		Role: llm.PostRoleBot,
+		ToolUse: []llm.ToolCall{{
+			ID:           "tc1",
+			Name:         "demo",
+			ServerOrigin: "https://srv.example",
+			Arguments:    json.RawMessage(`{}`),
+			Status:       llm.ToolCallStatusPending,
+			UIMeta:       uiMeta,
+		}},
+	}
+
+	blocks := PostToBlocks(post, true)
+	require.Len(t, blocks, 1)
+	assert.Equal(t, uiMeta, blocks[0].UIMeta)
+
+	roundTripped := BlocksToPost(blocks, "assistant", PostConversionOptions{})
+	require.Len(t, roundTripped.ToolUse, 1)
+	assert.Equal(t, uiMeta, roundTripped.ToolUse[0].UIMeta)
+}
+
 func TestBlocksToPostRehydratesToolCatalogMetadata(t *testing.T) {
 	// Persisted block omits the bare name on purpose: rehydration must derive
 	// it from the namespaced catalog entry, not echo a value the test pre-set.

--- a/conversation/find_tool_call.go
+++ b/conversation/find_tool_call.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package conversation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/store"
+)
+
+var (
+	// ErrToolCallNotFound is returned when no tool_use block with the given ID
+	// exists in the post-anchored turn span.
+	ErrToolCallNotFound = errors.New("tool call not found")
+	// ErrAmbiguousToolCallID is returned when more than one tool_use block in
+	// the post-anchored span shares the same ID.
+	ErrAmbiguousToolCallID = errors.New("ambiguous tool call id")
+)
+
+// FindToolCallBlocks scans the turn span anchored to postID for the tool_use
+// block with the given ID and its matching tool_result block.
+//
+// Anchoring: the assistant turn(s) whose PostID equals postID, plus subsequent
+// turns until the next post-anchored assistant turn. This prevents a shared
+// result from another round that reused a provider tool-call ID from
+// authorizing a different tool_use.
+//
+// Duplicate tool_use IDs within the span are rejected as ambiguous.
+func FindToolCallBlocks(turns []store.Turn, postID, toolCallID string) (toolUse, toolResult *ContentBlock, err error) {
+	if postID == "" || toolCallID == "" {
+		return nil, nil, ErrToolCallNotFound
+	}
+
+	span := postAnchoredTurnSpan(turns, postID)
+	if len(span) == 0 {
+		return nil, nil, ErrToolCallNotFound
+	}
+
+	var useCount int
+	for _, turn := range span {
+		var blocks []ContentBlock
+		if unmarshalErr := json.Unmarshal(turn.Content, &blocks); unmarshalErr != nil {
+			return nil, nil, fmt.Errorf("failed to unmarshal turn content: %w", unmarshalErr)
+		}
+		for i := range blocks {
+			block := blocks[i]
+			switch {
+			case block.Type == BlockTypeToolUse && block.ID == toolCallID:
+				useCount++
+				copied := block
+				toolUse = &copied
+			case block.Type == BlockTypeToolResult && block.ToolUseID == toolCallID:
+				copied := block
+				toolResult = &copied
+			}
+		}
+	}
+
+	if useCount == 0 {
+		return nil, nil, ErrToolCallNotFound
+	}
+	if useCount > 1 {
+		return nil, nil, ErrAmbiguousToolCallID
+	}
+	return toolUse, toolResult, nil
+}
+
+// postAnchoredTurnSpan returns the assistant turn(s) for postID and following
+// turns until another post-anchored assistant turn begins.
+func postAnchoredTurnSpan(turns []store.Turn, postID string) []store.Turn {
+	var span []store.Turn
+	inSpan := false
+	for _, turn := range turns {
+		if turn.PostID != nil && *turn.PostID == postID {
+			inSpan = true
+			span = append(span, turn)
+			continue
+		}
+		if !inSpan {
+			continue
+		}
+		if turn.PostID != nil && *turn.PostID != postID {
+			break
+		}
+		span = append(span, turn)
+	}
+	return span
+}

--- a/conversation/find_tool_call_test.go
+++ b/conversation/find_tool_call_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package conversation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/mattermost/mattermost-plugin-agents/v2/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindToolCallBlocksPostAnchored(t *testing.T) {
+	postA := "posta23456789012345678901a"
+	postB := "postb23456789012345678901b"
+	uiMeta := &llm.ToolUIMeta{ResourceURI: "ui://srv/app.html"}
+
+	mustBlocks := func(blocks []ContentBlock) json.RawMessage {
+		t.Helper()
+		data, err := json.Marshal(blocks)
+		require.NoError(t, err)
+		return data
+	}
+
+	turns := []store.Turn{
+		{
+			ID: "t1", PostID: &postA, Role: "assistant",
+			Content: mustBlocks([]ContentBlock{{
+				Type: BlockTypeToolUse, ID: "reuse", Name: "demo",
+				ServerOrigin: "http://srv-a/mcp", Shared: BoolPtr(false), UIMeta: uiMeta,
+			}}),
+			Sequence: 1,
+		},
+		{
+			ID: "t2", Role: "tool_result",
+			Content: mustBlocks([]ContentBlock{{
+				Type: BlockTypeToolResult, ToolUseID: "reuse", Content: "private",
+				Shared: BoolPtr(false),
+			}}),
+			Sequence: 2,
+		},
+		{
+			ID: "t3", PostID: &postB, Role: "assistant",
+			Content: mustBlocks([]ContentBlock{{
+				Type: BlockTypeToolUse, ID: "reuse", Name: "demo",
+				ServerOrigin: "http://srv-a/mcp", Shared: BoolPtr(true), UIMeta: uiMeta,
+			}}),
+			Sequence: 3,
+		},
+		{
+			ID: "t4", Role: "tool_result",
+			Content: mustBlocks([]ContentBlock{{
+				Type: BlockTypeToolResult, ToolUseID: "reuse", Content: "shared",
+				Shared: BoolPtr(true),
+			}}),
+			Sequence: 4,
+		},
+	}
+
+	t.Run("unshared round does not cross-authorize via later shared result", func(t *testing.T) {
+		toolUse, toolResult, err := FindToolCallBlocks(turns, postA, "reuse")
+		require.NoError(t, err)
+		require.NotNil(t, toolUse)
+		require.False(t, toolUse.Shared != nil && *toolUse.Shared)
+		require.NotNil(t, toolResult)
+		require.False(t, toolResult.Shared != nil && *toolResult.Shared)
+		require.Equal(t, "private", toolResult.Content)
+	})
+
+	t.Run("shared round resolves its own blocks", func(t *testing.T) {
+		toolUse, toolResult, err := FindToolCallBlocks(turns, postB, "reuse")
+		require.NoError(t, err)
+		require.NotNil(t, toolUse)
+		require.True(t, toolUse.Shared != nil && *toolUse.Shared)
+		require.NotNil(t, toolResult)
+		require.True(t, toolResult.Shared != nil && *toolResult.Shared)
+		require.Equal(t, "shared", toolResult.Content)
+	})
+
+	t.Run("duplicate id in same post span is ambiguous", func(t *testing.T) {
+		dupTurns := []store.Turn{{
+			ID: "d1", PostID: &postA, Role: "assistant",
+			Content: mustBlocks([]ContentBlock{
+				{Type: BlockTypeToolUse, ID: "dup", Name: "a"},
+				{Type: BlockTypeToolUse, ID: "dup", Name: "b"},
+			}),
+		}}
+		_, _, err := FindToolCallBlocks(dupTurns, postA, "dup")
+		require.ErrorIs(t, err, ErrAmbiguousToolCallID)
+	})
+
+	t.Run("missing tool call", func(t *testing.T) {
+		_, _, err := FindToolCallBlocks(turns, postA, "missing")
+		require.ErrorIs(t, err, ErrToolCallNotFound)
+	})
+}

--- a/conversation/helpers.go
+++ b/conversation/helpers.go
@@ -112,6 +112,7 @@ func toolUseBlocks(
 			Status:          StatusToString(tc.Status),
 			Shared:          BoolPtr(shared),
 			UserInteraction: tc.UserInteraction,
+			UIMeta:          tc.UIMeta,
 		})
 	}
 

--- a/conversation/helpers_test.go
+++ b/conversation/helpers_test.go
@@ -79,6 +79,20 @@ func TestToolUseBlocksPreservesApprovalMetadata(t *testing.T) {
 	assert.Equal(t, "get_issue", blocks[0].MCPBareName)
 }
 
+func TestToolUseBlocksCarriesUIMeta(t *testing.T) {
+	uiMeta := &llm.ToolUIMeta{ResourceURI: "ui://srv/app.html"}
+	blocks := toolUseBlocks("", llm.ReasoningData{}, []llm.ToolCall{{
+		ID:           "tc1",
+		Name:         "demo",
+		ServerOrigin: "https://srv.example",
+		Status:       llm.ToolCallStatusPending,
+		UIMeta:       uiMeta,
+	}}, true)
+
+	require.Len(t, blocks, 1)
+	assert.Equal(t, uiMeta, blocks[0].UIMeta)
+}
+
 func TestUnmarshalBlocks(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/asticode/go-astisub v0.39.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-shiori/go-readability v0.0.0-20251205110129-5db1dc9836f0
-	github.com/google/jsonschema-go v0.4.2
+	github.com/google/jsonschema-go v0.4.3
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jmoiron/sqlx v1.4.0
@@ -16,7 +16,7 @@ require (
 	github.com/mattermost/morph v1.1.0
 	github.com/mattermost/testcontainers-mattermost-go v0.1.0
 	github.com/maximhq/bifrost/core v1.5.18
-	github.com/modelcontextprotocol/go-sdk v1.4.1
+	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/nicksnyder/go-i18n/v2 v2.6.1
 	github.com/pgvector/pgvector-go v0.3.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
-github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/vP9vJGqPwcdqsWjOt+V8J7+bTc=
@@ -392,8 +392,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.4.1 h1:M4x9GyIPj+HoIlHNGpK2hq5o3BFhC+78PkEaldQRphc=
-github.com/modelcontextprotocol/go-sdk v1.4.1/go.mod h1:Bo/mS87hPQqHSRkMv4dQq1XCu6zv4INdXnFZabkNU6s=
+github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
+github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/llm/tools.go
+++ b/llm/tools.go
@@ -266,6 +266,11 @@ type ToolCall struct {
 	// ServerOrigin identifies the MCP server this tool came from (the BaseURL).
 	// Empty for built-in tools. Used for auto-approval decisions.
 	ServerOrigin string `json:"server_origin,omitempty"`
+
+	// UIMeta mirrors Tool.UIMeta so the webapp can detect UI-enabled tool
+	// calls. Nil when the tool has no MCP Apps UI. Redacted for
+	// non-requesters until the result is shared.
+	UIMeta *ToolUIMeta `json:"ui_meta,omitempty"`
 }
 
 // SanitizeNonPrintableChars replaces non-printable Unicode characters with their
@@ -441,9 +446,10 @@ type EnrichToolCallOptions struct {
 	BareNameFallback bool
 }
 
-// EnrichToolCall fills a tool call's Description, Schema, ServerOrigin, and
-// MCPBareName from the resolved store entry. MCPBareName is only set for MCP
-// tools (those with a server origin); builtins are left untouched.
+// EnrichToolCall fills a tool call's Description, Schema, ServerOrigin,
+// MCPBareName, and UIMeta from the resolved store entry. MCPBareName is only
+// set for MCP tools (those with a server origin); builtins are left untouched.
+// UIMeta is filled only when the call does not already carry one.
 func EnrichToolCall(tc *ToolCall, store *ToolStore, opts EnrichToolCallOptions) {
 	if tc == nil || store == nil {
 		return
@@ -466,6 +472,9 @@ func EnrichToolCall(tc *ToolCall, store *ToolStore, opts EnrichToolCallOptions) 
 	}
 	if tc.MCPBareName == "" && lookup.ServerOrigin != "" {
 		tc.MCPBareName = lookup.BareName
+	}
+	if tc.UIMeta == nil {
+		tc.UIMeta = tool.UIMeta
 	}
 }
 

--- a/llm/tools.go
+++ b/llm/tools.go
@@ -37,6 +37,10 @@ type Tool struct {
 	// Empty for built-in (non-MCP) tools. Used for auto-approval decisions.
 	ServerOrigin string
 
+	// UIMeta is the MCP Apps metadata (_meta.ui) declared on the tool by its
+	// MCP server. Nil for built-in tools and tools without an app UI.
+	UIMeta *ToolUIMeta
+
 	// UserInteraction marks a tool whose pending call is answered by the
 	// requesting user in the Mattermost UI instead of executed by the server;
 	// the Resolver is only an error backstop. Empty for normal tools.

--- a/llm/tools_test.go
+++ b/llm/tools_test.go
@@ -1142,3 +1142,48 @@ func TestEnrichToolCallNilSafe(t *testing.T) {
 	assert.Empty(t, tc.Description)
 	assert.Nil(t, tc.Schema)
 }
+
+func TestEnrichToolCallUIMeta(t *testing.T) {
+	storeUIMeta := &ToolUIMeta{ResourceURI: "ui://store/app"}
+	callUIMeta := &ToolUIMeta{ResourceURI: "ui://call/app"}
+
+	tests := []struct {
+		name     string
+		store    *ToolUIMeta
+		tc       *ToolCall
+		wantMeta *ToolUIMeta
+	}{
+		{
+			name:     "fills UIMeta from store when call has none",
+			store:    storeUIMeta,
+			tc:       &ToolCall{Name: "app_tool", ServerOrigin: "https://srv.example"},
+			wantMeta: storeUIMeta,
+		},
+		{
+			name:     "preserves existing UIMeta on the call",
+			store:    storeUIMeta,
+			tc:       &ToolCall{Name: "app_tool", ServerOrigin: "https://srv.example", UIMeta: callUIMeta},
+			wantMeta: callUIMeta,
+		},
+		{
+			name:     "stays nil when store tool has no UIMeta",
+			store:    nil,
+			tc:       &ToolCall{Name: "app_tool", ServerOrigin: "https://srv.example"},
+			wantMeta: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewNoTools()
+			store.AddTools([]Tool{{
+				Name:         "app_tool",
+				Description:  "App tool",
+				ServerOrigin: "https://srv.example",
+				UIMeta:       tt.store,
+			}})
+			EnrichToolCall(tt.tc, store, EnrichToolCallOptions{})
+			assert.Equal(t, tt.wantMeta, tt.tc.UIMeta)
+		})
+	}
+}

--- a/llm/tools_ui.go
+++ b/llm/tools_ui.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package llm
+
+// ToolUIVisibilityModel / ToolUIVisibilityApp are the values of the MCP Apps
+// tool visibility array (_meta.ui.visibility).
+const (
+	ToolUIVisibilityModel = "model"
+	ToolUIVisibilityApp   = "app"
+)
+
+// ToolUIMeta is the tool-side MCP Apps metadata (_meta.ui) declared by an MCP
+// server on a tool, per the io.modelcontextprotocol/ui extension (2026-01-26).
+// It is carried from tool discovery through ToolCall broadcasting and turn
+// persistence so the webapp can detect UI-enabled tool calls.
+type ToolUIMeta struct {
+	// ResourceURI is the ui:// URI of the HTML resource that renders this
+	// tool's results.
+	ResourceURI string `json:"resource_uri"`
+	// Visibility lists who may call the tool ("model", "app").
+	// Empty means the spec default ["model", "app"].
+	Visibility []string `json:"visibility,omitempty"`
+}
+
+// VisibleToModel reports whether the tool may be exposed to the LLM.
+// A nil/empty Visibility defaults to visible (spec default ["model","app"]).
+func (m *ToolUIMeta) VisibleToModel() bool {
+	if m == nil || len(m.Visibility) == 0 {
+		return true
+	}
+	for _, v := range m.Visibility {
+		if v == ToolUIVisibilityModel {
+			return true
+		}
+	}
+	return false
+}

--- a/mcp/apps_meta.go
+++ b/mcp/apps_meta.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"encoding/json"
+	"mime"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	// UIExtensionID is the MCP Apps extension identifier used in
+	// initialize capability negotiation (SEP-1865, stable 2026-01-26).
+	UIExtensionID = "io.modelcontextprotocol/ui"
+
+	// UIResourceMIMEType is the exact MIME type required for MCP App
+	// HTML resources.
+	UIResourceMIMEType = "text/html;profile=mcp-app"
+
+	// legacyToolUIResourceURIKey is the deprecated flat _meta key still
+	// emitted by real servers alongside the nested form. Remove after the
+	// extension GAs and servers drop it.
+	legacyToolUIResourceURIKey = "ui/resourceUri"
+)
+
+// uiClientCapabilities returns the ClientCapabilities every plugin MCP client
+// declares: the MCP Apps ui extension (mimeTypes is REQUIRED by the spec)
+// plus the roots capability the SDK previously declared by default. Setting
+// ClientOptions.Capabilities overrides that default, so RootsV2 must be
+// restated explicitly to keep the wire behavior unchanged.
+func uiClientCapabilities() *mcp.ClientCapabilities {
+	caps := &mcp.ClientCapabilities{
+		RootsV2: &mcp.RootCapabilities{ListChanged: true},
+	}
+	caps.AddExtension(UIExtensionID, map[string]any{
+		"mimeTypes": []any{UIResourceMIMEType},
+	})
+	return caps
+}
+
+// uiClientOptions returns the ClientOptions used at every mcp.NewClient call site.
+func uiClientOptions() *mcp.ClientOptions {
+	return &mcp.ClientOptions{Capabilities: uiClientCapabilities()}
+}
+
+// parseToolUIMeta extracts MCP Apps tool metadata from a tool's _meta map.
+// The canonical nested form (_meta.ui.resourceUri / _meta.ui.visibility) is
+// preferred; the deprecated flat _meta["ui/resourceUri"] is accepted as a
+// fallback because current real-world servers still emit it (spec deprecates
+// it "before GA"). Returns nil when the tool declares no UI.
+func parseToolUIMeta(meta map[string]any) *llm.ToolUIMeta {
+	if len(meta) == 0 {
+		return nil
+	}
+
+	if ui, ok := meta["ui"].(map[string]any); ok {
+		out := &llm.ToolUIMeta{}
+		if s, ok := ui["resourceUri"].(string); ok {
+			out.ResourceURI = s
+		}
+		if vis, ok := ui["visibility"].([]any); ok {
+			for _, v := range vis {
+				if s, ok := v.(string); ok {
+					out.Visibility = append(out.Visibility, s)
+				}
+			}
+		}
+		if out.ResourceURI != "" || len(out.Visibility) > 0 {
+			return out
+		}
+	}
+
+	if s, ok := meta[legacyToolUIResourceURIKey].(string); ok && s != "" {
+		return &llm.ToolUIMeta{ResourceURI: s}
+	}
+
+	return nil
+}
+
+// AppResourceCSP mirrors the spec's McpUiResourceCsp. JSON keys stay
+// camelCase (spec wire format): Phase 1c passes this object verbatim to
+// @mcp-ui/client's sandbox.csp prop and Phase 1b's sandbox server parses the
+// same shape from the ?csp= query parameter.
+type AppResourceCSP struct {
+	ConnectDomains  []string `json:"connectDomains,omitempty"`
+	ResourceDomains []string `json:"resourceDomains,omitempty"`
+	FrameDomains    []string `json:"frameDomains,omitempty"`
+	BaseURIDomains  []string `json:"baseUriDomains,omitempty"`
+}
+
+// AppResourceUIMeta mirrors the spec's UIResourceMeta (_meta.ui on a
+// resources/read result). Permissions is a pass-through map keyed by
+// permission name (camera, microphone, geolocation, clipboardWrite) with
+// empty-object values, exactly as the spec and @mcp-ui/client define it.
+type AppResourceUIMeta struct {
+	CSP           *AppResourceCSP           `json:"csp,omitempty"`
+	Permissions   map[string]map[string]any `json:"permissions,omitempty"`
+	Domain        string                    `json:"domain,omitempty"`
+	PrefersBorder *bool                     `json:"prefersBorder,omitempty"`
+}
+
+// parseResourceUIMeta extracts _meta.ui from a resources/read content item.
+// Malformed values are ignored field-by-field (a bad csp does not discard
+// prefersBorder). Returns nil when no ui metadata is present.
+func parseResourceUIMeta(meta map[string]any) *AppResourceUIMeta {
+	if len(meta) == 0 {
+		return nil
+	}
+	ui, ok := meta["ui"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	out := &AppResourceUIMeta{}
+
+	if cspRaw, ok := ui["csp"]; ok {
+		if cspMap, ok := cspRaw.(map[string]any); ok {
+			data, err := json.Marshal(cspMap)
+			if err == nil {
+				var csp AppResourceCSP
+				if err := json.Unmarshal(data, &csp); err == nil {
+					out.CSP = &csp
+				}
+			}
+		}
+	}
+
+	if permsRaw, ok := ui["permissions"].(map[string]any); ok {
+		perms := make(map[string]map[string]any)
+		for k, v := range permsRaw {
+			if inner, ok := v.(map[string]any); ok {
+				perms[k] = inner
+			}
+		}
+		if len(perms) > 0 {
+			out.Permissions = perms
+		}
+	}
+
+	if s, ok := ui["domain"].(string); ok {
+		out.Domain = s
+	}
+
+	if b, ok := ui["prefersBorder"].(bool); ok {
+		out.PrefersBorder = &b
+	}
+
+	if out.CSP == nil && out.Permissions == nil && out.Domain == "" && out.PrefersBorder == nil {
+		return nil
+	}
+	return out
+}
+
+// IsUIResourceMIMEType reports whether mimeType is exactly the MCP Apps HTML
+// profile (text/html;profile=mcp-app), tolerating parameter whitespace and
+// case variations per RFC 2045 via mime.ParseMediaType.
+func IsUIResourceMIMEType(mimeType string) bool {
+	mt, params, err := mime.ParseMediaType(mimeType)
+	if err != nil {
+		return false
+	}
+	return mt == "text/html" && params["profile"] == "mcp-app"
+}

--- a/mcp/apps_meta.go
+++ b/mcp/apps_meta.go
@@ -5,7 +5,10 @@ package mcp
 
 import (
 	"encoding/json"
+	"fmt"
 	"mime"
+	"net/url"
+	"unicode"
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -49,15 +52,17 @@ func uiClientOptions() *mcp.ClientOptions {
 // parseToolUIMeta extracts MCP Apps tool metadata from a tool's _meta map.
 // The canonical nested form (_meta.ui.resourceUri / _meta.ui.visibility) is
 // preferred; the deprecated flat _meta["ui/resourceUri"] is accepted as a
-// fallback because current real-world servers still emit it (spec deprecates
-// it "before GA"). Returns nil when the tool declares no UI.
+// fallback for ResourceURI when the nested form lacks a valid resourceUri
+// (spec deprecates the flat key "before GA"). Nested visibility is kept when
+// present even if the URI comes from the flat key. Returns nil when the tool
+// declares no UI.
 func parseToolUIMeta(meta map[string]any) *llm.ToolUIMeta {
 	if len(meta) == 0 {
 		return nil
 	}
 
+	out := &llm.ToolUIMeta{}
 	if ui, ok := meta["ui"].(map[string]any); ok {
-		out := &llm.ToolUIMeta{}
 		if s, ok := ui["resourceUri"].(string); ok {
 			out.ResourceURI = s
 		}
@@ -68,15 +73,38 @@ func parseToolUIMeta(meta map[string]any) *llm.ToolUIMeta {
 				}
 			}
 		}
-		if out.ResourceURI != "" || len(out.Visibility) > 0 {
-			return out
+	}
+
+	if out.ResourceURI == "" {
+		if s, ok := meta[legacyToolUIResourceURIKey].(string); ok && s != "" {
+			out.ResourceURI = s
 		}
 	}
 
-	if s, ok := meta[legacyToolUIResourceURIKey].(string); ok && s != "" {
-		return &llm.ToolUIMeta{ResourceURI: s}
+	if out.ResourceURI == "" && len(out.Visibility) == 0 {
+		return nil
 	}
+	return out
+}
 
+// validateUIResourceURI reports whether uri is a well-formed ui:// URI without
+// control characters. Valid Unicode in the path/host is preserved.
+func validateUIResourceURI(uri string) error {
+	if uri == "" {
+		return &InvalidAppResourceError{URI: uri, Reason: "empty URI"}
+	}
+	for _, r := range uri {
+		if r < 0x20 || r == 0x7f || unicode.IsControl(r) {
+			return &InvalidAppResourceError{URI: uri, Reason: "URI contains control characters"}
+		}
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return &InvalidAppResourceError{URI: uri, Reason: fmt.Sprintf("invalid URI: %v", err)}
+	}
+	if u.Scheme != "ui" {
+		return &InvalidAppResourceError{URI: uri, Reason: "URI scheme must be ui"}
+	}
 	return nil
 }
 

--- a/mcp/apps_meta_test.go
+++ b/mcp/apps_meta_test.go
@@ -1,0 +1,248 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseToolUIMeta(t *testing.T) {
+	tests := []struct {
+		name string
+		meta map[string]any
+		want *llm.ToolUIMeta
+	}{
+		{
+			name: "nil meta",
+			meta: nil,
+			want: nil,
+		},
+		{
+			name: "empty meta",
+			meta: map[string]any{},
+			want: nil,
+		},
+		{
+			name: "nested only",
+			meta: map[string]any{
+				"ui": map[string]any{"resourceUri": "ui://a/b"},
+			},
+			want: &llm.ToolUIMeta{ResourceURI: "ui://a/b"},
+		},
+		{
+			name: "nested with visibility",
+			meta: map[string]any{
+				"ui": map[string]any{
+					"resourceUri": "ui://a/b",
+					"visibility":  []any{"model", "app"},
+				},
+			},
+			want: &llm.ToolUIMeta{ResourceURI: "ui://a/b", Visibility: []string{"model", "app"}},
+		},
+		{
+			name: "app-only visibility, no resourceUri",
+			meta: map[string]any{
+				"ui": map[string]any{"visibility": []any{"app"}},
+			},
+			want: &llm.ToolUIMeta{Visibility: []string{"app"}},
+		},
+		{
+			name: "legacy flat only",
+			meta: map[string]any{
+				"ui/resourceUri": "ui://a/b",
+			},
+			want: &llm.ToolUIMeta{ResourceURI: "ui://a/b"},
+		},
+		{
+			name: "both forms, nested wins",
+			meta: map[string]any{
+				"ui":             map[string]any{"resourceUri": "ui://nested"},
+				"ui/resourceUri": "ui://flat",
+			},
+			want: &llm.ToolUIMeta{ResourceURI: "ui://nested"},
+		},
+		{
+			name: "ui not a map",
+			meta: map[string]any{"ui": "junk"},
+			want: nil,
+		},
+		{
+			name: "resourceUri not a string",
+			meta: map[string]any{
+				"ui": map[string]any{"resourceUri": 42},
+			},
+			want: nil,
+		},
+		{
+			name: "visibility mixed types",
+			meta: map[string]any{
+				"ui": map[string]any{
+					"visibility": []any{"model", 7},
+				},
+			},
+			want: &llm.ToolUIMeta{Visibility: []string{"model"}},
+		},
+		{
+			name: "unrelated meta keys",
+			meta: map[string]any{"other": "x"},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseToolUIMeta(tt.meta)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToolUIMetaVisibleToModel(t *testing.T) {
+	tests := []struct {
+		name       string
+		visibility []string
+		metaNil    bool
+		want       bool
+	}{
+		{name: "nil", metaNil: true, want: true},
+		{name: "empty", visibility: nil, want: true},
+		{name: "model only", visibility: []string{"model"}, want: true},
+		{name: "app only", visibility: []string{"app"}, want: false},
+		{name: "model and app", visibility: []string{"model", "app"}, want: true},
+		{name: "app and model", visibility: []string{"app", "model"}, want: true},
+		{name: "bogus", visibility: []string{"bogus"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m *llm.ToolUIMeta
+			if !tt.metaNil {
+				m = &llm.ToolUIMeta{Visibility: tt.visibility}
+			}
+			require.Equal(t, tt.want, m.VisibleToModel())
+		})
+	}
+}
+
+func ptrBool(b bool) *bool { return &b }
+
+func TestParseResourceUIMeta(t *testing.T) {
+	tests := []struct {
+		name string
+		meta map[string]any
+		want *AppResourceUIMeta
+	}{
+		{
+			name: "nil",
+			meta: nil,
+			want: nil,
+		},
+		{
+			name: "no ui",
+			meta: map[string]any{"x": 1},
+			want: nil,
+		},
+		{
+			name: "full",
+			meta: map[string]any{
+				"ui": map[string]any{
+					"csp": map[string]any{
+						"connectDomains":  []any{"https://a"},
+						"resourceDomains": []any{"https://b"},
+						"frameDomains":    []any{"https://c"},
+						"baseUriDomains":  []any{"https://d"},
+					},
+					"permissions":   map[string]any{"camera": map[string]any{}},
+					"domain":        "example.com",
+					"prefersBorder": true,
+				},
+			},
+			want: &AppResourceUIMeta{
+				CSP: &AppResourceCSP{
+					ConnectDomains:  []string{"https://a"},
+					ResourceDomains: []string{"https://b"},
+					FrameDomains:    []string{"https://c"},
+					BaseURIDomains:  []string{"https://d"},
+				},
+				Permissions:   map[string]map[string]any{"camera": {}},
+				Domain:        "example.com",
+				PrefersBorder: ptrBool(true),
+			},
+		},
+		{
+			name: "csp only, partial",
+			meta: map[string]any{
+				"ui": map[string]any{
+					"csp": map[string]any{
+						"connectDomains": []any{"https://a"},
+					},
+				},
+			},
+			want: &AppResourceUIMeta{
+				CSP: &AppResourceCSP{ConnectDomains: []string{"https://a"}},
+			},
+		},
+		{
+			name: "prefersBorder false",
+			meta: map[string]any{
+				"ui": map[string]any{"prefersBorder": false},
+			},
+			want: &AppResourceUIMeta{PrefersBorder: ptrBool(false)},
+		},
+		{
+			name: "malformed csp ignored, prefersBorder kept",
+			meta: map[string]any{
+				"ui": map[string]any{
+					"csp":           "junk",
+					"prefersBorder": true,
+				},
+			},
+			want: &AppResourceUIMeta{PrefersBorder: ptrBool(true)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseResourceUIMeta(tt.meta)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsUIResourceMIMEType(t *testing.T) {
+	tests := []struct {
+		name     string
+		mimeType string
+		want     bool
+	}{
+		{name: "exact", mimeType: "text/html;profile=mcp-app", want: true},
+		{name: "space after semicolon", mimeType: "text/html; profile=mcp-app", want: true},
+		{name: "type and param name case", mimeType: "TEXT/HTML;PROFILE=mcp-app", want: true},
+		// Parameter values are case-sensitive per RFC 2045.
+		{name: "param value case", mimeType: "text/html;profile=MCP-APP", want: false},
+		{name: "no profile", mimeType: "text/html", want: false},
+		{name: "wrong profile", mimeType: "text/html;profile=other", want: false},
+		{name: "wrong type", mimeType: "application/json", want: false},
+		{name: "empty", mimeType: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsUIResourceMIMEType(tt.mimeType))
+		})
+	}
+}
+
+func TestUIClientCapabilities(t *testing.T) {
+	caps := uiClientCapabilities()
+	require.NotNil(t, caps)
+	require.NotNil(t, caps.RootsV2)
+	require.True(t, caps.RootsV2.ListChanged)
+	require.Equal(t, map[string]any{
+		"mimeTypes": []any{UIResourceMIMEType},
+	}, caps.Extensions[UIExtensionID])
+}

--- a/mcp/apps_meta_test.go
+++ b/mcp/apps_meta_test.go
@@ -66,12 +66,36 @@ func TestParseToolUIMeta(t *testing.T) {
 			want: &llm.ToolUIMeta{ResourceURI: "ui://nested"},
 		},
 		{
+			name: "nested visibility plus flat URI",
+			meta: map[string]any{
+				"ui":             map[string]any{"visibility": []any{"model", "app"}},
+				"ui/resourceUri": "ui://flat",
+			},
+			want: &llm.ToolUIMeta{ResourceURI: "ui://flat", Visibility: []string{"model", "app"}},
+		},
+		{
+			name: "malformed nested URI plus flat URI",
+			meta: map[string]any{
+				"ui":             map[string]any{"resourceUri": 42, "visibility": []any{"app"}},
+				"ui/resourceUri": "ui://flat",
+			},
+			want: &llm.ToolUIMeta{ResourceURI: "ui://flat", Visibility: []string{"app"}},
+		},
+		{
+			name: "empty nested URI falls back to flat",
+			meta: map[string]any{
+				"ui":             map[string]any{"resourceUri": "", "visibility": []any{"app"}},
+				"ui/resourceUri": "ui://flat",
+			},
+			want: &llm.ToolUIMeta{ResourceURI: "ui://flat", Visibility: []string{"app"}},
+		},
+		{
 			name: "ui not a map",
 			meta: map[string]any{"ui": "junk"},
 			want: nil,
 		},
 		{
-			name: "resourceUri not a string",
+			name: "resourceUri not a string without flat fallback",
 			meta: map[string]any{
 				"ui": map[string]any{"resourceUri": 42},
 			},
@@ -224,6 +248,8 @@ func TestIsUIResourceMIMEType(t *testing.T) {
 		{name: "type and param name case", mimeType: "TEXT/HTML;PROFILE=mcp-app", want: true},
 		// Parameter values are case-sensitive per RFC 2045.
 		{name: "param value case", mimeType: "text/html;profile=MCP-APP", want: false},
+		// Extra parameters (e.g. charset) are ALLOWED; only type+profile matter.
+		{name: "extra charset param allowed", mimeType: "text/html;profile=mcp-app;charset=utf-8", want: true},
 		{name: "no profile", mimeType: "text/html", want: false},
 		{name: "wrong profile", mimeType: "text/html;profile=other", want: false},
 		{name: "wrong type", mimeType: "application/json", want: false},

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -528,12 +528,23 @@ func (c *Client) oauthNeededRedirectURL(metadataURL string) string {
 	return u.String()
 }
 
+// currentSession returns the live session under toolsMu.
+func (c *Client) currentSession() *mcp.ClientSession {
+	c.toolsMu.RLock()
+	defer c.toolsMu.RUnlock()
+	return c.session
+}
+
 // Close closes the connection to the MCP server
 func (c *Client) Close() error {
-	if c.session == nil {
+	c.toolsMu.Lock()
+	session := c.session
+	c.session = nil
+	c.toolsMu.Unlock()
+	if session == nil {
 		return nil
 	}
-	return c.session.Close()
+	return session.Close()
 }
 
 // Tools returns the tools available from this client
@@ -558,7 +569,8 @@ func (c *Client) CallToolWithMetadata(ctx context.Context, toolName string, args
 	)
 	defer span.End()
 
-	if c.session == nil {
+	session := c.currentSession()
+	if session == nil {
 		err := fmt.Errorf("MCP client not connected")
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -576,15 +588,19 @@ func (c *Client) CallToolWithMetadata(ctx context.Context, toolName string, args
 		params.Meta = mcp.Meta(metadata)
 	}
 
-	result, err := c.session.CallTool(ctx, params)
+	result, err := session.CallTool(ctx, params)
 	if err != nil {
 		if !errors.Is(err, mcp.ErrConnectionClosed) {
 			return "", fmt.Errorf("failed to call tool %s on server %s: %w", toolName, c.config.Name, err)
 		}
-		if reconnectErr := c.reconnect(ctx); reconnectErr != nil {
+		if reconnectErr := c.reconnect(ctx, session); reconnectErr != nil {
 			return "", reconnectErr
 		}
-		result, err = c.session.CallTool(ctx, params)
+		session = c.currentSession()
+		if session == nil {
+			return "", fmt.Errorf("MCP client not connected after reconnecting")
+		}
+		result, err = session.CallTool(ctx, params)
 		if err != nil {
 			return "", fmt.Errorf("failed to call tool %s on server %s after reconnecting: %w", toolName, c.config.Name, err)
 		}
@@ -618,7 +634,19 @@ func (c *Client) CallToolWithMetadata(ctx context.Context, toolName string, args
 // reconnect re-establishes the session after mcp.ErrConnectionClosed,
 // re-listing tools and updating the shared cache (remote) or recreating the
 // embedded client (embedded). Callers retry their operation once afterwards.
-func (c *Client) reconnect(ctx context.Context) error {
+//
+// failedSession is the session pointer the caller observed as closed. If another
+// goroutine has already replaced that session, reconnect is a no-op (single-flight).
+// The session being replaced is closed after a successful swap.
+func (c *Client) reconnect(ctx context.Context, failedSession *mcp.ClientSession) error {
+	c.toolsMu.Lock()
+	defer c.toolsMu.Unlock()
+
+	if c.session != failedSession {
+		return nil
+	}
+	oldSession := c.session
+
 	if c.embeddedClient != nil {
 		// Reconnect to embedded server using stored client helper and session ID
 		if c.sessionID == "" {
@@ -630,10 +658,11 @@ func (c *Client) reconnect(ctx context.Context) error {
 			return fmt.Errorf("failed to reconnect to embedded MCP server: %w", reconnectErr)
 		}
 
-		c.toolsMu.Lock()
 		c.session = newClient.session
 		c.tools = newClient.Tools()
-		c.toolsMu.Unlock()
+		if oldSession != nil {
+			_ = oldSession.Close()
+		}
 		c.log.Debug("Successfully reconnected to embedded MCP server", "userID", c.userID)
 		return nil
 	}
@@ -653,10 +682,11 @@ func (c *Client) reconnect(ctx context.Context) error {
 		return fmt.Errorf("no tools found after reconnecting to MCP server %s for user %s", c.config.Name, c.userID)
 	}
 
-	c.toolsMu.Lock()
 	c.session = newSession
 	c.tools = discoveredTools
-	c.toolsMu.Unlock()
+	if oldSession != nil {
+		_ = oldSession.Close()
+	}
 
 	if c.toolsCache != nil && shouldUseSharedToolsCache(c.config) {
 		if cacheErr := c.toolsCache.SetTools(c.config.Name, c.config.Name, c.config.BaseURL, discoveredTools, time.Now()); cacheErr != nil {

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -182,7 +182,7 @@ func (c *EmbeddedServerClient) CreateClient(ctx context.Context, userID, session
 			Name:    "mattermost-agents-embedded",
 			Version: "1.0",
 		},
-		nil,
+		uiClientOptions(),
 	)
 
 	// Connect to the embedded server using in-memory transport
@@ -349,7 +349,7 @@ func NewPluginClient(ctx context.Context, userID string, cfg PluginServerConfig,
 			Name:    "mattermost-agents-plugin-bridge",
 			Version: "1.0",
 		},
-		nil,
+		uiClientOptions(),
 	)
 
 	session, err := mcpClient.Connect(ctx, &mcp.StreamableClientTransport{
@@ -462,7 +462,7 @@ func (c *Client) createSession(ctx context.Context, serverConfig ServerConfig) (
 			Name:    "mattermost-agents",
 			Version: "1.0",
 		},
-		nil,
+		uiClientOptions(),
 	)
 
 	httpClient := c.httpClientForMCP(headers)

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -578,62 +578,15 @@ func (c *Client) CallToolWithMetadata(ctx context.Context, toolName string, args
 
 	result, err := c.session.CallTool(ctx, params)
 	if err != nil {
-		if errors.Is(err, mcp.ErrConnectionClosed) {
-			if c.embeddedClient != nil {
-				// Reconnect to embedded server using stored client helper and session ID
-				if c.sessionID == "" {
-					return "", fmt.Errorf("embedded server connection lost and cannot be reconnected: missing session ID")
-				}
-
-				newClient, reconnectErr := c.embeddedClient.CreateClient(ctx, c.userID, c.sessionID)
-				if reconnectErr != nil {
-					return "", fmt.Errorf("failed to reconnect to embedded MCP server: %w", reconnectErr)
-				}
-
-				c.toolsMu.Lock()
-				c.session = newClient.session
-				c.tools = newClient.Tools()
-				c.toolsMu.Unlock()
-				c.log.Debug("Successfully reconnected to embedded MCP server", "userID", c.userID)
-			} else {
-				// Reconnect to remote server
-				newSession, reconnectErr := c.createSession(ctx, c.config)
-				if reconnectErr != nil {
-					return "", fmt.Errorf("failed to reconnect to MCP server %s: %w", c.config.Name, reconnectErr)
-				}
-				discoveredTools, listErr := listAllTools(ctx, newSession)
-				if listErr != nil {
-					newSession.Close()
-					return "", fmt.Errorf("failed to list tools after reconnecting to MCP server %s: %w", c.config.Name, listErr)
-				}
-				if len(discoveredTools) == 0 {
-					newSession.Close()
-					return "", fmt.Errorf("no tools found after reconnecting to MCP server %s for user %s", c.config.Name, c.userID)
-				}
-
-				c.toolsMu.Lock()
-				c.session = newSession
-				c.tools = discoveredTools
-				c.toolsMu.Unlock()
-
-				if c.toolsCache != nil && shouldUseSharedToolsCache(c.config) {
-					if cacheErr := c.toolsCache.SetTools(c.config.Name, c.config.Name, c.config.BaseURL, discoveredTools, time.Now()); cacheErr != nil {
-						c.log.Warn("Failed to update tools cache after MCP reconnect",
-							"server", c.config.Name,
-							"userID", c.userID,
-							"error", cacheErr)
-					}
-				}
-				c.log.Debug("Successfully reconnected to MCP server", "userID", c.userID, "server", c.config.Name)
-			}
-
-			// Retry the tool call after reconnecting
-			result, err = c.session.CallTool(ctx, params)
-			if err != nil {
-				return "", fmt.Errorf("failed to call tool %s on server %s after reconnecting: %w", toolName, c.config.Name, err)
-			}
-		} else {
+		if !errors.Is(err, mcp.ErrConnectionClosed) {
 			return "", fmt.Errorf("failed to call tool %s on server %s: %w", toolName, c.config.Name, err)
+		}
+		if reconnectErr := c.reconnect(ctx); reconnectErr != nil {
+			return "", reconnectErr
+		}
+		result, err = c.session.CallTool(ctx, params)
+		if err != nil {
+			return "", fmt.Errorf("failed to call tool %s on server %s after reconnecting: %w", toolName, c.config.Name, err)
 		}
 	}
 	var textBuilder strings.Builder
@@ -660,4 +613,59 @@ func (c *Client) CallToolWithMetadata(ctx context.Context, toolName string, args
 	}
 
 	return "", fmt.Errorf("no text content found in response from tool %s on server %s", toolName, c.config.Name)
+}
+
+// reconnect re-establishes the session after mcp.ErrConnectionClosed,
+// re-listing tools and updating the shared cache (remote) or recreating the
+// embedded client (embedded). Callers retry their operation once afterwards.
+func (c *Client) reconnect(ctx context.Context) error {
+	if c.embeddedClient != nil {
+		// Reconnect to embedded server using stored client helper and session ID
+		if c.sessionID == "" {
+			return fmt.Errorf("embedded server connection lost and cannot be reconnected: missing session ID")
+		}
+
+		newClient, reconnectErr := c.embeddedClient.CreateClient(ctx, c.userID, c.sessionID)
+		if reconnectErr != nil {
+			return fmt.Errorf("failed to reconnect to embedded MCP server: %w", reconnectErr)
+		}
+
+		c.toolsMu.Lock()
+		c.session = newClient.session
+		c.tools = newClient.Tools()
+		c.toolsMu.Unlock()
+		c.log.Debug("Successfully reconnected to embedded MCP server", "userID", c.userID)
+		return nil
+	}
+
+	// Reconnect to remote server
+	newSession, reconnectErr := c.createSession(ctx, c.config)
+	if reconnectErr != nil {
+		return fmt.Errorf("failed to reconnect to MCP server %s: %w", c.config.Name, reconnectErr)
+	}
+	discoveredTools, listErr := listAllTools(ctx, newSession)
+	if listErr != nil {
+		newSession.Close()
+		return fmt.Errorf("failed to list tools after reconnecting to MCP server %s: %w", c.config.Name, listErr)
+	}
+	if len(discoveredTools) == 0 {
+		newSession.Close()
+		return fmt.Errorf("no tools found after reconnecting to MCP server %s for user %s", c.config.Name, c.userID)
+	}
+
+	c.toolsMu.Lock()
+	c.session = newSession
+	c.tools = discoveredTools
+	c.toolsMu.Unlock()
+
+	if c.toolsCache != nil && shouldUseSharedToolsCache(c.config) {
+		if cacheErr := c.toolsCache.SetTools(c.config.Name, c.config.Name, c.config.BaseURL, discoveredTools, time.Now()); cacheErr != nil {
+			c.log.Warn("Failed to update tools cache after MCP reconnect",
+				"server", c.config.Name,
+				"userID", c.userID,
+				"error", cacheErr)
+		}
+	}
+	c.log.Debug("Successfully reconnected to MCP server", "userID", c.userID, "server", c.config.Name)
+	return nil
 }

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -199,20 +199,6 @@ func (m *ClientManager) createAndStoreUserClient(ctx context.Context, userID str
 	return userClients, mcpErrors
 }
 
-// getClientForUser gets or creates an MCP client for a specific user.
-func (m *ClientManager) getClientForUser(ctx context.Context, userID string) (*UserClients, *Errors) {
-	m.clientsMu.Lock()
-	client, exists := m.clients[userID]
-	if exists {
-		m.activity[userID] = time.Now()
-		m.clientsMu.Unlock()
-		return client, client.InitialRemoteConnectErrors()
-	}
-	m.clientsMu.Unlock()
-
-	return m.createAndStoreUserClient(ctx, userID, false)
-}
-
 // getOrCreateUserClientsShell returns the cached per-user client set, or creates
 // an empty one without connecting any remote servers. Used by targeted resource
 // reads so viewing one app cannot dial every configured MCP server.

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -131,14 +131,15 @@ func (m *ClientManager) ReInit(config Config, embeddedServer EmbeddedMCPServer) 
 // Close closes the client manager and all managed clients
 // The client manger should not be used after Close is called
 func (m *ClientManager) Close() {
-	// If already closed, do nothing
-	if m.closeChan == nil {
-		return
+	// Stop the cleanup goroutine when this manager was fully initialized.
+	// Partial test managers may omit closeChan/ticker; still close clients.
+	if m.closeChan != nil {
+		close(m.closeChan)
+		m.closeChan = nil
+		if m.cleanupTicker != nil {
+			m.cleanupTicker.Stop()
+		}
 	}
-	// Stop the cleanup goroutine
-	close(m.closeChan)
-	m.closeChan = nil
-	m.cleanupTicker.Stop()
 
 	// Close all client connections
 	m.clientsMu.Lock()
@@ -212,6 +213,22 @@ func (m *ClientManager) getClientForUser(ctx context.Context, userID string) (*U
 	return m.createAndStoreUserClient(ctx, userID, false)
 }
 
+// getOrCreateUserClientsShell returns the cached per-user client set, or creates
+// an empty one without connecting any remote servers. Used by targeted resource
+// reads so viewing one app cannot dial every configured MCP server.
+func (m *ClientManager) getOrCreateUserClientsShell(userID string) *UserClients {
+	m.clientsMu.Lock()
+	defer m.clientsMu.Unlock()
+	if client, exists := m.clients[userID]; exists {
+		m.activity[userID] = time.Now()
+		return client
+	}
+	userClients := NewUserClients(userID, m.log, m.oauthManager, m.httpClient, m.toolsCache)
+	m.clients[userID] = userClients
+	m.activity[userID] = time.Now()
+	return userClients
+}
+
 // connectEmbeddedForUser establishes the embedded MCP session for a user when
 // the manager has an embedded client configured. Failures are logged and
 // non-fatal — the caller proceeds without embedded tools/resources.
@@ -234,14 +251,21 @@ func (m *ClientManager) connectEmbeddedForUser(ctx context.Context, userClient *
 
 // GetToolsForUser returns the tools available for a specific user, connecting to embedded server if session ID provided.
 func (m *ClientManager) GetToolsForUser(ctx context.Context, userID string) ([]llm.Tool, *Errors) {
-	// Get or create client for this user (connects to remote servers only)
-	userClient, initialErrors := m.getClientForUser(ctx, userID)
-	mcpErrors := cloneMCPErrors(initialErrors)
+	// Prefer a shell created by a prior targeted resource read when present; if
+	// remote fan-out has not run yet, connect the full remote list now.
+	userClient := m.getOrCreateUserClientsShell(userID)
+	var mcpErrors *Errors
+	if !userClient.hasRemoteFanOutDone() {
+		mcpErrors = userClient.ConnectToRemoteServers(cacheableContext(ctx), m.config.Servers, false)
+		userClient.setInitialRemoteConnectErrors(mcpErrors)
+	} else {
+		mcpErrors = cloneMCPErrors(userClient.InitialRemoteConnectErrors())
+	}
 
 	// Embedded and plugin connects intentionally receive the raw cancelable ctx:
 	// they run per-request and are not cached, so a canceled request should abort
-	// them. Only the remote connect uses cacheableContext(ctx) (in
-	// createAndStoreUserClient) because its result is cached across requests.
+	// them. Only the remote connect uses cacheableContext(ctx) because its result
+	// is cached across requests.
 	m.connectEmbeddedForUser(ctx, userClient, userID)
 
 	// Snapshot under RLock, then release before PluginHTTP work.

--- a/mcp/client_manager.go
+++ b/mcp/client_manager.go
@@ -212,6 +212,26 @@ func (m *ClientManager) getClientForUser(ctx context.Context, userID string) (*U
 	return m.createAndStoreUserClient(ctx, userID, false)
 }
 
+// connectEmbeddedForUser establishes the embedded MCP session for a user when
+// the manager has an embedded client configured. Failures are logged and
+// non-fatal — the caller proceeds without embedded tools/resources.
+func (m *ClientManager) connectEmbeddedForUser(ctx context.Context, userClient *UserClients, userID string) {
+	if m.embeddedClient == nil {
+		return
+	}
+	ensuredSessionID, ensureErr := m.ensureEmbeddedSessionID(userID)
+	if ensureErr != nil {
+		m.log.Debug("Failed to ensure embedded session for user - embedded MCP tools will not be available", "userID", userID, "error", ensureErr)
+		return
+	}
+	if ensuredSessionID == "" {
+		return
+	}
+	if embeddedErr := userClient.ConnectToEmbeddedServerIfAvailable(ctx, ensuredSessionID, m.embeddedClient, m.config.EmbeddedServer); embeddedErr != nil {
+		m.log.Debug("Failed to connect to embedded server for user - embedded MCP tools will not be available", "userID", userID, "sessionID", ensuredSessionID, "error", embeddedErr)
+	}
+}
+
 // GetToolsForUser returns the tools available for a specific user, connecting to embedded server if session ID provided.
 func (m *ClientManager) GetToolsForUser(ctx context.Context, userID string) ([]llm.Tool, *Errors) {
 	// Get or create client for this user (connects to remote servers only)
@@ -222,16 +242,7 @@ func (m *ClientManager) GetToolsForUser(ctx context.Context, userID string) ([]l
 	// they run per-request and are not cached, so a canceled request should abort
 	// them. Only the remote connect uses cacheableContext(ctx) (in
 	// createAndStoreUserClient) because its result is cached across requests.
-	if m.embeddedClient != nil {
-		ensuredSessionID, ensureErr := m.ensureEmbeddedSessionID(userID)
-		if ensureErr != nil {
-			m.log.Debug("Failed to ensure embedded session for user - embedded MCP tools will not be available", "userID", userID, "error", ensureErr)
-		} else if ensuredSessionID != "" {
-			if embeddedErr := userClient.ConnectToEmbeddedServerIfAvailable(ctx, ensuredSessionID, m.embeddedClient, m.config.EmbeddedServer); embeddedErr != nil {
-				m.log.Debug("Failed to connect to embedded server for user - embedded MCP tools will not be available", "userID", userID, "sessionID", ensuredSessionID, "error", embeddedErr)
-			}
-		}
-	}
+	m.connectEmbeddedForUser(ctx, userClient, userID)
 
 	// Snapshot under RLock, then release before PluginHTTP work.
 	pluginSnap := m.snapshotEnabledPluginServers()

--- a/mcp/client_manager_test.go
+++ b/mcp/client_manager_test.go
@@ -904,7 +904,7 @@ func TestCacheableContextIgnoresParentCancellation(t *testing.T) {
 	require.NoError(t, cacheCtx.Err())
 }
 
-func TestClientManagerGetClientForUserExistingClientConcurrent(t *testing.T) {
+func TestClientManagerGetOrCreateUserClientsShellExistingConcurrent(t *testing.T) {
 	before := time.Now()
 	userClients := &UserClients{clients: map[string]*Client{}}
 	manager := &ClientManager{
@@ -927,9 +927,9 @@ func TestClientManagerGetClientForUserExistingClientConcurrent(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for range iterations {
-				got, errs := manager.getClientForUser(context.Background(), "user-1")
-				if got != userClients || errs != nil {
-					t.Errorf("getClientForUser returned unexpected result: got=%p errs=%v", got, errs)
+				got := manager.getOrCreateUserClientsShell("user-1")
+				if got != userClients {
+					t.Errorf("getOrCreateUserClientsShell returned unexpected result: got=%p", got)
 					return
 				}
 			}

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -471,3 +471,76 @@ func TestNewClientErrorsOnEmptyRemoteToolCatalog(t *testing.T) {
 	require.Contains(t, err.Error(), "no tools found")
 	require.Nil(t, cache.GetTools("empty"))
 }
+
+func TestClientDeclaresUIExtension(t *testing.T) {
+	assertUICaps := func(t *testing.T, caps *mcp.ClientCapabilities) {
+		t.Helper()
+		require.NotNil(t, caps)
+		// RootsV2 is json:"-" and only used when configuring ClientOptions;
+		// on the wire (and thus in InitializeParams) the deprecated Roots
+		// field is what servers observe.
+		require.True(t, caps.Roots.ListChanged) //nolint:staticcheck // SA1019: wire-visible field
+		ext, ok := caps.Extensions[UIExtensionID].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, []any{UIResourceMIMEType}, ext["mimeTypes"])
+	}
+
+	t.Run("createSession path", func(t *testing.T) {
+		var captured *mcp.ClientCapabilities
+		server := mcp.NewServer(&mcp.Implementation{Name: "cap-server", Version: "1.0"}, nil)
+		server.AddTool(&mcp.Tool{
+			Name:        "probe",
+			Description: "Capture client capabilities",
+			InputSchema: map[string]any{"type": "object"},
+		}, func(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			if params := req.Session.InitializeParams(); params != nil {
+				captured = params.Capabilities
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+			}, nil
+		})
+		httpServer := startStreamableMCPServer(t, server)
+		cache := newTestToolsCache()
+
+		client, err := NewClient(context.Background(), "user-id", ServerConfig{
+			Name:    "caps",
+			BaseURL: httpServer.URL,
+			Enabled: true,
+		}, newTestLogService(), newTestOAuthManager(), httpServer.Client(), cache, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = client.Close() })
+
+		_, err = client.CallTool(context.Background(), "probe", map[string]any{})
+		require.NoError(t, err)
+		assertUICaps(t, captured)
+	})
+
+	t.Run("embedded CreateClient path", func(t *testing.T) {
+		var captured *mcp.ClientCapabilities
+		server := mcp.NewServer(&mcp.Implementation{Name: "cap-embedded", Version: "1.0"}, nil)
+		server.AddTool(&mcp.Tool{
+			Name:        "probe",
+			Description: "Capture client capabilities",
+			InputSchema: map[string]any{"type": "object"},
+		}, func(_ context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			if params := req.Session.InitializeParams(); params != nil {
+				captured = params.Capabilities
+			}
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+			}, nil
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		embeddedClient := NewEmbeddedServerClient(&fakeEmbeddedMCPServer{ctx: ctx, server: server}, newTestLogService(), nil)
+		client, err := embeddedClient.CreateClient(context.Background(), "user-id", "")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = client.Close() })
+
+		_, err = client.CallTool(context.Background(), "probe", map[string]any{})
+		require.NoError(t, err)
+		assertUICaps(t, captured)
+	})
+}

--- a/mcp/oauth_manager.go
+++ b/mcp/oauth_manager.go
@@ -47,6 +47,12 @@ func (e *OAuthNeededError) Unwrap() error {
 	return nil
 }
 
+// NewOAuthNeededError builds an OAuthNeededError with a known auth URL,
+// for callers that detect the needs-auth state outside a live 401 challenge.
+func NewOAuthNeededError(authURL string) *OAuthNeededError {
+	return &OAuthNeededError{authURL: authURL}
+}
+
 // generateState generates a random state parameter for OAuth
 func generateState() (string, error) {
 	b := make([]byte, 16)

--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/mattermost/mattermost-plugin-agents/v2/telemetry"
@@ -16,18 +17,31 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const (
+	// MaxAppResourceBytes is the maximum accepted size of a ui:// app HTML body.
+	MaxAppResourceBytes = 4 << 20 // 4 MiB
+)
+
 // ErrServerNotConnected is returned when the user has no live session to the
 // requested MCP server and none could be established without user action.
 var ErrServerNotConnected = errors.New("no connected MCP client for server")
+
+// ErrServerNotConfigured is returned when the normalized origin matches no
+// currently enabled remote, plugin, or embedded MCP server.
+var ErrServerNotConfigured = errors.New("MCP server is not configured")
 
 // InvalidAppResourceError is returned when a ui:// resource is served with a
 // MIME type other than text/html;profile=mcp-app, or with no content.
 type InvalidAppResourceError struct {
 	URI      string
 	MIMEType string
+	Reason   string
 }
 
 func (e *InvalidAppResourceError) Error() string {
+	if e.Reason != "" {
+		return fmt.Sprintf("resource %s is not a valid MCP App resource: %s", e.URI, e.Reason)
+	}
 	return fmt.Sprintf("resource %s is not a valid MCP App resource (mimeType %q)", e.URI, e.MIMEType)
 }
 
@@ -45,6 +59,49 @@ type AppResource struct {
 	UIMeta *AppResourceUIMeta `json:"ui_meta,omitempty"`
 }
 
+type resolvedMCPOrigin struct {
+	kind       string // "remote", "embedded", "plugin"
+	serverID   string
+	remote     ServerConfig
+	plugin     PluginServerConfig
+	normalized string
+}
+
+// resolveEnabledOrigin maps a server origin to an enabled remote/plugin/embedded
+// target. Returns ErrServerNotConfigured when no enabled match exists.
+func (m *ClientManager) resolveEnabledOrigin(serverOrigin string) (*resolvedMCPOrigin, error) {
+	normalized := llm.NormalizeMCPServerOrigin(serverOrigin)
+	if normalized == "" {
+		return nil, ErrServerNotConfigured
+	}
+
+	if normalized == llm.NormalizeMCPServerOrigin(EmbeddedClientKey) {
+		if m.embeddedClient == nil || !m.config.EmbeddedServer.Enabled {
+			return nil, ErrServerNotConfigured
+		}
+		return &resolvedMCPOrigin{kind: "embedded", serverID: EmbeddedClientKey, normalized: normalized}, nil
+	}
+
+	if strings.HasPrefix(normalized, "plugin://") {
+		for _, cfg := range m.snapshotEnabledPluginServers() {
+			if llm.NormalizeMCPServerOrigin("plugin://"+cfg.PluginID) == normalized {
+				return &resolvedMCPOrigin{kind: "plugin", serverID: "plugin://" + cfg.PluginID, plugin: cfg, normalized: normalized}, nil
+			}
+		}
+		return nil, ErrServerNotConfigured
+	}
+
+	for _, server := range m.config.Servers {
+		if !server.Enabled || server.BaseURL == "" {
+			continue
+		}
+		if llm.NormalizeMCPServerOrigin(server.BaseURL) == normalized {
+			return &resolvedMCPOrigin{kind: "remote", serverID: server.Name, remote: server, normalized: normalized}, nil
+		}
+	}
+	return nil, ErrServerNotConfigured
+}
+
 // ReadAppResource fetches a ui:// resource from this MCP server via
 // resources/read, validates the MCP Apps MIME profile, and returns the HTML
 // plus the resource's _meta.ui. It reuses the client's existing session and
@@ -58,6 +115,12 @@ func (c *Client) ReadAppResource(ctx context.Context, uri string) (*AppResource,
 	)
 	defer span.End()
 
+	if err := validateUIResourceURI(uri); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
 	session := c.currentSession()
 	if session == nil {
 		err := fmt.Errorf("MCP client not connected")
@@ -68,27 +131,33 @@ func (c *Client) ReadAppResource(ctx context.Context, uri string) (*AppResource,
 
 	result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
 	if err != nil {
-		if !errors.Is(err, mcp.ErrConnectionClosed) {
-			err = fmt.Errorf("failed to read resource %s on server %s: %w", uri, c.config.Name, err)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			return nil, err
+		if errors.Is(err, mcp.ErrConnectionClosed) {
+			if reconnectErr := c.reconnect(ctx, session); reconnectErr != nil {
+				if oauthErr := c.oauthNeededError(reconnectErr); oauthErr != nil {
+					span.RecordError(oauthErr)
+					span.SetStatus(codes.Error, oauthErr.Error())
+					return nil, oauthErr
+				}
+				span.RecordError(reconnectErr)
+				span.SetStatus(codes.Error, reconnectErr.Error())
+				return nil, reconnectErr
+			}
+			session = c.currentSession()
+			if session == nil {
+				err = fmt.Errorf("MCP client not connected after reconnecting")
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
+				return nil, err
+			}
+			result, err = session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
 		}
-		if reconnectErr := c.reconnect(ctx, session); reconnectErr != nil {
-			span.RecordError(reconnectErr)
-			span.SetStatus(codes.Error, reconnectErr.Error())
-			return nil, reconnectErr
-		}
-		session = c.currentSession()
-		if session == nil {
-			err = fmt.Errorf("MCP client not connected after reconnecting")
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			return nil, err
-		}
-		result, err = session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
 		if err != nil {
-			err = fmt.Errorf("failed to read resource %s on server %s after reconnecting: %w", uri, c.config.Name, err)
+			if oauthErr := c.oauthNeededError(err); oauthErr != nil {
+				span.RecordError(oauthErr)
+				span.SetStatus(codes.Error, oauthErr.Error())
+				return nil, oauthErr
+			}
+			err = fmt.Errorf("failed to read resource %s on server %s: %w", uri, c.config.Name, err)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 			return nil, err
@@ -106,7 +175,7 @@ func (c *Client) ReadAppResource(ctx context.Context, uri string) (*AppResource,
 
 func appResourceFromReadResult(uri string, result *mcp.ReadResourceResult) (*AppResource, error) {
 	if result == nil || len(result.Contents) == 0 {
-		return nil, &InvalidAppResourceError{URI: uri}
+		return nil, &InvalidAppResourceError{URI: uri, Reason: "empty contents"}
 	}
 
 	var contents *mcp.ResourceContents
@@ -117,10 +186,7 @@ func appResourceFromReadResult(uri string, result *mcp.ReadResourceResult) (*App
 		}
 	}
 	if contents == nil {
-		contents = result.Contents[0]
-	}
-	if contents == nil {
-		return nil, &InvalidAppResourceError{URI: uri}
+		return nil, &InvalidAppResourceError{URI: uri, Reason: "no content with matching URI"}
 	}
 
 	if !IsUIResourceMIMEType(contents.MIMEType) {
@@ -129,10 +195,19 @@ func appResourceFromReadResult(uri string, result *mcp.ReadResourceResult) (*App
 
 	html := contents.Text
 	if html == "" && len(contents.Blob) > 0 {
+		if !utf8.Valid(contents.Blob) {
+			return nil, &InvalidAppResourceError{URI: uri, Reason: "invalid UTF-8 blob"}
+		}
 		html = string(contents.Blob)
 	}
 	if html == "" {
-		return nil, &InvalidAppResourceError{URI: uri, MIMEType: contents.MIMEType}
+		return nil, &InvalidAppResourceError{URI: uri, MIMEType: contents.MIMEType, Reason: "empty body"}
+	}
+	if !utf8.ValidString(html) {
+		return nil, &InvalidAppResourceError{URI: uri, Reason: "invalid UTF-8 text"}
+	}
+	if len(html) > MaxAppResourceBytes {
+		return nil, &InvalidAppResourceError{URI: uri, Reason: "resource exceeds size limit"}
 	}
 
 	return &AppResource{
@@ -150,34 +225,48 @@ func (c *UserClients) ReadAppResource(ctx context.Context, serverOrigin, uri str
 	normalized := llm.NormalizeMCPServerOrigin(serverOrigin)
 	for _, entry := range c.snapshotClients() {
 		if llm.NormalizeMCPServerOrigin(entry.client.config.BaseURL) == normalized {
-			return entry.client.ReadAppResource(ctx, uri)
+			res, err := entry.client.ReadAppResource(ctx, uri)
+			if err != nil {
+				c.rememberOAuthNeededForToolCall(entry.client, err)
+			}
+			return res, err
 		}
 	}
 	return nil, ErrServerNotConnected
 }
 
 // ReadUserAppResource fetches a ui:// resource for a user from the MCP server
-// identified by serverOrigin, establishing the user's client set on demand
-// (same connect strategy as GetToolsForUser: cached remote clients, embedded
-// session, plugin servers). Returns *OAuthNeededError when the user must
-// complete OAuth with that server first, and ErrServerNotConnected when the
-// server is unreachable for this user for any other reason.
+// identified by serverOrigin. It connects only that enabled origin into the
+// per-user client set (lazy, targeted) — unlike GetToolsForUser, it does not
+// fan out to every configured server. Returns ErrServerNotConfigured when the
+// origin is unknown or disabled, *OAuthNeededError when the user must complete
+// OAuth first, and ErrServerNotConnected when the server is otherwise unreachable.
 func (m *ClientManager) ReadUserAppResource(ctx context.Context, userID, serverOrigin, uri string) (*AppResource, error) {
-	userClient, mcpErrors := m.getClientForUser(ctx, userID)
-	normalized := llm.NormalizeMCPServerOrigin(serverOrigin)
-
-	if normalized == llm.NormalizeMCPServerOrigin(EmbeddedClientKey) {
-		m.connectEmbeddedForUser(ctx, userClient, userID)
+	target, err := m.resolveEnabledOrigin(serverOrigin)
+	if err != nil {
+		return nil, err
 	}
 
-	if strings.HasPrefix(normalized, "plugin://") {
-		for _, cfg := range m.snapshotEnabledPluginServers() {
-			if llm.NormalizeMCPServerOrigin("plugin://"+cfg.PluginID) == normalized {
-				if connectErr := userClient.ConnectToPluginServer(ctx, cfg, m.sourcePluginAPI); connectErr != nil {
-					m.log.Error("Failed to connect to plugin MCP server for app resource", "userID", userID, "pluginID", cfg.PluginID, "error", connectErr)
-				}
-				break
+	userClient := m.getOrCreateUserClientsShell(userID)
+
+	switch target.kind {
+	case "embedded":
+		m.connectEmbeddedForUser(ctx, userClient, userID)
+	case "plugin":
+		if connectErr := userClient.ConnectToPluginServer(ctx, target.plugin, m.sourcePluginAPI); connectErr != nil {
+			m.log.Error("Failed to connect to plugin MCP server for app resource",
+				"userID", userID, "pluginID", target.plugin.PluginID, "error", connectErr)
+			return nil, fmt.Errorf("%w: %v", ErrServerNotConnected, connectErr)
+		}
+	case "remote":
+		if connectErr := userClient.ConnectToRemoteServer(cacheableContext(ctx), target.remote, false); connectErr != nil {
+			var oauthErr *OAuthNeededError
+			if errors.As(connectErr, &oauthErr) {
+				return nil, oauthErr
 			}
+			m.log.Error("Failed to connect to MCP server for app resource",
+				"userID", userID, "server", target.remote.Name, "error", connectErr)
+			return nil, fmt.Errorf("%w: %v", ErrServerNotConnected, connectErr)
 		}
 	}
 
@@ -185,37 +274,21 @@ func (m *ClientManager) ReadUserAppResource(ctx context.Context, userID, serverO
 	if err == nil {
 		return res, nil
 	}
-	if !errors.Is(err, ErrServerNotConnected) {
-		return nil, err
+	var oauthErr *OAuthNeededError
+	if errors.As(err, &oauthErr) {
+		return nil, oauthErr
 	}
-
-	if mcpErrors != nil {
-		for _, ae := range mcpErrors.ToolAuthErrors {
-			if llm.NormalizeMCPServerOrigin(ae.ServerOrigin) == normalized {
-				return nil, NewOAuthNeededError(ae.AuthURL)
-			}
-		}
-	}
-
-	if m.oauthManager != nil {
-		for _, server := range m.config.Servers {
-			if llm.NormalizeMCPServerOrigin(server.BaseURL) != normalized {
-				continue
-			}
-			state, loadErr := m.oauthManager.LoadAuthNeededState(userID, server.Name)
+	if errors.Is(err, ErrServerNotConnected) {
+		if m.oauthManager != nil && target.kind == "remote" {
+			state, loadErr := m.oauthManager.LoadAuthNeededState(userID, target.remote.Name)
 			if loadErr != nil {
-				m.log.Debug("Failed to load OAuth-needed state for app resource", "userID", userID, "server", server.Name, "error", loadErr)
-				break
-			}
-			if state != nil && state.AuthURL != "" {
+				m.log.Debug("Failed to load OAuth-needed state for app resource",
+					"userID", userID, "server", target.remote.Name, "error", loadErr)
+			} else if state != nil && state.AuthURL != "" {
 				return nil, NewOAuthNeededError(state.AuthURL)
 			}
-			break
 		}
+		return nil, err
 	}
-
-	if mcpErrors != nil && len(mcpErrors.Errors) > 0 {
-		return nil, fmt.Errorf("%w: %v", ErrServerNotConnected, mcpErrors.Errors)
-	}
-	return nil, ErrServerNotConnected
+	return nil, err
 }

--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/mattermost/mattermost-plugin-agents/v2/telemetry"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ErrServerNotConnected is returned when the user has no live session to the
+// requested MCP server and none could be established without user action.
+var ErrServerNotConnected = errors.New("no connected MCP client for server")
+
+// InvalidAppResourceError is returned when a ui:// resource is served with a
+// MIME type other than text/html;profile=mcp-app, or with no content.
+type InvalidAppResourceError struct {
+	URI      string
+	MIMEType string
+}
+
+func (e *InvalidAppResourceError) Error() string {
+	return fmt.Sprintf("resource %s is not a valid MCP App resource (mimeType %q)", e.URI, e.MIMEType)
+}
+
+// AppResource is the fetched content of a ui:// MCP App resource.
+type AppResource struct {
+	// URI echoes the resource URI that was read.
+	URI string `json:"uri"`
+	// MIMEType is the validated MIME type (always the mcp-app HTML profile).
+	MIMEType string `json:"mime_type"`
+	// HTML is the raw app HTML (decoded from text or blob content).
+	HTML string `json:"html"`
+	// UIMeta is the resource's _meta.ui (csp, permissions, prefersBorder…).
+	// Nil when the server declared none; the host then applies the spec's
+	// restrictive CSP default (Phase 1b).
+	UIMeta *AppResourceUIMeta `json:"ui_meta,omitempty"`
+}
+
+// ReadAppResource fetches a ui:// resource from this MCP server via
+// resources/read, validates the MCP Apps MIME profile, and returns the HTML
+// plus the resource's _meta.ui. It reuses the client's existing session and
+// transparently reconnects once on a closed connection (same policy as
+// CallToolWithMetadata).
+func (c *Client) ReadAppResource(ctx context.Context, uri string) (*AppResource, error) {
+	ctx, span := telemetry.Tracer().Start(ctx, "mcp read resource",
+		trace.WithAttributes(
+			telemetry.MCPServer.String(c.config.Name),
+		),
+	)
+	defer span.End()
+
+	if c.session == nil {
+		err := fmt.Errorf("MCP client not connected")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	result, err := c.session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
+	if err != nil {
+		if !errors.Is(err, mcp.ErrConnectionClosed) {
+			err = fmt.Errorf("failed to read resource %s on server %s: %w", uri, c.config.Name, err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, err
+		}
+		if reconnectErr := c.reconnect(ctx); reconnectErr != nil {
+			span.RecordError(reconnectErr)
+			span.SetStatus(codes.Error, reconnectErr.Error())
+			return nil, reconnectErr
+		}
+		result, err = c.session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
+		if err != nil {
+			err = fmt.Errorf("failed to read resource %s on server %s after reconnecting: %w", uri, c.config.Name, err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, err
+		}
+	}
+
+	res, err := appResourceFromReadResult(uri, result)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+	return res, nil
+}
+
+func appResourceFromReadResult(uri string, result *mcp.ReadResourceResult) (*AppResource, error) {
+	if result == nil || len(result.Contents) == 0 {
+		return nil, &InvalidAppResourceError{URI: uri}
+	}
+
+	var contents *mcp.ResourceContents
+	for _, c := range result.Contents {
+		if c != nil && c.URI == uri {
+			contents = c
+			break
+		}
+	}
+	if contents == nil {
+		contents = result.Contents[0]
+	}
+	if contents == nil {
+		return nil, &InvalidAppResourceError{URI: uri}
+	}
+
+	if !IsUIResourceMIMEType(contents.MIMEType) {
+		return nil, &InvalidAppResourceError{URI: uri, MIMEType: contents.MIMEType}
+	}
+
+	html := contents.Text
+	if html == "" && len(contents.Blob) > 0 {
+		html = string(contents.Blob)
+	}
+	if html == "" {
+		return nil, &InvalidAppResourceError{URI: uri, MIMEType: contents.MIMEType}
+	}
+
+	return &AppResource{
+		URI:      uri,
+		MIMEType: UIResourceMIMEType,
+		HTML:     html,
+		UIMeta:   parseResourceUIMeta(contents.Meta),
+	}, nil
+}
+
+// ReadAppResource routes a ui:// resource read to the user's client for the
+// given server origin. Returns ErrServerNotConnected when no client for that
+// origin exists in this user's client set.
+func (c *UserClients) ReadAppResource(ctx context.Context, serverOrigin, uri string) (*AppResource, error) {
+	normalized := llm.NormalizeMCPServerOrigin(serverOrigin)
+	for _, entry := range c.snapshotClients() {
+		if llm.NormalizeMCPServerOrigin(entry.client.config.BaseURL) == normalized {
+			return entry.client.ReadAppResource(ctx, uri)
+		}
+	}
+	return nil, ErrServerNotConnected
+}
+
+// ReadUserAppResource fetches a ui:// resource for a user from the MCP server
+// identified by serverOrigin, establishing the user's client set on demand
+// (same connect strategy as GetToolsForUser: cached remote clients, embedded
+// session, plugin servers). Returns *OAuthNeededError when the user must
+// complete OAuth with that server first, and ErrServerNotConnected when the
+// server is unreachable for this user for any other reason.
+func (m *ClientManager) ReadUserAppResource(ctx context.Context, userID, serverOrigin, uri string) (*AppResource, error) {
+	userClient, mcpErrors := m.getClientForUser(ctx, userID)
+	normalized := llm.NormalizeMCPServerOrigin(serverOrigin)
+
+	if normalized == llm.NormalizeMCPServerOrigin(EmbeddedClientKey) {
+		m.connectEmbeddedForUser(ctx, userClient, userID)
+	}
+
+	if strings.HasPrefix(normalized, "plugin://") {
+		for _, cfg := range m.snapshotEnabledPluginServers() {
+			if llm.NormalizeMCPServerOrigin("plugin://"+cfg.PluginID) == normalized {
+				if connectErr := userClient.ConnectToPluginServer(ctx, cfg, m.sourcePluginAPI); connectErr != nil {
+					m.log.Error("Failed to connect to plugin MCP server for app resource", "userID", userID, "pluginID", cfg.PluginID, "error", connectErr)
+				}
+				break
+			}
+		}
+	}
+
+	res, err := userClient.ReadAppResource(ctx, serverOrigin, uri)
+	if err == nil {
+		return res, nil
+	}
+	if !errors.Is(err, ErrServerNotConnected) {
+		return nil, err
+	}
+
+	if mcpErrors != nil {
+		for _, ae := range mcpErrors.ToolAuthErrors {
+			if llm.NormalizeMCPServerOrigin(ae.ServerOrigin) == normalized {
+				return nil, NewOAuthNeededError(ae.AuthURL)
+			}
+		}
+	}
+
+	if m.oauthManager != nil {
+		for _, server := range m.config.Servers {
+			if llm.NormalizeMCPServerOrigin(server.BaseURL) != normalized {
+				continue
+			}
+			state, loadErr := m.oauthManager.LoadAuthNeededState(userID, server.Name)
+			if loadErr != nil {
+				m.log.Debug("Failed to load OAuth-needed state for app resource", "userID", userID, "server", server.Name, "error", loadErr)
+				break
+			}
+			if state != nil && state.AuthURL != "" {
+				return nil, NewOAuthNeededError(state.AuthURL)
+			}
+			break
+		}
+	}
+
+	if mcpErrors != nil && len(mcpErrors.Errors) > 0 {
+		return nil, fmt.Errorf("%w: %v", ErrServerNotConnected, mcpErrors.Errors)
+	}
+	return nil, ErrServerNotConnected
+}

--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -58,14 +58,15 @@ func (c *Client) ReadAppResource(ctx context.Context, uri string) (*AppResource,
 	)
 	defer span.End()
 
-	if c.session == nil {
+	session := c.currentSession()
+	if session == nil {
 		err := fmt.Errorf("MCP client not connected")
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
-	result, err := c.session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
+	result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
 	if err != nil {
 		if !errors.Is(err, mcp.ErrConnectionClosed) {
 			err = fmt.Errorf("failed to read resource %s on server %s: %w", uri, c.config.Name, err)
@@ -73,12 +74,19 @@ func (c *Client) ReadAppResource(ctx context.Context, uri string) (*AppResource,
 			span.SetStatus(codes.Error, err.Error())
 			return nil, err
 		}
-		if reconnectErr := c.reconnect(ctx); reconnectErr != nil {
+		if reconnectErr := c.reconnect(ctx, session); reconnectErr != nil {
 			span.RecordError(reconnectErr)
 			span.SetStatus(codes.Error, reconnectErr.Error())
 			return nil, reconnectErr
 		}
-		result, err = c.session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
+		session = c.currentSession()
+		if session == nil {
+			err = fmt.Errorf("MCP client not connected after reconnecting")
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return nil, err
+		}
+		result, err = session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
 		if err != nil {
 			err = fmt.Errorf("failed to read resource %s on server %s after reconnecting: %w", uri, c.config.Name, err)
 			span.RecordError(err)

--- a/mcp/resources_test.go
+++ b/mcp/resources_test.go
@@ -6,10 +6,14 @@ package mcp
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 )
@@ -155,11 +159,99 @@ func TestClientReadAppResourceReconnects(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = client.Close() })
 
-	require.NoError(t, client.session.Close())
+	require.NoError(t, client.currentSession().Close())
 
 	got, err := client.ReadAppResource(context.Background(), uri)
 	require.NoError(t, err)
 	require.Equal(t, "<html>reconnected</html>", got.HTML)
+}
+
+type countingEmbeddedMCPServer struct {
+	fakeEmbeddedMCPServer
+	creates atomic.Int32
+}
+
+func (c *countingEmbeddedMCPServer) CreateClientTransport(userID, sessionID string, pluginAPI *pluginapi.Client) (*mcp.InMemoryTransport, error) {
+	c.creates.Add(1)
+	return c.fakeEmbeddedMCPServer.CreateClientTransport(userID, sessionID, pluginAPI)
+}
+
+func TestClientReconnectSingleFlightUnderConcurrentReads(t *testing.T) {
+	const uri = "ui://embedded/app.html"
+	server := newAppResourceMCPServer(uri, UIResourceMIMEType, "<html>race</html>", nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	pluginAPI := newTestPluginAPIWithSession("session-id")
+
+	counting := &countingEmbeddedMCPServer{fakeEmbeddedMCPServer: fakeEmbeddedMCPServer{ctx: ctx, server: server}}
+	embeddedClient := NewEmbeddedServerClient(counting, pluginAPI.Log, pluginAPI)
+	client, err := embeddedClient.CreateClient(context.Background(), "test-user", "session-id")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	require.Equal(t, int32(1), counting.creates.Load())
+
+	require.NoError(t, client.currentSession().Close())
+
+	const n = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, readErr := client.ReadAppResource(context.Background(), uri)
+			if readErr != nil {
+				errs <- readErr
+				return
+			}
+			if got.HTML != "<html>race</html>" {
+				errs <- fmt.Errorf("unexpected html %q", got.HTML)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	// Initial create + exactly one reconnect.
+	require.Equal(t, int32(2), counting.creates.Load())
+}
+
+func TestClientConcurrentReadAndToolCallAfterClose(t *testing.T) {
+	const uri = "ui://embedded/app.html"
+	server := newAppResourceMCPServer(uri, UIResourceMIMEType, "<html>both</html>", nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	pluginAPI := newTestPluginAPIWithSession("session-id")
+
+	counting := &countingEmbeddedMCPServer{fakeEmbeddedMCPServer: fakeEmbeddedMCPServer{ctx: ctx, server: server}}
+	embeddedClient := NewEmbeddedServerClient(counting, pluginAPI.Log, pluginAPI)
+	client, err := embeddedClient.CreateClient(context.Background(), "test-user", "session-id")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.NoError(t, client.currentSession().Close())
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, readErr := client.ReadAppResource(context.Background(), uri)
+		errs <- readErr
+	}()
+	go func() {
+		defer wg.Done()
+		_, callErr := client.CallTool(context.Background(), "probe", map[string]any{})
+		errs <- callErr
+	}()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(2), counting.creates.Load())
 }
 
 func TestUserClientsReadAppResourceRouting(t *testing.T) {

--- a/mcp/resources_test.go
+++ b/mcp/resources_test.go
@@ -4,15 +4,19 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
@@ -294,45 +298,256 @@ func TestUserClientsReadAppResourceRouting(t *testing.T) {
 
 func TestClientManagerReadUserAppResource(t *testing.T) {
 	const (
-		userID  = "user-id"
-		origin  = "http://srv-a/"
-		uri     = "ui://srv-a/app.html"
-		authURL = "https://auth.example/start"
+		userID = "user-id"
+		uri    = "ui://srv-a/app.html"
 	)
 
-	t.Run("needs auth from initial connect errors", func(t *testing.T) {
-		userClients := NewUserClients(userID, newTestLogService(), nil, nil, nil)
-		userClients.setInitialRemoteConnectErrors(&Errors{
-			ToolAuthErrors: []llm.ToolAuthError{{
-				ServerOrigin: origin,
-				AuthURL:      authURL,
-			}},
-		})
-		m := &ClientManager{
-			clients:  map[string]*UserClients{userID: userClients},
-			activity: map[string]time.Time{userID: time.Now()},
-			log:      newTestLogService(),
-		}
-		t.Cleanup(m.Close)
-
-		got, err := m.ReadUserAppResource(context.Background(), userID, origin, uri)
-		require.Nil(t, got)
-		var oauthErr *OAuthNeededError
-		require.ErrorAs(t, err, &oauthErr)
-		require.Equal(t, authURL, oauthErr.AuthURL())
-	})
-
 	t.Run("unknown origin", func(t *testing.T) {
-		userClients := NewUserClients(userID, newTestLogService(), nil, nil, nil)
 		m := &ClientManager{
-			clients:  map[string]*UserClients{userID: userClients},
-			activity: map[string]time.Time{userID: time.Now()},
+			clients:  make(map[string]*UserClients),
+			activity: make(map[string]time.Time),
 			log:      newTestLogService(),
+			config:   Config{Servers: []ServerConfig{{Name: "srv-a", BaseURL: "http://srv-a/", Enabled: true}}},
 		}
 		t.Cleanup(m.Close)
 
 		got, err := m.ReadUserAppResource(context.Background(), userID, "http://unknown/", uri)
 		require.Nil(t, got)
-		require.ErrorIs(t, err, ErrServerNotConnected)
+		require.ErrorIs(t, err, ErrServerNotConfigured)
 	})
+
+	t.Run("disabled origin is not configured", func(t *testing.T) {
+		m := &ClientManager{
+			clients:  make(map[string]*UserClients),
+			activity: make(map[string]time.Time),
+			log:      newTestLogService(),
+			config: Config{Servers: []ServerConfig{
+				{Name: "srv-a", BaseURL: "http://srv-a/", Enabled: false},
+			}},
+		}
+		t.Cleanup(m.Close)
+
+		got, err := m.ReadUserAppResource(context.Background(), userID, "http://srv-a/", uri)
+		require.Nil(t, got)
+		require.ErrorIs(t, err, ErrServerNotConfigured)
+	})
+
+	t.Run("lazy connect dials only the target enabled server", func(t *testing.T) {
+		targetServer := newAppResourceMCPServer(uri, UIResourceMIMEType, "<html>target</html>", nil, nil)
+		otherServer := newTestMCPServer(0, "other_tool")
+		targetHTTP := startStreamableMCPServer(t, targetServer)
+		otherHTTP := startStreamableMCPServer(t, otherServer)
+
+		var targetHits, otherHits atomic.Int32
+		counting := &countingHostTransport{
+			base: http.DefaultTransport,
+			counts: map[string]*atomic.Int32{
+				targetHTTP.Listener.Addr().String(): &targetHits,
+				otherHTTP.Listener.Addr().String():  &otherHits,
+			},
+		}
+		httpClient := &http.Client{Transport: counting}
+
+		m := &ClientManager{
+			clients:      make(map[string]*UserClients),
+			activity:     make(map[string]time.Time),
+			log:          newTestLogService(),
+			httpClient:   httpClient,
+			toolsCache:   newTestToolsCache(),
+			oauthManager: newTestOAuthManager(),
+			config: Config{
+				Servers: []ServerConfig{
+					{Name: "target", BaseURL: targetHTTP.URL, Enabled: true},
+					{Name: "other", BaseURL: otherHTTP.URL, Enabled: true},
+					{Name: "disabled", BaseURL: "http://disabled.example/", Enabled: false},
+				},
+			},
+		}
+		// Close clients before httptest cleanup so SSE GETs are released.
+		t.Cleanup(func() {
+			m.Close()
+			targetHTTP.CloseClientConnections()
+			otherHTTP.CloseClientConnections()
+		})
+
+		got, err := m.ReadUserAppResource(context.Background(), userID, targetHTTP.URL, uri)
+		require.NoError(t, err)
+		require.Equal(t, "<html>target</html>", got.HTML)
+		require.Greater(t, targetHits.Load(), int32(0))
+		require.Zero(t, otherHits.Load(), "other enabled servers must not be dialed")
+		require.False(t, m.clients[userID].hasRemoteFanOutDone())
+	})
+
+	t.Run("live resources/read 401 returns OAuthNeededError", func(t *testing.T) {
+		server := newAppResourceMCPServer(uri, UIResourceMIMEType, "<html>x</html>", nil, nil)
+		// Manage lifecycle here: a mid-session 401 can leave the streamable
+		// transport wedged, so close the HTTP server before Client.Close.
+		httpServer := httptest.NewServer(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
+			return server
+		}, nil))
+		challenge := &resourcesReadChallengeTransport{base: httpServer.Client().Transport}
+		client, err := NewClient(context.Background(), userID, ServerConfig{
+			Name: "oauth-srv", BaseURL: httpServer.URL, Enabled: true,
+		}, newTestLogService(), newTestOAuthManager(), &http.Client{Transport: challenge}, newTestToolsCache(), false)
+		require.NoError(t, err)
+
+		got, readErr := client.ReadAppResource(context.Background(), uri)
+		// Close the client first so the SSE GET is released before httptest.Close.
+		_ = client.Close()
+		httpServer.CloseClientConnections()
+		httpServer.Close()
+
+		require.Nil(t, got)
+		var oauthErr *OAuthNeededError
+		require.ErrorAs(t, readErr, &oauthErr)
+		require.NotEmpty(t, oauthErr.AuthURL())
+	})
+}
+
+type countingHostTransport struct {
+	base   http.RoundTripper
+	counts map[string]*atomic.Int32
+}
+
+func (t *countingHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if counter, ok := t.counts[req.URL.Host]; ok {
+		counter.Add(1)
+	}
+	return t.base.RoundTrip(req)
+}
+
+// resourcesReadChallengeTransport lets initialize/tools succeed, then returns a
+// 401 WWW-Authenticate challenge for resources/read so oauthNeededError fires.
+type resourcesReadChallengeTransport struct {
+	base http.RoundTripper
+}
+
+func (t *resourcesReadChallengeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	// SSE session GETs and other body-less requests must pass through unchanged.
+	if req.Body == nil || req.Method == http.MethodGet {
+		return base.RoundTrip(req)
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	_ = req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	if bytes.Contains(body, []byte(`"method":"resources/read"`)) || bytes.Contains(body, []byte(`"method": "resources/read"`)) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header: http.Header{
+				"Www-Authenticate": []string{`Bearer resource_metadata="https://auth.example/.well-known/oauth-protected-resource"`},
+			},
+			Body:    io.NopCloser(strings.NewReader("")),
+			Request: req,
+		}, nil
+	}
+	return base.RoundTrip(req)
+}
+
+func TestAppResourceFromReadResultBoundary(t *testing.T) {
+	const uri = "ui://srv/app.html"
+
+	tests := []struct {
+		name     string
+		uri      string
+		result   *mcp.ReadResourceResult
+		checkErr func(t *testing.T, err error)
+		wantHTML string
+	}{
+		{
+			name: "mismatched URI rejected",
+			uri:  uri,
+			result: &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{{
+				URI: "ui://other/app.html", MIMEType: UIResourceMIMEType, Text: "<html>x</html>",
+			}}},
+			checkErr: func(t *testing.T, err error) {
+				var invalid *InvalidAppResourceError
+				require.ErrorAs(t, err, &invalid)
+				require.Contains(t, invalid.Reason, "matching URI")
+			},
+		},
+		{
+			name: "charset MIME parameter allowed",
+			uri:  uri,
+			result: &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{{
+				URI: uri, MIMEType: "text/html;profile=mcp-app;charset=utf-8", Text: "<html>ok</html>",
+			}}},
+			wantHTML: "<html>ok</html>",
+		},
+		{
+			name: "oversize rejected",
+			uri:  uri,
+			result: &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{{
+				URI: uri, MIMEType: UIResourceMIMEType, Text: strings.Repeat("a", MaxAppResourceBytes+1),
+			}}},
+			checkErr: func(t *testing.T, err error) {
+				var invalid *InvalidAppResourceError
+				require.ErrorAs(t, err, &invalid)
+				require.Contains(t, invalid.Reason, "size limit")
+			},
+		},
+		{
+			name: "invalid UTF-8 blob rejected",
+			uri:  uri,
+			result: &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{{
+				URI: uri, MIMEType: UIResourceMIMEType, Blob: []byte{0xff, 0xfe, 0xfd},
+			}}},
+			checkErr: func(t *testing.T, err error) {
+				var invalid *InvalidAppResourceError
+				require.ErrorAs(t, err, &invalid)
+				require.Contains(t, invalid.Reason, "UTF-8")
+			},
+		},
+		{
+			name: "unicode ui URI accepted via validate",
+			uri:  "ui://srv/アプリ.html",
+			result: &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{{
+				URI: "ui://srv/アプリ.html", MIMEType: UIResourceMIMEType, Text: "<html>ok</html>",
+			}}},
+			wantHTML: "<html>ok</html>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := appResourceFromReadResult(tt.uri, tt.result)
+			if tt.checkErr != nil {
+				tt.checkErr(t, err)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantHTML, got.HTML)
+		})
+	}
+}
+
+func TestValidateUIResourceURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr bool
+	}{
+		{name: "valid", uri: "ui://srv/app.html"},
+		{name: "unicode", uri: "ui://srv/アプリ.html"},
+		{name: "empty", uri: "", wantErr: true},
+		{name: "http scheme", uri: "http://evil.example/x", wantErr: true},
+		{name: "control char", uri: "ui://srv/app\x00.html", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateUIResourceURI(tt.uri)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }

--- a/mcp/resources_test.go
+++ b/mcp/resources_test.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func newAppResourceMCPServer(uri, mimeType, text string, blob []byte, uiMeta map[string]any) *mcp.Server {
+	server := mcp.NewServer(&mcp.Implementation{Name: "app-resource-server", Version: "1.0"}, nil)
+	addTestMCPTool(server, "probe")
+	server.AddResource(&mcp.Resource{
+		URI:      uri,
+		MIMEType: mimeType,
+		Name:     "app",
+	}, func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{
+				URI:      uri,
+				MIMEType: mimeType,
+				Text:     text,
+				Blob:     blob,
+				Meta:     uiMeta,
+			}},
+		}, nil
+	})
+	return server
+}
+
+func connectClientToAppResourceServer(t *testing.T, server *mcp.Server) *Client {
+	t.Helper()
+	httpServer := startStreamableMCPServer(t, server)
+	cache := newTestToolsCache()
+	client, err := NewClient(context.Background(), "user-id", ServerConfig{
+		Name:    "app-srv",
+		BaseURL: httpServer.URL,
+		Enabled: true,
+	}, newTestLogService(), newTestOAuthManager(), httpServer.Client(), cache, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func TestClientReadAppResource(t *testing.T) {
+	const uri = "ui://srv/app.html"
+	prefersBorder := true
+
+	tests := []struct {
+		name       string
+		server     *mcp.Server
+		wantHTML   string
+		wantUIMeta *AppResourceUIMeta
+		wantErr    error
+		checkErr   func(t *testing.T, err error)
+	}{
+		{
+			name: "happy path text",
+			server: newAppResourceMCPServer(uri, UIResourceMIMEType, "<html>hi</html>", nil, map[string]any{
+				"ui": map[string]any{
+					"csp":           map[string]any{"connectDomains": []any{"https://api.example"}},
+					"prefersBorder": true,
+				},
+			}),
+			wantHTML: "<html>hi</html>",
+			wantUIMeta: &AppResourceUIMeta{
+				CSP:           &AppResourceCSP{ConnectDomains: []string{"https://api.example"}},
+				PrefersBorder: &prefersBorder,
+			},
+		},
+		{
+			name:     "blob content",
+			server:   newAppResourceMCPServer(uri, UIResourceMIMEType, "", []byte("<html>blob</html>"), nil),
+			wantHTML: "<html>blob</html>",
+		},
+		{
+			name:       "no ui meta",
+			server:     newAppResourceMCPServer(uri, UIResourceMIMEType, "<html>x</html>", nil, nil),
+			wantHTML:   "<html>x</html>",
+			wantUIMeta: nil,
+		},
+		{
+			name:   "wrong MIME",
+			server: newAppResourceMCPServer(uri, "text/html", "<html>x</html>", nil, nil),
+			checkErr: func(t *testing.T, err error) {
+				var invalid *InvalidAppResourceError
+				require.ErrorAs(t, err, &invalid)
+				require.Equal(t, "text/html", invalid.MIMEType)
+			},
+		},
+		{
+			name:   "empty content",
+			server: newAppResourceMCPServer(uri, UIResourceMIMEType, "", nil, nil),
+			checkErr: func(t *testing.T, err error) {
+				var invalid *InvalidAppResourceError
+				require.ErrorAs(t, err, &invalid)
+			},
+		},
+		{
+			name: "resource not found",
+			server: func() *mcp.Server {
+				server := mcp.NewServer(&mcp.Implementation{Name: "missing", Version: "1.0"}, nil)
+				addTestMCPTool(server, "probe")
+				server.AddResource(&mcp.Resource{
+					URI:      uri,
+					MIMEType: UIResourceMIMEType,
+					Name:     "app",
+				}, func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+					return nil, mcp.ResourceNotFoundError(uri)
+				})
+				return server
+			}(),
+			checkErr: func(t *testing.T, err error) {
+				require.Error(t, err)
+				var invalid *InvalidAppResourceError
+				require.False(t, errors.As(err, &invalid))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := connectClientToAppResourceServer(t, tt.server)
+			got, err := client.ReadAppResource(context.Background(), uri)
+			if tt.checkErr != nil {
+				tt.checkErr(t, err)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, uri, got.URI)
+			require.Equal(t, UIResourceMIMEType, got.MIMEType)
+			require.Equal(t, tt.wantHTML, got.HTML)
+			require.Equal(t, tt.wantUIMeta, got.UIMeta)
+		})
+	}
+}
+
+func TestClientReadAppResourceReconnects(t *testing.T) {
+	const uri = "ui://embedded/app.html"
+	server := newAppResourceMCPServer(uri, UIResourceMIMEType, "<html>reconnected</html>", nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	pluginAPI := newTestPluginAPIWithSession("session-id")
+
+	embeddedClient := NewEmbeddedServerClient(&fakeEmbeddedMCPServer{ctx: ctx, server: server}, pluginAPI.Log, pluginAPI)
+	client, err := embeddedClient.CreateClient(context.Background(), "test-user", "session-id")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.NoError(t, client.session.Close())
+
+	got, err := client.ReadAppResource(context.Background(), uri)
+	require.NoError(t, err)
+	require.Equal(t, "<html>reconnected</html>", got.HTML)
+}
+
+func TestUserClientsReadAppResourceRouting(t *testing.T) {
+	const uri = "ui://srv-a/app.html"
+	server := newAppResourceMCPServer(uri, UIResourceMIMEType, "<html>routed</html>", nil, nil)
+	client := connectClientToAppResourceServer(t, server)
+	client.config.BaseURL = "http://srv-a/"
+
+	userClients := &UserClients{
+		userID: "user-id",
+		clients: map[string]*Client{
+			"srv-a": client,
+		},
+		log: newTestLogService(),
+	}
+
+	tests := []struct {
+		name   string
+		origin string
+		wantOK bool
+	}{
+		{name: "exact origin", origin: "http://srv-a/", wantOK: true},
+		{name: "trailing-slash variance", origin: "http://srv-a", wantOK: true},
+		{name: "unknown origin", origin: "http://other/", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := userClients.ReadAppResource(context.Background(), tt.origin, uri)
+			if !tt.wantOK {
+				require.ErrorIs(t, err, ErrServerNotConnected)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, "<html>routed</html>", got.HTML)
+		})
+	}
+}
+
+func TestClientManagerReadUserAppResource(t *testing.T) {
+	const (
+		userID  = "user-id"
+		origin  = "http://srv-a/"
+		uri     = "ui://srv-a/app.html"
+		authURL = "https://auth.example/start"
+	)
+
+	t.Run("needs auth from initial connect errors", func(t *testing.T) {
+		userClients := NewUserClients(userID, newTestLogService(), nil, nil, nil)
+		userClients.setInitialRemoteConnectErrors(&Errors{
+			ToolAuthErrors: []llm.ToolAuthError{{
+				ServerOrigin: origin,
+				AuthURL:      authURL,
+			}},
+		})
+		m := &ClientManager{
+			clients:  map[string]*UserClients{userID: userClients},
+			activity: map[string]time.Time{userID: time.Now()},
+			log:      newTestLogService(),
+		}
+		t.Cleanup(m.Close)
+
+		got, err := m.ReadUserAppResource(context.Background(), userID, origin, uri)
+		require.Nil(t, got)
+		var oauthErr *OAuthNeededError
+		require.ErrorAs(t, err, &oauthErr)
+		require.Equal(t, authURL, oauthErr.AuthURL())
+	})
+
+	t.Run("unknown origin", func(t *testing.T) {
+		userClients := NewUserClients(userID, newTestLogService(), nil, nil, nil)
+		m := &ClientManager{
+			clients:  map[string]*UserClients{userID: userClients},
+			activity: map[string]time.Time{userID: time.Now()},
+			log:      newTestLogService(),
+		}
+		t.Cleanup(m.Close)
+
+		got, err := m.ReadUserAppResource(context.Background(), userID, "http://unknown/", uri)
+		require.Nil(t, got)
+		require.ErrorIs(t, err, ErrServerNotConnected)
+	})
+}

--- a/mcp/user_clients.go
+++ b/mcp/user_clients.go
@@ -233,6 +233,12 @@ func (c *UserClients) GetTools(ctx context.Context) []llm.Tool {
 		sort.Strings(toolNames)
 		for _, toolName := range toolNames {
 			tool := clientTools[toolName]
+			uiMeta := parseToolUIMeta(tool.Meta)
+			// Spec: tools whose visibility excludes "model" MUST NOT be
+			// exposed to the agent. App-callable tools are Phase 3.
+			if !uiMeta.VisibleToModel() {
+				continue
+			}
 			runtimeToolName := llm.NamespaceMCPToolName(serverSlug, toolName)
 			// Namespacing should make cross-server duplicate bare names safe. A
 			// final collision means the slug de-dupe or upstream catalog is broken.
@@ -252,6 +258,7 @@ func (c *UserClients) GetTools(ctx context.Context) []llm.Tool {
 				Schema:       tool.InputSchema,
 				Resolver:     c.createToolResolver(client, toolName),
 				ServerOrigin: client.config.BaseURL,
+				UIMeta:       uiMeta,
 			})
 		}
 	}

--- a/mcp/user_clients.go
+++ b/mcp/user_clients.go
@@ -42,6 +42,11 @@ type UserClients struct {
 	// user client is cached; otherwise callers only see those errors once (first
 	// GetToolsForUser) and lose stable auth-required state on subsequent requests.
 	initialRemoteConnectErrors *Errors
+	// remoteFanOutDone is true after ConnectToRemoteServers has been invoked for
+	// the full configured server list (GetToolsForUser / refresh). Targeted
+	// single-server connects from ReadUserAppResource leave this false so the
+	// next GetToolsForUser still fans out to remaining servers.
+	remoteFanOutDone bool
 }
 
 type userClientSnapshot struct {
@@ -64,6 +69,9 @@ func NewUserClients(userID string, log pluginapi.LogService, oauthManager *OAuth
 func (c *UserClients) ConnectToRemoteServers(ctx context.Context, servers []ServerConfig, forceRefresh bool) *Errors {
 	if len(servers) == 0 {
 		c.log.Debug("No remote MCP servers provided for user", "userID", c.userID)
+		c.clientsMu.Lock()
+		c.remoteFanOutDone = true
+		c.clientsMu.Unlock()
 		return nil
 	}
 
@@ -73,6 +81,9 @@ func (c *UserClients) ConnectToRemoteServers(ctx context.Context, servers []Serv
 	for _, serverConfig := range servers {
 		if serverConfig.BaseURL == "" {
 			c.log.Warn("Skipping MCP server with empty BaseURL", "serverID", serverConfig.Name)
+			continue
+		}
+		if !forceRefresh && c.hasClient(serverConfig.Name) {
 			continue
 		}
 
@@ -99,7 +110,28 @@ func (c *UserClients) ConnectToRemoteServers(ctx context.Context, servers []Serv
 		}
 	}
 
+	c.clientsMu.Lock()
+	c.remoteFanOutDone = true
+	c.clientsMu.Unlock()
 	return mcpErrors
+}
+
+func (c *UserClients) hasRemoteFanOutDone() bool {
+	c.clientsMu.RLock()
+	defer c.clientsMu.RUnlock()
+	return c.remoteFanOutDone
+}
+
+// ConnectToRemoteServer connects a single remote MCP server into this user's
+// client set when not already present (unless forceRefresh).
+func (c *UserClients) ConnectToRemoteServer(ctx context.Context, serverConfig ServerConfig, forceRefresh bool) error {
+	if serverConfig.BaseURL == "" {
+		return fmt.Errorf("empty BaseURL for MCP server %s", serverConfig.Name)
+	}
+	if !forceRefresh && c.hasClient(serverConfig.Name) {
+		return nil
+	}
+	return c.connectToServer(ctx, serverConfig.Name, serverConfig, forceRefresh)
 }
 
 // ConnectToEmbeddedServerIfAvailable connects to the embedded server if session ID is provided.

--- a/mcp/user_clients.go
+++ b/mcp/user_clients.go
@@ -179,6 +179,12 @@ func (c *UserClients) connectToServer(ctx context.Context, serverID string, serv
 	}
 	c.clientsMu.Lock()
 	defer c.clientsMu.Unlock()
+	if existing := c.clients[serverID]; existing != nil {
+		// Close the map entry we are about to overwrite. Concurrent cold
+		// ConnectToRemoteServer callers can both pass hasClient and each
+		// create a client; without this the loser leaks.
+		_ = existing.Close()
+	}
 	c.clients[serverID] = serverClient
 	return nil
 }

--- a/mcp/user_clients_test.go
+++ b/mcp/user_clients_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 	plugintest "github.com/mattermost/mattermost/server/public/plugin/plugintest"
@@ -373,4 +374,105 @@ func testClientWithTools(name, baseURL string, toolNames ...string) *Client {
 		},
 		tools: tools,
 	}
+}
+
+func TestGetToolsPreservesUIMeta(t *testing.T) {
+	tests := []struct {
+		name       string
+		toolMeta   gomcp.Meta
+		wantAbsent bool
+		wantUIMeta *llm.ToolUIMeta
+	}{
+		{
+			name: "nested ui meta",
+			toolMeta: gomcp.Meta{
+				"ui": map[string]any{"resourceUri": "ui://a/b"},
+			},
+			wantUIMeta: &llm.ToolUIMeta{ResourceURI: "ui://a/b"},
+		},
+		{
+			name: "legacy flat meta",
+			toolMeta: gomcp.Meta{
+				"ui/resourceUri": "ui://a/b",
+			},
+			wantUIMeta: &llm.ToolUIMeta{ResourceURI: "ui://a/b"},
+		},
+		{
+			name:       "no meta",
+			toolMeta:   nil,
+			wantUIMeta: nil,
+		},
+		{
+			name: "app-only tool",
+			toolMeta: gomcp.Meta{
+				"ui": map[string]any{"visibility": []any{"app"}},
+			},
+			wantAbsent: true,
+		},
+		{
+			name: "model+app tool",
+			toolMeta: gomcp.Meta{
+				"ui": map[string]any{
+					"resourceUri": "ui://a/b",
+					"visibility":  []any{"model", "app"},
+				},
+			},
+			wantUIMeta: &llm.ToolUIMeta{
+				ResourceURI: "ui://a/b",
+				Visibility:  []string{"model", "app"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userClients := &UserClients{
+				userID: "user-id",
+				clients: map[string]*Client{
+					"srv": {
+						config: ServerConfig{
+							Name:    "srv",
+							BaseURL: "https://srv.example/mcp",
+							Enabled: true,
+						},
+						tools: map[string]*gomcp.Tool{
+							"demo": {
+								Name:        "demo",
+								Description: "Demo tool",
+								Meta:        tt.toolMeta,
+							},
+						},
+					},
+				},
+			}
+
+			tools := userClients.GetTools(context.Background())
+			if tt.wantAbsent {
+				require.Empty(t, tools)
+				return
+			}
+			require.Len(t, tools, 1)
+			require.Equal(t, tt.wantUIMeta, tools[0].UIMeta)
+		})
+	}
+
+	t.Run("cache round-trips _meta", func(t *testing.T) {
+		cache := newTestToolsCache()
+		tool := &gomcp.Tool{
+			Name:        "cached",
+			Description: "Cached tool",
+			InputSchema: map[string]any{"type": "object"},
+			Meta: gomcp.Meta{
+				"ui": map[string]any{"resourceUri": "ui://cached/app"},
+			},
+		}
+		require.NoError(t, cache.SetTools("srv", "srv", "https://srv.example/mcp", map[string]*gomcp.Tool{
+			"cached": tool,
+		}, time.Now()))
+
+		cached := cache.GetTools("srv")
+		require.NotNil(t, cached)
+		require.Contains(t, cached, "cached")
+		require.Equal(t, "ui://cached/app", parseToolUIMeta(cached["cached"].Meta).ResourceURI)
+	})
 }

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -156,6 +156,7 @@ func (a *turnAccumulator) buildContentBlocks() []conversation.ContentBlock {
 			Shared:           conversation.BoolPtr(a.isDM),
 			UserInteraction:  tc.UserInteraction,
 			WouldAutoExecute: tc.WouldAutoExecute,
+			UIMeta:           tc.UIMeta,
 		})
 	}
 
@@ -444,8 +445,10 @@ func isResolvedToolCallsEvent(toolCalls []llm.ToolCall) bool {
 	return true
 }
 
-// redactToolCalls returns a copy of the tool calls with Arguments and Result
-// cleared so that non-requesters see tool names and status but not payloads.
+// redactToolCalls returns a copy of the tool calls with Arguments, Result,
+// and UIMeta cleared so that non-requesters see tool names and status but
+// not payloads or app-resource pointers. Onlookers obtain UIMeta via
+// GET /conversations/:id once the result is shared.
 func redactToolCalls(toolCalls []llm.ToolCall) []llm.ToolCall {
 	redacted := make([]llm.ToolCall, len(toolCalls))
 	for i, tc := range toolCalls {

--- a/streaming/turn_persistence_test.go
+++ b/streaming/turn_persistence_test.go
@@ -1516,3 +1516,43 @@ func TestRedactToolCallsPreservesUserInteraction(t *testing.T) {
 	require.Equal(t, llm.UserInteractionSelect, redacted[0].UserInteraction)
 	require.True(t, redacted[0].WouldAutoExecute)
 }
+
+func TestRedactToolCallsClearsUIMeta(t *testing.T) {
+	uiMeta := &llm.ToolUIMeta{ResourceURI: "ui://srv/app.html"}
+	redacted := redactToolCalls([]llm.ToolCall{{
+		ID:           "tc1",
+		Name:         "demo",
+		ServerOrigin: "https://srv.example",
+		Status:       llm.ToolCallStatusSuccess,
+		Arguments:    json.RawMessage(`{"q":1}`),
+		Result:       "ok",
+		UIMeta:       uiMeta,
+	}})
+
+	require.Len(t, redacted, 1)
+	require.Nil(t, redacted[0].UIMeta)
+	require.Equal(t, "tc1", redacted[0].ID)
+	require.Equal(t, "demo", redacted[0].Name)
+	require.Equal(t, "https://srv.example", redacted[0].ServerOrigin)
+	require.Equal(t, llm.ToolCallStatusSuccess, redacted[0].Status)
+	require.Empty(t, redacted[0].Arguments)
+	require.Empty(t, redacted[0].Result)
+}
+
+func TestBuildContentBlocksCarriesUIMeta(t *testing.T) {
+	uiMeta := &llm.ToolUIMeta{ResourceURI: "ui://srv/app.html"}
+	acc := &turnAccumulator{
+		toolCalls: []llm.ToolCall{{
+			ID:           "tc1",
+			Name:         "demo",
+			ServerOrigin: "https://srv.example",
+			Status:       llm.ToolCallStatusPending,
+			UIMeta:       uiMeta,
+		}},
+	}
+
+	blocks := acc.buildContentBlocks()
+	require.Len(t, blocks, 1)
+	require.Equal(t, conversation.BlockTypeToolUse, blocks[0].Type)
+	require.Equal(t, uiMeta, blocks[0].UIMeta)
+}

--- a/toolrunner/toolrunner.go
+++ b/toolrunner/toolrunner.go
@@ -541,6 +541,7 @@ func buildResolvedToolCalls(toolCalls []llm.ToolCall, toolResults []ToolResult) 
 			Schema:       tc.Schema,
 			ServerOrigin: tc.ServerOrigin,
 			MCPBareName:  tc.MCPBareName,
+			UIMeta:       tc.UIMeta,
 		}
 		if toolResults[i].IsError {
 			resolved[i].Status = llm.ToolCallStatusError

--- a/toolrunner/toolrunner_test.go
+++ b/toolrunner/toolrunner_test.go
@@ -17,6 +17,25 @@ import (
 	"github.com/mattermost/mattermost-plugin-agents/v2/llm"
 )
 
+func TestBuildResolvedToolCallsCarriesUIMeta(t *testing.T) {
+	uiMeta := &llm.ToolUIMeta{ResourceURI: "ui://srv/app.html", Visibility: []string{"model", "app"}}
+	toolCalls := []llm.ToolCall{{
+		ID:           "tc1",
+		Name:         "demo",
+		Description:  "Demo",
+		Arguments:    json.RawMessage(`{}`),
+		ServerOrigin: "https://srv.example",
+		MCPBareName:  "demo",
+		UIMeta:       uiMeta,
+	}}
+	results := []ToolResult{{Result: "ok", IsError: false}}
+
+	resolved := buildResolvedToolCalls(toolCalls, results)
+	require.Len(t, resolved, 1)
+	assert.Equal(t, uiMeta, resolved[0].UIMeta)
+	assert.Equal(t, llm.ToolCallStatusAutoApproved, resolved[0].Status)
+}
+
 // testLLM implements llm.LanguageModel with scripted responses.
 type testLLM struct {
 	responses []testResponse


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

First PR in a 3-PR stack adding [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview) (`io.modelcontextprotocol/ui`, spec 2026-01-26) host support to the Agents plugin. This PR is backend-only plumbing; nothing user-visible changes yet.

- Bumps `modelcontextprotocol/go-sdk` to v1.6.1 and declares the `io.modelcontextprotocol/ui` extension (with required `mimeTypes: ["text/html;profile=mcp-app"]`) in client capabilities during MCP handshake.
- Parses and preserves tool `_meta.ui` (canonical nested form; deprecated flat `ui/resourceUri` accepted as fallback) into `llm.Tool`, and plumbs it through `llm.ToolCall` → `conversation.ContentBlock` (`tool_use`) → the `postupdate` websocket payload and `GET /conversations/:id`. Tools with `visibility: ["app"]` are hidden from the model. UI metadata is redacted for non-requesters until the result is shared.
- Adds `ReadAppResource` to the MCP client layer: per-user, lazily connects only the target server, locked session access with single-flight reconnect, 4 MiB size cap, exact-URI match, UTF-8 and `text/html;profile=mcp-app` MIME validation.
- New authenticated endpoint `GET /mcp/app-resource?post_id=&tool_call_id=`: derives the server origin and `ui://` URI exclusively from the persisted tool_use block (unforgeable), enforces the authorization invariant — caller can read the conversation, result shared or caller is requester, caller has/establishes their own session to that server — and returns a spec-shaped MCP `ReadResourceResult` (`contents[].uri/mimeType/text/_meta.ui`). Error taxonomy: `401 mcp_auth_required` (+ OAuth start URL), `403 forbidden`, `404`, `502` with fixed non-sensitive messages.
- `conversation.FindToolCallBlocks` resolves tool calls scoped to the response owned by the anchoring post, rejecting ambiguous duplicate tool-call IDs.

Review process: implemented via a prescriptive plan, then two independent strict review passes with all blockers/majors remediated (session concurrency single-flight, lazy origin-targeted connect, response-owned turn spans, spec-shaped response contract, resource boundary hardening, error hygiene).

Testing: table-driven unit tests throughout (`go test -race` clean) — endpoint authorization matrix (20+ cases incl. cross-round duplicate-ID and needs-auth vs forbidden), meta parsing edge cases, concurrent reconnect races, live-401-during-read OAuth detection against real in-memory/HTTP go-sdk fixtures. End-to-end validation (browser demo with a real MCP App) is in the final PR of the stack.

#### Release Note

```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e193627-47b6-4074-867c-9f4abddfa67d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e193627-47b6-4074-867c-9f4abddfa67d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added support for MCP Apps, allowing compatible tools to provide interactive HTML resources and UI metadata.
- Added an authenticated endpoint for retrieving app resources.
- MCP clients now advertise UI capabilities and can reconnect automatically when reading resources or executing tools.

## Bug Fixes
- Preserved tool UI metadata throughout conversations, streaming, persistence, and tool execution.
- Improved privacy controls by hiding UI metadata and unshared tool details from non-requesters.
- Added validation for resource formats, permissions, visibility, and duplicate tool calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->