### PR TITLE
[MM-69856] Append Zoom chat continuation lines to prior message

### DIFF
--- a/subtitles/subtitles.go
+++ b/subtitles/subtitles.go
@@ -19,28 +19,31 @@ type Subtitles struct {
 
 func readZoomChat(chat io.Reader) (*astisub.Subtitles, error) {
 	storage := astisub.NewSubtitles()
+	zeroTime, err := time.Parse("15:04:05", "00:00:00")
+	if err != nil {
+		return nil, err
+	}
 
 	scanner := bufio.NewScanner(chat)
 	for scanner.Scan() {
 		line := scanner.Text()
-		// Zoom chat lines are "HH:MM:SS <text>". Continuation/short lines lack a timestamp.
-		if len(line) < 9 {
+		// Timestamped Zoom lines are "HH:MM:SS <text>". Anything else is a continuation.
+		if len(line) >= 9 {
+			if startAt, parseErr := time.Parse("15:04:05", line[:8]); parseErr == nil {
+				item := &astisub.Item{
+					StartAt: startAt.Sub(zeroTime),
+					EndAt:   startAt.Add(5 * time.Second).Sub(zeroTime),
+					Lines:   []astisub.Line{{Items: []astisub.LineItem{{Text: line[9:]}}}},
+				}
+				storage.Items = append(storage.Items, item)
+				continue
+			}
+		}
+		if len(storage.Items) == 0 {
 			continue
 		}
-		text := line[9:]
-		item := &astisub.Item{}
-		startAt, err := time.Parse("15:04:05", line[:8])
-		if err != nil {
-			return nil, err
-		}
-		zeroTime, err := time.Parse("15:04:05", "00:00:00")
-		if err != nil {
-			return nil, err
-		}
-		item.StartAt = startAt.Sub(zeroTime)
-		item.EndAt = startAt.Add(5 * time.Second).Sub(zeroTime)
-		item.Lines = append(item.Lines, astisub.Line{Items: []astisub.LineItem{{Text: text}}})
-		storage.Items = append(storage.Items, item)
+		last := storage.Items[len(storage.Items)-1]
+		last.Lines = append(last.Lines, astisub.Line{Items: []astisub.LineItem{{Text: line}}})
 	}
 	return storage, nil
 }

--- a/subtitles/subtitles.go
+++ b/subtitles/subtitles.go
@@ -27,8 +27,8 @@ func readZoomChat(chat io.Reader) (*astisub.Subtitles, error) {
 	scanner := bufio.NewScanner(chat)
 	for scanner.Scan() {
 		line := scanner.Text()
-		// Timestamped Zoom lines are "HH:MM:SS <text>". Anything else is a continuation.
-		if len(line) >= 9 {
+		// Timestamped Zoom lines are "HH:MM:SS <text>" (space or tab separator).
+		if len(line) >= 9 && (line[8] == ' ' || line[8] == '\t') {
 			if startAt, parseErr := time.Parse("15:04:05", line[:8]); parseErr == nil {
 				item := &astisub.Item{
 					StartAt: startAt.Sub(zeroTime),
@@ -44,6 +44,9 @@ func readZoomChat(chat io.Reader) (*astisub.Subtitles, error) {
 		}
 		last := storage.Items[len(storage.Items)-1]
 		last.Lines = append(last.Lines, astisub.Line{Items: []astisub.LineItem{{Text: line}}})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
 	}
 	return storage, nil
 }

--- a/subtitles/subtitles_test.go
+++ b/subtitles/subtitles_test.go
@@ -4,6 +4,8 @@
 package subtitles
 
 import (
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -89,6 +91,18 @@ more of the message here
 			input:     "x\nnot-time More text here\n",
 			wantEmpty: true,
 		},
+		{
+			name: "tab-separated timestamp lines are accepted",
+			input: "00:00:01\tAlice: Hello\n" +
+				"00:00:05\tBob: Hi",
+			wantLLM: "00:01 to 00:06 - Alice: Hello\n00:05 to 00:10 - Bob: Hi",
+		},
+		{
+			name: "malformed timestamp separator appends as continuation",
+			input: `00:00:01 Alice: Hello
+00:00:05XBob: Hi`,
+			wantLLM: "00:01 to 00:06 - Alice: Hello - 00:00:05XBob: Hi",
+		},
 	}
 
 	for _, tc := range tests {
@@ -110,4 +124,25 @@ more of the message here
 			require.Equal(t, tc.wantLLM, subs.FormatForLLM())
 		})
 	}
+}
+
+func TestNewSubtitlesFromZoomChatScannerError(t *testing.T) {
+	t.Parallel()
+
+	reader := io.MultiReader(
+		strings.NewReader("00:00:01 Alice: Hello\n"),
+		errReader{err: errors.New("read failed")},
+	)
+
+	subs, err := NewSubtitlesFromZoomChat(reader)
+	require.ErrorContains(t, err, "read failed")
+	require.Nil(t, subs)
+}
+
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read([]byte) (int, error) {
+	return 0, r.err
 }

--- a/subtitles/subtitles_test.go
+++ b/subtitles/subtitles_test.go
@@ -58,11 +58,10 @@ func TestNewSubtitlesFromZoomChat(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		input           string
-		wantLLM         string
-		wantEmpty       bool
-		wantErrContains string
+		name      string
+		input     string
+		wantLLM   string
+		wantEmpty bool
 	}{
 		{
 			name: "valid zoom chat lines",
@@ -71,22 +70,24 @@ func TestNewSubtitlesFromZoomChat(t *testing.T) {
 			wantLLM: "00:01 to 00:06 - Alice: Hello everyone\n00:05 to 00:10 - Bob: Hi Alice",
 		},
 		{
-			name: "short continuation lines are skipped",
+			name: "short continuation lines append to previous item",
 			input: `00:00:01 Alice: Hello
 x
 00:00:05 Bob: Hi
 ab`,
-			wantLLM: "00:01 to 00:06 - Alice: Hello\n00:05 to 00:10 - Bob: Hi",
+			wantLLM: "00:01 to 00:06 - Alice: Hello - x\n00:05 to 00:10 - Bob: Hi - ab",
 		},
 		{
-			name:      "only short lines yields empty subtitles",
-			input:     "x\nab\n",
+			name: "long continuation lines append instead of failing parse",
+			input: `00:00:01 Alice: Hello
+more of the message here
+00:00:05 Bob: Hi`,
+			wantLLM: "00:01 to 00:06 - Alice: Hello - more of the message here\n00:05 to 00:10 - Bob: Hi",
+		},
+		{
+			name:      "only non-timestamp lines yields empty subtitles",
+			input:     "x\nnot-time More text here\n",
 			wantEmpty: true,
-		},
-		{
-			name:            "invalid timestamp returns error",
-			input:           "not-time More text here",
-			wantErrContains: "parsing time",
 		},
 	}
 
@@ -99,11 +100,6 @@ ab`,
 			require.NotPanics(t, func() {
 				subs, err = NewSubtitlesFromZoomChat(strings.NewReader(tc.input))
 			})
-
-			if tc.wantErrContains != "" {
-				require.ErrorContains(t, err, tc.wantErrContains)
-				return
-			}
 
 			require.NoError(t, err)
 			require.NotNil(t, subs)


### PR DESCRIPTION
#### Summary
Follow-up to #906: treat a valid `HH:MM:SS` timestamp as the discriminator for Zoom chat lines. Non-timestamp lines (short or long) append to the previous message instead of being skipped or failing the entire parse.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69856

#### Release Note
```release-note
Improved Zoom chat transcription parsing so multiline continuation messages are preserved when summarizing meetings.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of Zoom chat transcripts when generating subtitles.
  * Subtitle timing and text now better match `HH:MM:SS <text>` lines, with consistent subtitle durations.
  * Continuation lines are appended to the preceding subtitle (including short, multi-line, and malformed-separator cases).
  * Transcripts containing only non-timestamp lines no longer produce invalid subtitles.
* **Tests**
  * Updated Zoom chat parsing coverage and added a test to ensure underlying reader/scanner failures surface as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->