### PR TITLE
fix: guard nil map in web search context to prevent plugin crash

### DIFF
--- a/conversations/web_search_context.go
+++ b/conversations/web_search_context.go
@@ -60,6 +60,13 @@ func (c *Conversations) unmarshalWebSearchContext(webSearchContextJSON string, p
 		return nil
 	}
 
+	// Unmarshaling the literal JSON "null" succeeds and leaves params nil, which
+	// would make the unconditional writes below panic ("assignment to entry in
+	// nil map"). A user can set this prop to any value, so guard against it.
+	if params == nil {
+		params = make(map[string]interface{})
+	}
+
 	// Reconstruct proper types for web search context values
 	if raw, ok := params[mmtools.WebSearchContextKey]; ok {
 		// Re-marshal and unmarshal to get proper types

--- a/conversations/web_search_context_test.go
+++ b/conversations/web_search_context_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2023-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package conversations
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-agents/v2/mmapi/mocks"
+	"github.com/mattermost/mattermost-plugin-agents/v2/mmtools"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalWebSearchContext(t *testing.T) {
+	cases := []struct {
+		name          string
+		json          string
+		wantNil       bool
+		wantResetKeys bool
+	}{
+		{
+			// A user (or buggy client) can set the web_search_context post prop
+			// to the literal JSON "null". json.Unmarshal succeeds and leaves the
+			// target map nil, so the unconditional writes that follow used to
+			// panic with "assignment to entry in nil map" and crash the plugin.
+			name:          "literal null does not panic",
+			json:          "null",
+			wantResetKeys: true,
+		},
+		{
+			name:          "empty object resets tracking",
+			json:          "{}",
+			wantResetKeys: true,
+		},
+		{
+			name:          "valid context is parsed and tracking reset",
+			json:          `{"mm_web_search_allowed_urls":["https://example.com"]}`,
+			wantResetKeys: true,
+		},
+		{
+			name:    "invalid json returns nil",
+			json:    "{not-json",
+			wantNil: true,
+		},
+		{
+			name:    "non-object json returns nil",
+			json:    "123",
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mmClient := mocks.NewMockClient(t)
+			mmClient.EXPECT().LogDebug(mock.Anything, mock.Anything).Maybe()
+			mmClient.EXPECT().LogError(mock.Anything, mock.Anything).Maybe()
+
+			c := &Conversations{mmClient: mmClient}
+
+			params := c.unmarshalWebSearchContext(tc.json, "post-id")
+
+			if tc.wantNil {
+				require.Nil(t, params)
+				return
+			}
+
+			require.NotNil(t, params)
+			if tc.wantResetKeys {
+				require.Equal(t, 0, params[mmtools.WebSearchCountKey])
+				require.Equal(t, []string{}, params[mmtools.WebSearchExecutedQueriesKey])
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Fixes a crash when parsing the `web_search_context` post prop.

In `conversations/web_search_context.go`, `unmarshalWebSearchContext` unmarshals the prop value into a `map[string]interface{}`. For certain inputs `json.Unmarshal` succeeds but leaves the map nil, and the unconditional writes that follow then panic:

```
panic: assignment to entry in nil map
  conversations/web_search_context.go:100
```

**Fix:** guard against a nil map right after a successful unmarshal (`if params == nil { params = make(map[string]interface{}) }`). This is the minimal change that addresses the root cause — the subsequent writes are now always safe regardless of the prop value.

Added a table-driven test (`TestUnmarshalWebSearchContext`) covering the nil-map case, empty object, a valid context payload, invalid JSON, and non-object JSON.

**QA / proof:**

Before the fix, the parsing path panicked at `web_search_context.go:100` (`assignment to entry in nil map`). After the fix, all cases pass:

```
--- PASS: TestUnmarshalWebSearchContext (0.00s)
    --- PASS: TestUnmarshalWebSearchContext/literal_null_does_not_panic (0.00s)
    --- PASS: TestUnmarshalWebSearchContext/empty_object_resets_tracking (0.00s)
    --- PASS: TestUnmarshalWebSearchContext/valid_context_is_parsed_and_tracking_reset (0.00s)
    --- PASS: TestUnmarshalWebSearchContext/invalid_json_returns_nil (0.00s)
    --- PASS: TestUnmarshalWebSearchContext/non-object_json_returns_nil (0.00s)
ok  github.com/mattermost/mattermost-plugin-agents/v2/conversations
```

Full `conversations` package tests, `go vet`, and `golangci-lint` all pass.

#### Ticket Link

<!-- none provided -->

#### Release Note

```release-note
Fixed a crash when parsing certain values of the web_search_context post prop.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-214fa6fe-be61-499c-9634-61ed5b04bb5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-214fa6fe-be61-499c-9634-61ed5b04bb5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause web search context processing to fail when stored context was empty or represented as `null`.
  * Improved handling of invalid or non-object context data to prevent unexpected errors.

* **Tests**
  * Added coverage for empty, valid, `null`, invalid, and non-object context values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->