### PR TITLE
webapp: harden LLMBotPost handling of free-form post props

### DIFF
--- a/webapp/src/client.test.ts
+++ b/webapp/src/client.test.ts
@@ -10,6 +10,8 @@ import manifest from './manifest';
 
 import {
     doLoopInAgent,
+    getConversation,
+    getConversationContext,
     normalizeConversationResponse,
     searchAllChannels,
     setSiteURL,
@@ -71,7 +73,7 @@ function okResponse(): Response {
 // Mattermost IDs are 26 characters of lowercase letters and digits.
 const WELL_FORMED_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
 
-// The post id reaches doLoopInAgent straight off a post prop, so a caller can hand it anything.
+// These ids reach the client straight off free-form post props, so a caller can hand them anything.
 const NOT_WELL_FORMED_IDS: Array<{name: string; id: string}> = [
     {name: 'empty', id: ''},
     {name: 'relative path segments', id: '../../some/other/route'},
@@ -221,6 +223,40 @@ describe('doLoopInAgent', () => {
 
     test.each(NOT_WELL_FORMED_IDS)('does not issue a request when the post id is not well-formed: $name', async ({id}) => {
         await expect(doLoopInAgent(id, 'matty')).rejects.toThrow();
+
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+});
+
+describe('getConversation', () => {
+    test('requests the conversation route for a well-formed id', async () => {
+        await expect(getConversation(WELL_FORMED_ID)).resolves.toEqual({turns: []});
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url, options] = mockFetch.mock.calls[0];
+        expect(url).toBe(`${siteURL}/plugins/${manifest.id}/conversations/${WELL_FORMED_ID}`);
+        expect(options).toEqual(expect.objectContaining({method: 'GET'}));
+    });
+
+    test.each(NOT_WELL_FORMED_IDS)('does not issue a request when the conversation id is not well-formed: $name', async ({id}) => {
+        await expect(getConversation(id)).rejects.toThrow();
+
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+});
+
+describe('getConversationContext', () => {
+    test('requests the conversation context route for a well-formed id', async () => {
+        await expect(getConversationContext(WELL_FORMED_ID)).resolves.toEqual({});
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url, options] = mockFetch.mock.calls[0];
+        expect(url).toBe(`${siteURL}/plugins/${manifest.id}/conversations/${WELL_FORMED_ID}/context`);
+        expect(options).toEqual(expect.objectContaining({method: 'GET'}));
+    });
+
+    test.each(NOT_WELL_FORMED_IDS)('does not issue a request when the conversation id is not well-formed: $name', async ({id}) => {
+        await expect(getConversationContext(id)).rejects.toThrow();
 
         expect(mockFetch).not.toHaveBeenCalled();
     });

--- a/webapp/src/client.tsx
+++ b/webapp/src/client.tsx
@@ -60,17 +60,21 @@ function baseRoute(): string {
     return `${Client4.url}/plugins/${manifest.id}`;
 }
 
-// Encoded so the id can only ever occupy one path segment.
+// Interpolated ids are encoded so each one can only ever occupy one path segment.
 function postRoute(postid: string): string {
     return `${baseRoute()}/post/${encodeURIComponent(postid)}`;
 }
 
 function channelRoute(channelid: string): string {
-    return `${baseRoute()}/channel/${channelid}`;
+    return `${baseRoute()}/channel/${encodeURIComponent(channelid)}`;
 }
 
 function agentRoute(agentId: string): string {
-    return `${baseRoute()}/agents/${agentId}`;
+    return `${baseRoute()}/agents/${encodeURIComponent(agentId)}`;
+}
+
+function conversationRoute(conversationId: string): string {
+    return `${baseRoute()}/conversations/${encodeURIComponent(conversationId)}`;
 }
 
 // readAgentErrorMessage extracts the server-provided error message from an
@@ -352,7 +356,17 @@ export function normalizeConversationResponse(raw: ConversationResponse): Conver
 }
 
 export async function getConversation(conversationId: string): Promise<ConversationResponse> {
-    const url = `${baseRoute()}/conversations/${conversationId}`;
+    // The id can arrive straight off a free-form post prop; refuse to build a
+    // request from a value that is not a well-formed id.
+    if (!isValidId(conversationId)) {
+        throw new ClientError(Client4.url, {
+            message: 'Invalid conversation id',
+            status_code: 400,
+            url: Client4.url,
+        });
+    }
+
+    const url = conversationRoute(conversationId);
     const response = await fetch(url, Client4.getOptions({
         method: 'GET',
     }));
@@ -370,7 +384,16 @@ export async function getConversation(conversationId: string): Promise<Conversat
 }
 
 export async function getConversationContext(conversationId: string): Promise<Composition> {
-    const url = `${baseRoute()}/conversations/${conversationId}/context`;
+    // Same as getConversation: never build a request from a malformed id.
+    if (!isValidId(conversationId)) {
+        throw new ClientError(Client4.url, {
+            message: 'Invalid conversation id',
+            status_code: 400,
+            url: Client4.url,
+        });
+    }
+
+    const url = `${conversationRoute(conversationId)}/context`;
     const response = await fetch(url, Client4.getOptions({
         method: 'GET',
     }));

--- a/webapp/src/components/llmbot_post/llmbot_post.test.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.test.tsx
@@ -10,6 +10,8 @@ import {WebSocketMessage} from '@mattermost/client';
 
 import {useConversation} from '@/hooks/use_conversation';
 
+import {MAX_SEARCH_SOURCES} from '../search_sources';
+
 import {LLMBotPost, PostUpdateWebsocketMessage} from './llmbot_post';
 
 jest.mock('react-redux', () => ({
@@ -58,20 +60,41 @@ jest.mock('../tool_approval_set', () => ({
     default: () => null,
 }));
 
+// The preview fetches the source post and profile on mount; stub it out so the
+// source list can render without a client.
+jest.mock('../post_preview', () => ({
+    PostPreview: () => null,
+}));
+
 const mockUseSelector = useSelector as unknown as jest.Mock;
 const mockUseConversation = useConversation as jest.Mock;
 
 type PostUpdateHandler = (msg: WebSocketMessage<PostUpdateWebsocketMessage>) => void;
 
-function makePost(message = '') {
+// Mattermost IDs are 26 characters of lowercase letters and digits.
+const WELL_FORMED_ID = 'c7f2m9xq4v1b8n3k6t5w0hzjd2';
+
+function makePost(message = '', props: Record<string, unknown> = {}) {
     return {
         id: 'post_1',
         channel_id: 'channel_1',
         root_id: 'root_1',
         message,
         props: {
-            conversation_id: 'conversation_1',
+            conversation_id: WELL_FORMED_ID,
+            ...props,
         },
+    };
+}
+
+// Builds a search source entry with a unique well-formed post id.
+function makeSource(i: number) {
+    return {
+        postId: String(i).padStart(26, '0'),
+        channelId: WELL_FORMED_ID,
+        userId: WELL_FORMED_ID,
+        content: `source message ${i}`,
+        score: 0.5,
     };
 }
 
@@ -165,5 +188,66 @@ describe('LLMBotPost streaming fallback rendering', () => {
             expect(screen.getByText(errorText)).toBeTruthy();
         });
         expect(screen.queryByText('Starting...')).toBeNull();
+    });
+});
+
+describe('LLMBotPost conversation_id prop handling', () => {
+    // Keep call assertions scoped to each test; the file-level beforeEach only
+    // re-stubs the return value.
+    beforeEach(() => {
+        mockUseConversation.mockClear();
+    });
+
+    test('passes a well-formed conversation_id to useConversation', () => {
+        renderPost();
+
+        expect(mockUseConversation).toHaveBeenCalledWith(WELL_FORMED_ID);
+    });
+
+    // Post props are free-form JSON, so the prop can hold anything; a value
+    // that is not a well-formed id must be treated as absent.
+    test.each([
+        {name: 'relative path segments', value: '../../some/other/route'},
+        {name: 'too short', value: 'abc'},
+        {name: 'right length but contains a separator', value: 'abcdefghijklmnopqrstuvwxy/'},
+        {name: 'not a string', value: 42},
+        {name: 'null', value: null},
+    ])('ignores a conversation_id that is not well-formed: $name', ({value}) => {
+        expect(() => renderPost(makePost('', {conversation_id: value}))).not.toThrow();
+
+        expect(mockUseConversation).toHaveBeenCalledWith(void 0); // eslint-disable-line no-void
+    });
+});
+
+describe('LLMBotPost search_results prop handling', () => {
+    test('renders the source list for a well-formed search_results prop', () => {
+        const sources = [makeSource(1), makeSource(2)];
+        renderPost(makePost('hello', {search_results: JSON.stringify(sources)}));
+
+        expect(screen.getByText('Sources')).toBeTruthy();
+        expect(screen.getByText('2')).toBeTruthy();
+    });
+
+    test('bounds the rendered source list to the server maximum result count', () => {
+        const sources = Array.from({length: MAX_SEARCH_SOURCES + 50}, (_, i) => makeSource(i));
+        renderPost(makePost('hello', {search_results: JSON.stringify(sources)}));
+
+        expect(screen.getByText(String(MAX_SEARCH_SOURCES))).toBeTruthy();
+    });
+
+    // Post props are free-form JSON; none of these values may throw during
+    // render, and none should produce a source list.
+    test.each([
+        {name: 'not a string', value: 42},
+        {name: 'an object instead of a JSON string', value: {postId: WELL_FORMED_ID}},
+        {name: 'not valid JSON', value: '{not json'},
+        {name: 'a JSON object instead of an array', value: '{"postId":"x"}'},
+        {name: 'a JSON string instead of an array', value: '"just a string"'},
+        {name: 'entries that are not objects', value: '[null, "x", 7]'},
+        {name: 'entries without well-formed ids', value: JSON.stringify([{postId: 'short', channelId: 'short', userId: 'short', content: 'hi', score: 1}])},
+    ])('renders no source list when search_results is malformed: $name', ({value}) => {
+        expect(() => renderPost(makePost('hello', {search_results: value}))).not.toThrow();
+
+        expect(screen.queryByText('Sources')).toBeNull();
     });
 });

--- a/webapp/src/components/llmbot_post/llmbot_post.tsx
+++ b/webapp/src/components/llmbot_post/llmbot_post.tsx
@@ -14,8 +14,10 @@ import {useSelectNotAIPost} from '@/hooks';
 import {useConversation, invalidateConversation} from '@/hooks/use_conversation';
 import {PostMessagePreview} from '@/mm_webapp';
 
+import {isValidId} from '@/utils/ids';
+
 import PostText from '../post_text';
-import {SearchSources} from '../search_sources';
+import {SearchSources, parseSearchSources} from '../search_sources';
 import ToolApprovalSet from '../tool_approval_set';
 import {ToolApprovalStage, ToolCall, ToolCallStatus} from '../tool_types';
 import {Annotation} from '../citations/types';
@@ -67,7 +69,11 @@ function isResolvedToolCallEvent(toolCalls: ToolCall[]): boolean {
 export const LLMBotPost = (props: LLMBotPostProps) => {
     const selectPost = useSelectNotAIPost();
 
-    const conversationId: string | undefined = props.post.props?.conversation_id;
+    // Post props are free-form JSON; a conversation_id that is not a
+    // well-formed id is treated as absent so no request is built from it and
+    // the component falls back to its no-conversation rendering path.
+    const rawConversationId: unknown = props.post.props?.conversation_id;
+    const conversationId: string | undefined = isValidId(rawConversationId) ? rawConversationId : undefined; // eslint-disable-line no-undefined
     const {conversation, loading: conversationLoading, error: conversationError} = useConversation(conversationId);
 
     // Meeting summarization posts have no conversation entity yet; fall back to
@@ -386,6 +392,13 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
         return 'done';
     };
 
+    // Parsed defensively: search_results is a free-form post prop, so a
+    // malformed value yields an empty list instead of throwing during render.
+    const searchSources = useMemo(
+        () => parseSearchSources(props.post.props?.[SearchResultsPropKey]),
+        [props.post.props],
+    );
+
     const isReasoningCollapsed = (roundId: string): boolean => !expandedReasoning[roundId];
     const toggleReasoning = (roundId: string, collapsed: boolean) => {
         setExpandedReasoning((prev) => ({...prev, [roundId]: !collapsed}));
@@ -435,9 +448,9 @@ export const LLMBotPost = (props: LLMBotPostProps) => {
                     />
                 );
             })}
-            {props.post.props?.[SearchResultsPropKey] && (
+            {searchSources.length > 0 && (
                 <SearchSources
-                    sources={JSON.parse(props.post.props[SearchResultsPropKey])}
+                    sources={searchSources}
                 />
             )}
             { showPostbackButton &&

--- a/webapp/src/components/search_sources.tsx
+++ b/webapp/src/components/search_sources.tsx
@@ -5,7 +5,13 @@ import React, {useState} from 'react';
 import styled from 'styled-components';
 import {FormattedMessage} from 'react-intl';
 
+import {isValidId} from '@/utils/ids';
+
 import {PostPreview} from './post_preview';
+
+// Mirrors maxMaxResults in api/api_search.go: the server never returns more
+// than this many search results, so anything beyond it is dropped.
+export const MAX_SEARCH_SOURCES = 100;
 
 // Utility for formatting relevance scores
 const formatScore = (score: number): string => {
@@ -46,16 +52,17 @@ const SourceCount = styled.span`
 	line-height: 16px;
 `;
 
-const CollapseIcon = styled.i<{isOpen: boolean}>`
+// Transient ($-prefixed) props so styled-components doesn't forward them to the DOM.
+const CollapseIcon = styled.i<{$isOpen: boolean}>`
     font-size: 18px;
     color: rgba(var(--center-channel-color-rgb), 0.56);
     margin-left: auto;
-    transform: ${(props) => (props.isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
+    transform: ${(props) => (props.$isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
     transition: transform 0.15s ease-in-out;
 `;
 
-const SourcesList = styled.div<{isOpen: boolean}>`
-    display: ${(props) => (props.isOpen ? 'flex' : 'none')};
+const SourcesList = styled.div<{$isOpen: boolean}>`
+    display: ${(props) => (props.$isOpen ? 'flex' : 'none')};
     flex-direction: column;
     margin-top: 8px;
 `;
@@ -96,12 +103,64 @@ const SourceItem = styled.div`
     }
 `;
 
-interface Source {
+export interface Source {
     postId: string;
     channelId: string;
     userId: string;
     content: string;
     score: number;
+}
+
+// toSource accepts an entry only when it is an object referencing well-formed
+// ids; the remaining display fields are coerced to safe defaults.
+function toSource(entry: unknown): Source | null {
+    if (typeof entry !== 'object' || entry === null) {
+        return null;
+    }
+    const {postId, channelId, userId, content, score} = entry as Record<string, unknown>;
+    if (!isValidId(postId) || !isValidId(channelId) || !isValidId(userId)) {
+        return null;
+    }
+    return {
+        postId,
+        channelId,
+        userId,
+        content: typeof content === 'string' ? content : '',
+        score: typeof score === 'number' && Number.isFinite(score) ? score : 0,
+    };
+}
+
+// parseSearchSources decodes the search_results post prop. Post props are
+// free-form JSON, so the value may be missing, not a string, not valid JSON,
+// not an array, or hold entries without well-formed ids. Anything unusable is
+// dropped rather than thrown so a bad prop can never break the post render,
+// and the result is bounded to the server's maximum result count.
+export function parseSearchSources(raw: unknown): Source[] {
+    if (typeof raw !== 'string' || raw === '') {
+        return [];
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return [];
+    }
+    if (!Array.isArray(parsed)) {
+        return [];
+    }
+
+    const sources: Source[] = [];
+    for (const entry of parsed) {
+        if (sources.length >= MAX_SEARCH_SOURCES) {
+            break;
+        }
+        const source = toSource(entry);
+        if (source) {
+            sources.push(source);
+        }
+    }
+    return sources;
 }
 
 interface SourceItemProps {
@@ -148,10 +207,10 @@ export const SearchSources = ({sources}: Props) => {
                 </SourcesTitle>
                 <CollapseIcon
                     className='icon-chevron-down'
-                    isOpen={isOpen}
+                    $isOpen={isOpen}
                 />
             </SourcesHeader>
-            <SourcesList isOpen={isOpen}>
+            <SourcesList $isOpen={isOpen}>
                 {sources.map((source, index) => (
                     <SearchSource
                         key={source.postId}

--- a/webapp/src/hooks/use_conversation_id_for_thread.ts
+++ b/webapp/src/hooks/use_conversation_id_for_thread.ts
@@ -5,10 +5,13 @@ import {useSelector} from 'react-redux';
 
 import {GlobalState} from '@mattermost/types/store';
 
+import {isValidId} from '@/utils/ids';
+
 /**
  * useConversationIdForThread resolves the plugin's conversation_id from a
  * Mattermost root post id by scanning posts in the thread for the
- * conversation_id prop the plugin writes onto every bot post.
+ * conversation_id prop the plugin writes onto every bot post. Post props are
+ * free-form JSON, so a prop that is not a well-formed id is skipped.
  *
  * Returns an empty string ('') when no bot post is in Redux yet (e.g. a fresh
  * thread the user hasn't opened, or one where the assistant has not replied).
@@ -21,8 +24,8 @@ export function useConversationIdForThread(rootPostId: string | null | undefined
         const posts = state.entities.posts.posts;
 
         const root = posts[rootPostId];
-        const rootConvId = root?.props?.conversation_id;
-        if (typeof rootConvId === 'string' && rootConvId) {
+        const rootConvId: unknown = root?.props?.conversation_id;
+        if (isValidId(rootConvId)) {
             return rootConvId;
         }
 
@@ -31,8 +34,8 @@ export function useConversationIdForThread(rootPostId: string | null | undefined
             return '';
         }
         for (const id of replyIds) {
-            const convId = posts[id]?.props?.conversation_id;
-            if (typeof convId === 'string' && convId) {
+            const convId: unknown = posts[id]?.props?.conversation_id;
+            if (isValidId(convId)) {
                 return convId;
             }
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Post props are free-form JSON delivered over the websocket and REST API, so values read from them carry no type or format guarantee. `LLMBotPost` consumed two of them without enough validation, which could produce broken plugin API requests or render-time failures:

- `conversation_id` was interpolated directly into the `conversations` request path. It is now validated as a well-formed Mattermost ID (26 chars, `a–z0–9`) before any request is built; a malformed value is treated as absent so the component falls back to its no-conversation rendering. The same check applies in `useConversationIdForThread`, the client functions refuse to issue a request for a malformed id, and interpolated id path segments in the route builders are percent-encoded.
- `search_results` was `JSON.parse`d inline and rendered as-is, so a malformed value could throw during render and break the post. Parsing now goes through `parseSearchSources`, which never throws, drops entries without well-formed `postId`/`channelId`/`userId`, coerces display fields to safe defaults, and bounds the list to `MAX_SEARCH_SOURCES` (100), mirroring the server's `maxMaxResults` in `api/api_search.go`.

Adds table-driven unit tests for the client routes and the component's prop handling, reusing the existing `isValidId` helper in `webapp/src/utils/ids.ts`. Full webapp suite passes (349 tests); lint and type check are clean.

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d91614c2-5095-43f9-a895-6f316a277d38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d91614c2-5095-43f9-a895-6f316a277d38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid conversation identifiers to prevent failed or unintended requests.
  - Prevented malformed search results from causing rendering errors.
  - Ensured conversation and threaded-post data only uses valid identifiers.
  - Safely encodes route identifiers for reliable navigation and requests.

- **Improvements**
  - Search source lists now ignore invalid entries, safely handle incomplete data, and remain limited to 100 results.
  - Search sources are displayed only when usable results are available.
  - Prevented internal display properties from appearing in rendered page markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->